### PR TITLE
Removing transactions from read-only methods

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/project/ProjectController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/project/ProjectController.java
@@ -118,7 +118,7 @@ public class ProjectController extends AbstractRESTController {
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<ProjectVO> loadProject(@PathVariable(value = PROJECT_ID_PARAM) final Long projectId) {
-        return Result.success(ProjectConverter.convertTo(projectManager.loadProject(projectId)));
+        return Result.success(ProjectConverter.convertTo(projectManager.loadProjectAndUpdateLastOpenedDate(projectId)));
     }
 
     @RequestMapping(value = "/project/load", method = RequestMethod.GET)
@@ -131,7 +131,9 @@ public class ProjectController extends AbstractRESTController {
         value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
         })
     public Result<ProjectVO> loadProject(@RequestParam final String projectName) {
-        return Result.success(ProjectConverter.convertTo(projectManager.loadProject(projectName)));
+        return Result.success(ProjectConverter.convertTo(
+                projectManager.loadProjectAndUpdateLastOpenedDate(projectName))
+        );
     }
 
     @RequestMapping(value = "/project/save", method = RequestMethod.POST)
@@ -213,7 +215,7 @@ public class ProjectController extends AbstractRESTController {
     public Result<ProjectVO> hideProjectItem(@PathVariable(value = PROJECT_ID_PARAM) final Long projectId,
                                           @PathVariable(value = BIOLOGICAL_ITEM_ID_PARAM) final Long biologicalItemId) {
         projectManager.hideProjectItem(projectId, biologicalItemId);
-        return Result.success(ProjectConverter.convertTo(projectManager.loadProject(projectId)));
+        return Result.success(ProjectConverter.convertTo(projectManager.loadProjectAndUpdateLastOpenedDate(projectId)));
     }
 
     @RequestMapping(value = "/project/{projectId}/search", method = RequestMethod.GET)

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/BiologicalDataItemDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/BiologicalDataItemDao.java
@@ -165,7 +165,7 @@ public class BiologicalDataItemDao extends NamedParameterJdbcDaoSupport {
      * @param name search query
      * @return {@code List} of files with a matching name
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BiologicalDataItem> loadFilesByNameStrict(final String name) {
         final MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(BiologicalDataItemParameters.NAME.name(), name);
@@ -173,7 +173,7 @@ public class BiologicalDataItemDao extends NamedParameterJdbcDaoSupport {
                 params, getRowMapper());
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BiologicalDataItem> loadFilesByNameCaseInsensitive(final String name) {
         final MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(BiologicalDataItemParameters.NAME.name(), name.toLowerCase());
@@ -201,7 +201,7 @@ public class BiologicalDataItemDao extends NamedParameterJdbcDaoSupport {
      * @param name search query
      * @return {@code List} of files with a matching name
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BiologicalDataItem> loadFilesByName(final String name) {
         final MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(BiologicalDataItemParameters.NAME.name(), "%" + name.toLowerCase() + "%");

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/UrlShorterDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/UrlShorterDao.java
@@ -59,7 +59,7 @@ public class UrlShorterDao extends NamedParameterJdbcDaoSupport {
         getNamedParameterJdbcTemplate().update(insertUrlQuery, params);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Optional<String> loadUrlById(String id) {
         final MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(Parameters.ID.name(), id);

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/bam/BamFileDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/bam/BamFileDao.java
@@ -90,7 +90,7 @@ public class BamFileDao extends NamedParameterJdbcDaoSupport {
      * @param id {@code long} a BamFile ID
      * @return {@code BamFile} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public BamFile loadBamFile(long id) {
         List<BiologicalDataItem> files = getJdbcTemplate().query(loadBamFileQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), id);
@@ -103,7 +103,7 @@ public class BamFileDao extends NamedParameterJdbcDaoSupport {
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;BamFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BamFile> loadBamFilesByReferenceId(long referenceId) {
         return getJdbcTemplate().query(loadBamFilesByReferenceIdQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), referenceId)
@@ -115,7 +115,7 @@ public class BamFileDao extends NamedParameterJdbcDaoSupport {
      * @param name BAM file name
      * @return true, is file is already registered otherwise false
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Boolean hasThisName(String name) {
         List<String> names = getJdbcTemplate().query(searchByNameBamFileQuery,
                 new SingleColumnRowMapper<>(), name);

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/bed/BedFileDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/bed/BedFileDao.java
@@ -90,7 +90,7 @@ public class BedFileDao extends NamedParameterJdbcDaoSupport {
      * @param id {@code long} a BedFile ID
      * @return {@code BedFile} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public BedFile loadBedFile(long id) {
         List<BiologicalDataItem> files = getJdbcTemplate().query(loadBedFileQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), id);
@@ -103,7 +103,7 @@ public class BedFileDao extends NamedParameterJdbcDaoSupport {
      * @param referenceId {@code long} a reference ID in the system
      * @return a {@code List} of {@code BedFile} instances
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BedFile> loadBedFilesByReferenceId(long referenceId) {
         return getJdbcTemplate().query(loadBedFilesByReferenceIdQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), referenceId)

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/bucket/BucketDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/bucket/BucketDao.java
@@ -75,7 +75,7 @@ public class BucketDao extends NamedParameterJdbcDaoSupport {
      * Loads all {@code Bucket} records saved in the database
      * @return a {@code List} of {@code Bucket} instances
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Bucket> loadAllBucket() {
         return getNamedParameterJdbcTemplate().query(loadAllBucketQuery,
                 BucketParameters.getRowMapper());
@@ -86,7 +86,7 @@ public class BucketDao extends NamedParameterJdbcDaoSupport {
      * @param bucketId a Bucket ID
      * @return {@code Bucket} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Bucket loadBucketById(final Long bucketId) {
         List<Bucket> buckets = getJdbcTemplate().query(loadBucketByIdQuery, BucketParameters.getPasswordRowMapper(),
                 bucketId);

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/gene/GeneFileDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/gene/GeneFileDao.java
@@ -94,7 +94,7 @@ public class GeneFileDao extends NamedParameterJdbcDaoSupport{
      * @param id {@code long} a GeneFile ID
      * @return {@code GeneFile} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public GeneFile loadGeneFile(long id) {
         List<BiologicalDataItem> files = getJdbcTemplate().query(loadGeneFileQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), id);
@@ -121,7 +121,7 @@ public class GeneFileDao extends NamedParameterJdbcDaoSupport{
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;GeneFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<GeneFile> loadGeneFilesByReferenceId(long referenceId) {
         return getJdbcTemplate().query(loadGeneFilesByReferenceIdQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), referenceId)

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/maf/MafFileDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/maf/MafFileDao.java
@@ -98,7 +98,7 @@ public class MafFileDao extends NamedParameterJdbcDaoSupport {
      * @param referenceId {@code long} a reference ID in the system
      * @return a {@code List} of {@code MafFile} instances
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<MafFile> loadMafFilesByReferenceId(long referenceId) {
         return getJdbcTemplate().query(loadMafFilesByReferenceIdQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), referenceId)
@@ -110,7 +110,7 @@ public class MafFileDao extends NamedParameterJdbcDaoSupport {
      * @param id {@code long} a MafFile ID
      * @return {@code MafFile} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public MafFile loadMafFile(long id) {
         List<BiologicalDataItem> files = getJdbcTemplate().query(loadMafFileQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), id);

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/person/PersonDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/person/PersonDao.java
@@ -74,7 +74,7 @@ public class PersonDao extends NamedParameterJdbcDaoSupport {
      * @return a loaded {@code Person} instance or
      *          {@code null} if user with a given ID doesn't exist
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Person loadPersonById(long personId) {
         List<Person> persons = getJdbcTemplate().query(loadPersonByIdQuery, PersonParameters.getRowMapper(), personId);
         return persons.isEmpty() ? null : persons.get(0);
@@ -87,7 +87,7 @@ public class PersonDao extends NamedParameterJdbcDaoSupport {
      * @return  a loaded {@code Person} instance or
      *          {@code null} if user with a given name and password doesn't exist
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Person loadPersonByNameAndPassword(String name, String password) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(PersonParameters.NAME.name(), name);
@@ -104,7 +104,7 @@ public class PersonDao extends NamedParameterJdbcDaoSupport {
      * @return  a loaded {@code Person} instance or
      *          {@code null} if user with a given name doesn't exist
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Person loadPersonByName(String name) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(PersonParameters.NAME.name(), name);

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/project/ProjectDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/project/ProjectDao.java
@@ -122,14 +122,14 @@ public class ProjectDao extends NamedParameterJdbcDaoSupport {
      * @param userId {@code Long} an ID of a user to load projects for.
      * @return a {@code List&lt;Project&gt;} of projects, created by specified user.
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Project> loadTopLevelProjectsOrderByLastOpened(long userId) {
         return getJdbcTemplate().query(loadTopLevelProjectsForUserOrderByLastOpenedQuery,
                                        ProjectParameters.getRowMapper(), userId);
     }
 
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Project> loadAllProjects(long userId) {
         return getJdbcTemplate().query(loadAllProjectsQuery, ProjectParameters.getRowMapper(), userId);
     }
@@ -139,7 +139,7 @@ public class ProjectDao extends NamedParameterJdbcDaoSupport {
      * @param userId {@code Long} an ID of a user to load projects for.
      * @return a {@code List&lt;Project&gt;} of projects, created by specified user.
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Project> loadTopLevelProjects(long userId) {
         return getJdbcTemplate().query(loadTopLevelProjectsForUserQuery, ProjectParameters.getRowMapper(), userId);
     }
@@ -149,7 +149,7 @@ public class ProjectDao extends NamedParameterJdbcDaoSupport {
      * @param parentId a parent Project's ID to load nested projects
      * @return a list of nested {@code Project}s
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Project> loadNestedProjects(long parentId) {
         return getJdbcTemplate().query(loadProjectsByParentIdQuery, ProjectParameters.getRowMapper(), parentId);
     }
@@ -183,7 +183,7 @@ public class ProjectDao extends NamedParameterJdbcDaoSupport {
      * @param projectId {@code Long} an ID of a project from
      * @return a {@code Project} instance from the database
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Project loadProject(long projectId) {
         List<Project> projects = getJdbcTemplate().query(loadProjectByIdQuery, ProjectParameters.getRowMapper(),
                                                          projectId);
@@ -195,14 +195,14 @@ public class ProjectDao extends NamedParameterJdbcDaoSupport {
      * @param projectName {@code String} a name of a project
      * @return a {@code Project} instance from the database
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Project loadProject(String projectName) {
         List<Project> projects = getJdbcTemplate().query(loadProjectByNameQuery, ProjectParameters.getRowMapper(),
                                                          projectName);
         return projects.isEmpty() ? null : projects.get(0);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Project> loadProjectsByBioDataItemId(final long bioDataItemId) {
         return getJdbcTemplate().query(loadProjectsByBioDataItemIdQuery, ProjectParameters.getRowMapper(),
                                        bioDataItemId);
@@ -268,7 +268,7 @@ public class ProjectDao extends NamedParameterJdbcDaoSupport {
      * @param projectId Id of a project to load ProjectItems
      * @return a List of ProjectItems
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<ProjectItem> loadProjectItemsByProjectId(long projectId) {
         return getJdbcTemplate().query(loadProjectItemsByProjectIdQuery, ProjectItemParameters.getRowMapper(),
                 projectId);
@@ -289,7 +289,7 @@ public class ProjectDao extends NamedParameterJdbcDaoSupport {
         return loadProjectItemsByList(listId);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Map<Long, Set<ProjectItem>> loadAllProjectItems() {
         Map<Long, Set<ProjectItem>> itemsMap = new HashMap<>();
         final RowMapper<ProjectItem> projectItemRowMapper = ProjectItemParameters.getSimpleItemMapper();
@@ -487,7 +487,7 @@ public class ProjectDao extends NamedParameterJdbcDaoSupport {
      * @param biologicalItemId {@code Long} ID of an item to test
      * @return {@code true} if project item is hidden, {@code false} if not
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Boolean isProjectItemHidden(long projectId, long biologicalItemId) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(ProjectItemParameters.PROJECT_ID.name(), projectId);

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/reference/BookmarkDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/reference/BookmarkDao.java
@@ -89,12 +89,12 @@ public class BookmarkDao extends NamedParameterJdbcDaoSupport {
      * Loads {@code Bookmark} entities, saved for given project ID and chromosome ID
      * @return {@code List&lt;Bookmark&gt;}
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Bookmark> loadAllBookmarks(long userId) {
         return getJdbcTemplate().query(loadAllBookmarksQuery, BookmarkParameters.getRowMapper(), userId);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Bookmark> searchBookmarks(String searchStr, long userId, int limit) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(BookmarkParameters.BOOKMARK_NAME.name(), searchStr + '%');
@@ -104,7 +104,7 @@ public class BookmarkDao extends NamedParameterJdbcDaoSupport {
         return getNamedParameterJdbcTemplate().query(searchBookmarksQuery, params, BookmarkParameters.getRowMapper());
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public int searchBookmarkCount(String searchStr, long userId) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(BookmarkParameters.BOOKMARK_NAME.name(), searchStr + '%');
@@ -118,7 +118,7 @@ public class BookmarkDao extends NamedParameterJdbcDaoSupport {
      * @param bookmarkId {@code Long} a {@code Bookmark} to load
      * @return {@code Bookmark}
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Bookmark loadBookmarkById(long bookmarkId) {
         List<Bookmark> bookmarks = getJdbcTemplate().query(loadBookmarkByIdQuery, BookmarkParameters.getRowMapper(),
                 bookmarkId);

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/reference/ReferenceGenomeDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/reference/ReferenceGenomeDao.java
@@ -197,7 +197,7 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
      * @param referenceId {@code Reference} ID to load
      * @return loaded {@code Reference} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Reference loadReferenceGenome(final Long referenceId) {
         final List<Reference> list = getNamedParameterJdbcTemplate().query(loadReferenceGenomeByIdQuery,
                 new MapSqlParameterSource(GenomeParameters.REFERENCE_GENOME_ID.name(), referenceId),
@@ -210,7 +210,7 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
      * @param itemID {@code Reference} Biological DataItemID to load
      * @return loaded {@code Reference} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Reference loadReferenceGenomeByBioItemId(final Long itemID) {
         final List<Reference> list = getNamedParameterJdbcTemplate().query(loadReferenceGenomeByBioIdQuery,
                 new MapSqlParameterSource(GenomeParameters.BIO_DATA_ITEM_ID.name(), itemID),
@@ -229,7 +229,7 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
      * Loads all persisted {@code Reference} entities from the database
      * @return all {@code Reference} instances, saved in the database
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Reference> loadAllReferenceGenomes() {
         return getNamedParameterJdbcTemplate().query(loadAllReferenceGenomesQuery,
                 GenomeParameters.getReferenceGenomeMetaDataMapper());
@@ -268,7 +268,7 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
         this.loadChromosomeByIdQuery = loadChromosomeByIdQuery;
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Chromosome loadChromosome(final Long chromosomeId) {
         final List<Chromosome> list = getNamedParameterJdbcTemplate().query(loadChromosomeByIdQuery,
                 new MapSqlParameterSource(GenomeParameters.CHROMOSOME_ID.name(), chromosomeId),
@@ -277,14 +277,14 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
     }
 
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Chromosome> loadAllChromosomesByReferenceId(final Long referenceId) {
         return getNamedParameterJdbcTemplate().query(loadAllChromosomesByReferenceIdQuery,
                 new MapSqlParameterSource(GenomeParameters.REFERENCE_GENOME_ID.name(), referenceId),
                 GenomeParameters.getChromosomeMapper());
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BaseEntity> loadAllFileByReferenceId(final Long referenceId) {
         return getNamedParameterJdbcTemplate().query(loadBiologicalItemsQuery, new MapSqlParameterSource(
             GenomeParameters.REFERENCE_GENOME_ID.name(), referenceId), GenomeParameters.getBioDataMapper());
@@ -295,7 +295,7 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
      * @param referenceId ID for the genome
      * @return List of BiologicalDataItem, matching specified IDs
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Long> loadAnnotationFileIdsByReferenceId(Long referenceId) {
         return getNamedParameterJdbcTemplate().query(
                 loadAnnotationDataIdsByReferenceIdQuery,
@@ -336,7 +336,7 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
         getNamedParameterJdbcTemplate().update(deleteAnnotationDataItemByReferenceIdQuery, params);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Long> loadGenomeIdsByAnnotationDataItemId(Long annotationFileBiologicalItemId) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/seg/SegFileDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/seg/SegFileDao.java
@@ -107,7 +107,7 @@ public class SegFileDao extends NamedParameterJdbcDaoSupport {
      * @param id {@code long} a SegFile ID
      * @return {@code SegFile} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public SegFile loadSegFile(long id) {
         List<BiologicalDataItem> files = getJdbcTemplate().query(loadSegFileQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), id);
@@ -120,7 +120,7 @@ public class SegFileDao extends NamedParameterJdbcDaoSupport {
      * @param referenceId {@code long} a reference ID in the system
      * @return a {@code List} of {@code SegFile} instances
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<SegFile> loadSegFilesByReferenceId(long referenceId) {
         return getJdbcTemplate().query(loadSegFilesByReferenceIdQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), referenceId)
@@ -170,7 +170,7 @@ public class SegFileDao extends NamedParameterJdbcDaoSupport {
      * @param segFileId {@code long} file ID for which samples were saved.
      * @return {@code List&lt;Sample&gt;} of samples for given file ID.
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<SegSample> loadSamplesForFile(long segFileId) {
         return getJdbcTemplate().query(loadSamplesForFileQuery, SegSampleParameters.getSegSampleMapper(), segFileId);
     }
@@ -212,7 +212,7 @@ public class SegFileDao extends NamedParameterJdbcDaoSupport {
      * @return {@code Map&lt;Long, List&lt;Sample&gt;&gt;} with file IDs for giver reference ID as keys, and with
      * lists of samples, corresponding this file IDs as values.
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Map<Long, List<SegSample>> loadSamplesForFilesByReference(long referenceId) {
         Map<Long, List<SegSample>> sampleFileMap = new HashMap<>();
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/vcf/VcfFileDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/vcf/VcfFileDao.java
@@ -115,7 +115,7 @@ public class VcfFileDao extends NamedParameterJdbcDaoSupport {
      * @param id {@code long} a VcfFile ID
      * @return {@code VcfFile} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public VcfFile loadVcfFile(long id) {
         List<BiologicalDataItem> files = getJdbcTemplate().query(loadVcfFileQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), id);
@@ -143,7 +143,7 @@ public class VcfFileDao extends NamedParameterJdbcDaoSupport {
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;VcfFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<VcfFile> loadVcfFilesByReferenceId(long referenceId) {
         return getJdbcTemplate().query(loadVcfFilesByReferenceIdQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), referenceId)
@@ -194,7 +194,7 @@ public class VcfFileDao extends NamedParameterJdbcDaoSupport {
      * @param vcfFileId {@code long} file ID for which samples were saved.
      * @return {@code List&lt;Sample&gt;} of samples for given file ID.
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<VcfSample> loadSamplesForFile(long vcfFileId) {
         return getJdbcTemplate().query(loadSamplesForFileQuery, SampleParameters.getVcfSampleMapper(), vcfFileId);
     }
@@ -235,7 +235,7 @@ public class VcfFileDao extends NamedParameterJdbcDaoSupport {
      * @return {@code Map&lt;Long, List&lt;Sample&gt;&gt;} with file IDs for giver reference ID as keys, and with
      * lists of samples, corresponding this file IDs as values.
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Map<Long, List<VcfSample>> loadSamplesForFilesByReference(long vcfFileId) {
         Map<Long, List<VcfSample>> sampleFileMap = new HashMap<>();
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/wig/WigFileDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/wig/WigFileDao.java
@@ -70,7 +70,7 @@ public class WigFileDao extends NamedParameterJdbcDaoSupport {
      * @param referenceId {@code long} a reference ID in the system
      * @return a {@code List} of {@code WigFile} instances
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<WigFile> loadWigFilesByReferenceId(long referenceId) {
         return getJdbcTemplate().query(loadWigFilesByReferenceIdQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), referenceId)
@@ -82,7 +82,7 @@ public class WigFileDao extends NamedParameterJdbcDaoSupport {
      * @param id {@code long} a WigFile ID
      * @return {@code WigFile} instance
      */
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public WigFile loadWigFile(long id) {
         List<BiologicalDataItem> files = getJdbcTemplate().query(loadWigFileQuery, BiologicalDataItemDao
                 .BiologicalDataItemParameters.getRowMapper(), id);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/BiologicalDataItemManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/BiologicalDataItemManager.java
@@ -116,9 +116,9 @@ public class BiologicalDataItemManager {
         throws JsonProcessingException {
         Project project;
         if (NumberUtils.isDigits(dataset)) {
-            project = projectManager.loadProject(Long.parseLong(dataset));
+            project = projectManager.loadProjectAndUpdateLastOpenedDate(Long.parseLong(dataset));
         } else {
-            project = projectManager.loadProject(dataset);
+            project = projectManager.loadProjectAndUpdateLastOpenedDate(dataset);
         }
 
         Assert.notNull(project, getMessage(MessagesConstants.ERROR_PROJECT_NOT_FOUND, dataset));

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
@@ -173,7 +173,7 @@ public class FeatureIndexManager {
      */
     public Set<String> searchGenesInVcfFilesInProject(long projectId, String gene, List<Long> vcfFileIds)
             throws IOException {
-        Project project = projectManager.loadProject(projectId);
+        Project project = projectManager.loadProjectAndUpdateLastOpenedDate(projectId);
         List<VcfFile> vcfFiles = project.getItems().stream()
             .filter(i -> i.getBioDataItem().getFormat() == BiologicalDataItemFormat.VCF)
             .map(i -> (VcfFile) i.getBioDataItem())
@@ -214,7 +214,7 @@ public class FeatureIndexManager {
     public List<Chromosome> filterChromosomes(VcfFilterForm filterForm, long projectId) throws IOException {
         Assert.isTrue(filterForm.getVcfFileIds() != null && !filterForm.getVcfFileIds().isEmpty(), MessageHelper
                 .getMessage(MessagesConstants.ERROR_NULL_PARAM, VCF_FILE_IDS_FIELD));
-        Project project = projectManager.loadProject(projectId);
+        Project project = projectManager.loadProjectAndUpdateLastOpenedDate(projectId);
         List<VcfFile> vcfFiles = project.getItems().stream()
             .filter(i -> i.getBioDataItem().getFormat() == BiologicalDataItemFormat.VCF)
             .map(i -> (VcfFile) i.getBioDataItem())
@@ -262,7 +262,7 @@ public class FeatureIndexManager {
      */
     public IndexSearchResult<VcfIndexEntry> filterVariations(VcfFilterForm filterForm, long projectId)
         throws IOException {
-        Project project = projectManager.loadProject(projectId);
+        Project project = projectManager.loadProjectAndUpdateLastOpenedDate(projectId);
         List<VcfFile> files = project.getItems().stream()
             .filter(i -> i.getBioDataItem().getFormat() == BiologicalDataItemFormat.VCF)
             .map(i -> (VcfFile) i.getBioDataItem())
@@ -298,7 +298,7 @@ public class FeatureIndexManager {
             throw new IllegalArgumentException("No page size is specified");
         }
 
-        Project project = projectManager.loadProject(projectId);
+        Project project = projectManager.loadProjectAndUpdateLastOpenedDate(projectId);
         List<VcfFile> files = project.getItems().stream()
             .filter(i -> i.getBioDataItem().getFormat() == BiologicalDataItemFormat.VCF)
             .map(i -> (VcfFile) i.getBioDataItem())
@@ -318,7 +318,7 @@ public class FeatureIndexManager {
      */
     public List<Group> groupVariations(VcfFilterForm filterForm, long projectId, String groupByField)
         throws IOException {
-        Project project = projectManager.loadProject(projectId);
+        Project project = projectManager.loadProjectAndUpdateLastOpenedDate(projectId);
         List<VcfFile> files = project.getItems().stream()
             .filter(i -> i.getBioDataItem().getFormat() == BiologicalDataItemFormat.VCF)
             .map(i -> (VcfFile) i.getBioDataItem())
@@ -379,7 +379,7 @@ public class FeatureIndexManager {
         IndexSearchResult<FeatureIndexEntry> bookmarkSearchRes = bookmarkManager.searchBookmarks(featureId,
                                                                                          maxFeatureSearchResultsCount);
 
-        Project project = projectManager.loadProject(projectId);
+        Project project = projectManager.loadProjectAndUpdateLastOpenedDate(projectId);
         Optional<Reference> maybeReference = project.getItems().stream()
             .filter(i -> i.getBioDataItem().getFormat() == BiologicalDataItemFormat.REFERENCE)
             .map(i -> (Reference) i.getBioDataItem()).findFirst();
@@ -440,7 +440,7 @@ public class FeatureIndexManager {
      * @throws IOException
      */
     public VcfFilterInfo loadVcfFilterInfoForProject(long projectId) throws IOException {
-        Project project = projectManager.loadProject(projectId);
+        Project project = projectManager.loadProjectAndUpdateLastOpenedDate(projectId);
         List<Long> vcfIds = project.getItems().stream()
                 .filter(item -> item.getBioDataItem() != null
                         && item.getBioDataItem().getFormat() == BiologicalDataItemFormat.VCF)

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/UrlShorterManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/UrlShorterManager.java
@@ -82,7 +82,7 @@ public class UrlShorterManager {
     /**
      * Load original url by given short url-postfix.
      * */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Optional<String> getOriginalUrl(String id) {
         return urlShorterDao.loadUrlById(id);
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamFileManager.java
@@ -83,7 +83,7 @@ public class BamFileManager {
      * @param bamFileId {@code long} a BamFile ID
      * @return {@code BamFile} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public BamFile loadBamFile(Long bamFileId) {
         return bamFileDao.loadBamFile(bamFileId);
     }
@@ -94,7 +94,7 @@ public class BamFileManager {
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;BamFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BamFile> loadBamFilesByReferenceId(long referenceId) {
         return bamFileDao.loadBamFilesByReferenceId(referenceId);
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedFileManager.java
@@ -75,7 +75,7 @@ public class BedFileManager {
      * @param bedFileId {@code long} a BedFile ID
      * @return {@code BedFile} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public BedFile loadBedFile(long bedFileId) {
         return bedFileDao.loadBedFile(bedFileId);
     }
@@ -96,7 +96,7 @@ public class BedFileManager {
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;BedFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BedFile> loadBedFilesByReferenceId(long referenceId) {
         return bedFileDao.loadBedFilesByReferenceId(referenceId);
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bucket/BucketManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bucket/BucketManager.java
@@ -66,7 +66,7 @@ public class BucketManager {
      * @param bucketId {@code Long} a bucket ID
      * @return {@code Bucket} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Bucket loadBucket(final Long bucketId) {
         return bucketDao.loadBucketById(bucketId);
     }
@@ -76,7 +76,7 @@ public class BucketManager {
      *
      * @return {@code List&lt;Bucket&gt;} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Bucket> loadAllBucket() {
         return bucketDao.loadAllBucket();
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
@@ -86,7 +86,7 @@ public class DataItemManager {
      *               otherwise a substring, case insensitive search is performed
      * @return list of found files
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BiologicalDataItem> findFilesByName(final String name, boolean strict) {
         if (strict) {
             return biologicalDataItemDao.loadFilesByNameStrict(name);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneFileManager.java
@@ -117,14 +117,14 @@ public class GeneFileManager {
      * @param geneFileId {@code long} a GeneFile ID
      * @return {@code GeneFile} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public GeneFile loadGeneFile(long geneFileId) {
         GeneFile geneFile = geneFileDao.loadGeneFile(geneFileId);
         Assert.notNull(geneFile, MessageHelper.getMessage(MessagesConstants.ERROR_FILE_NOT_FOUND, geneFileId));
         return geneFile;
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public boolean geneFileExists(long geneFileId) {
         GeneFile geneFile = geneFileDao.loadGeneFile(geneFileId);
         return geneFile != null;
@@ -146,7 +146,7 @@ public class GeneFileManager {
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;GeneFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<GeneFile> loadGeneFilesByReferenceId(long referenceId) {
         return geneFileDao.loadGeneFilesByReferenceId(referenceId);
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/maf/MafFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/maf/MafFileManager.java
@@ -70,7 +70,7 @@ public class MafFileManager {
      * @param mafFileId {@code long} a MafFile ID
      * @return {@code MafFile} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public MafFile loadMafFile(long mafFileId) {
         MafFile mafFile = mafFileDao.loadMafFile(mafFileId);
         Assert.notNull(mafFile, "MAF file with requested ID not found: " + mafFileId);
@@ -82,7 +82,7 @@ public class MafFileManager {
      * @param mafFileId {@code long} a MafFile ID
      * @return {@code MafFile} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public MafFile loadMafFileNullable(long mafFileId) {
         MafFile mafFile = mafFileDao.loadMafFile(mafFileId);
         return mafFile;
@@ -102,7 +102,7 @@ public class MafFileManager {
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;MafFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<MafFile> loadMafFilesByReferenceId(long referenceId) {
         return mafFileDao.loadMafFilesByReferenceId(referenceId);
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/person/PersonManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/person/PersonManager.java
@@ -78,14 +78,14 @@ public class PersonManager {
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Person loadPersonByNameAndPassword(String name, String password) {
         Person person = personDao.loadPersonByNameAndPassword(name, password);
         Assert.notNull(person, "Unauthorized: Incorrect user name or password");
         return person;
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Person loadPersonById(long personId) {
         return personDao.loadPersonById(personId);
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/BookmarkManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/BookmarkManager.java
@@ -79,7 +79,7 @@ public class BookmarkManager {
      * Loads {@code Bookmark} entities for current user
      * @return a {@code List} of {@code Bookmark} entities
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Bookmark> loadBookmarksByProject() {
         return bookmarkDao.loadAllBookmarks(AuthUtils.getCurrentUserId());
     }
@@ -140,7 +140,6 @@ public class BookmarkManager {
      * @param limit search result count
      * @return an {@link IndexSearchResult} object, that contains search results
      */
-    @Transactional(propagation = Propagation.REQUIRED)
     public IndexSearchResult<FeatureIndexEntry> searchBookmarks(String searchStr, int limit) {
         int bookmarksCount = bookmarkDao.searchBookmarkCount(searchStr, AuthUtils.getCurrentUserId());
         List<Bookmark> bookmarks = bookmarkDao.searchBookmarks(searchStr, AuthUtils.getCurrentUserId(), limit);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
@@ -220,7 +220,7 @@ public class ReferenceGenomeManager {
      * @return {@code List} list of reference genomes that are available in the system now
      */
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Reference> loadAllReferenceGenomes() {
         return loadAllReferenceGenomes(null);
     }
@@ -270,7 +270,7 @@ public class ReferenceGenomeManager {
      * @throws IllegalArgumentException will be thrown in a case, if no chromosome with the given ID can be
      *                                  found in the system
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Chromosome loadChromosome(final Long chromosomeId) {
         final Chromosome chromosome = referenceGenomeDao.loadChromosome(chromosomeId);
         Assert.notNull(chromosome, getMessage(MessageCode.NO_SUCH_CHROMOSOME));
@@ -286,7 +286,7 @@ public class ReferenceGenomeManager {
      * @throws IllegalArgumentException will be thrown in a case, if no chromosome associated with the given
      *                                  reference ID can be found in the system
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<Chromosome> loadChromosomes(final Long referenceId) {
         final List<Chromosome> chromosomes = referenceGenomeDao.loadAllChromosomesByReferenceId(referenceId);
         Assert.isTrue(CollectionUtils.isNotEmpty(chromosomes), getMessage(MessageCode.NO_SUCH_REFERENCE));
@@ -299,7 +299,7 @@ public class ReferenceGenomeManager {
      * @param referenceId {@code Long} specifies ID of a reference genome which chromosomes should be loaded
      * @return {@code List}
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<BaseEntity> loadAllFile(final Long referenceId) {
         return referenceGenomeDao.loadAllFileByReferenceId(referenceId);
     }
@@ -312,7 +312,7 @@ public class ReferenceGenomeManager {
      * @throws IllegalArgumentException will be thrown in a case, if no reference with the given ID can be
      *                                  found in the system
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public Reference getOnlyReference(final Long referenceId) {
         Assert.notNull(referenceId, getMessage(MessageCode.NO_SUCH_REFERENCE));
         final Reference reference = referenceGenomeDao.loadReferenceGenome(referenceId);
@@ -329,7 +329,7 @@ public class ReferenceGenomeManager {
         return loadReferenceGenome(referenceId);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public boolean isRegistered(Long id) {
         return referenceGenomeDao.loadReferenceGenome(id) != null;
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceManager.java
@@ -312,8 +312,8 @@ import com.epam.catgenome.util.Utils;
      * @return deleted reference
      * @throws IOException if an error occurred during deleting directory
      */
-    @Transactional(propagation = Propagation.REQUIRED) public Reference unregisterGenome(
-            final long referenceId) throws IOException {
+    @Transactional(propagation = Propagation.REQUIRED)
+    public Reference unregisterGenome(final long referenceId) throws IOException {
         Assert.notNull(referenceId, MessagesConstants.ERROR_INVALID_PARAM);
         Assert.isTrue(referenceId > 0, MessagesConstants.ERROR_INVALID_PARAM);
         Reference reference = referenceGenomeManager.loadReferenceGenome(referenceId);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/seg/SegFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/seg/SegFileManager.java
@@ -80,7 +80,7 @@ public class SegFileManager {
      * @param segFileId {@code long} a BedFile ID
      * @return {@code SegFile} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public SegFile loadSegFile(long segFileId) {
         SegFile segFile = segFileDao.loadSegFile(segFileId);
 
@@ -107,7 +107,7 @@ public class SegFileManager {
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;SegFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<SegFile> loadSedFilesByReferenceId(long referenceId) {
         return segFileDao.loadSegFilesByReferenceId(referenceId);
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfFileManager.java
@@ -89,7 +89,7 @@ public class VcfFileManager {
      * @param vcfFileId {@code long} a VcfFile ID
      * @return {@code VcfFile} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public VcfFile loadVcfFile(Long vcfFileId) {
         VcfFile vcfFile = vcfFileDao.loadVcfFile(vcfFileId);
         if (vcfFile != null) {
@@ -154,7 +154,7 @@ public class VcfFileManager {
      * @param referenceId {@code long} a reference ID in the system
      * @return {@code List&lt;VcfFile&gt;} instance
      */
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.SUPPORTS)
     public List<VcfFile> loadVcfFilesByReferenceId(long referenceId) {
         List<VcfFile> files = vcfFileDao.loadVcfFilesByReferenceId(referenceId);
 

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/FeatureIndexManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/FeatureIndexManagerTest.java
@@ -518,7 +518,7 @@ public class FeatureIndexManagerTest extends AbstractManagerTest {
         // add multiple files
         project.getItems().clear();
         projectManager.saveProject(project);
-        Project loadedProject = projectManager.loadProject(project.getId());
+        Project loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertTrue(loadedProject.getItems().isEmpty());
         entryList2 = featureIndexManager.filterVariations(new VcfFilterForm(), project.getId());
         Assert.assertTrue(entryList2.getEntries().isEmpty());

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/ProjectManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/ProjectManagerTest.java
@@ -152,7 +152,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
 
         projectManager.saveProject(project);
 
-        Project loadedProject = projectManager.loadProject(project.getId());
+        Project loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertNotNull(loadedProject);
         Assert.assertFalse(loadedProject.getItems().isEmpty());
 
@@ -167,20 +167,20 @@ public class ProjectManagerTest extends AbstractManagerTest {
 
         projectManager.saveProject(loadedProject);
 
-        loadedProject = projectManager.loadProject(project.getId());
+        loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertEquals(loadedProject.getItems().size(), 3);
 
         loadedProject.getItems().remove(2);
         projectManager.saveProject(loadedProject);
 
-        loadedProject = projectManager.loadProject(project.getId());
+        loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertEquals(loadedProject.getItems().size(), 2);
         Assert.assertEquals(TEST_VCF_FILE_NAME1, loadedProject.getItems().get(1).getBioDataItem().getName());
 
         loadedProject.getItems().get(0).setHidden(true);
         projectManager.saveProject(loadedProject);
 
-        loadedProject = projectManager.loadProject(project.getId());
+        loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertEquals(loadedProject.getItems().size(), 2);
         Assert.assertTrue(loadedProject.getItems().get(0).getHidden());
 
@@ -209,7 +209,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
         // Now delete project
         projectManager.deleteProject(project.getId(), false);
         try {
-            projectManager.loadProject(project.getId());
+            projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
             Assert.fail("No exception happened, but should happen");
         } catch (IllegalArgumentException e) {
             // success, nothing to do here
@@ -236,7 +236,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
 
         projectManager.saveProject(project);
 
-        Project loadedProject = projectManager.loadProject(project.getId());
+        Project loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertNotNull(loadedProject);
         Assert.assertEquals("pretty", loadedProject.getPrettyName());
         Assert.assertFalse(loadedProject.getItems().isEmpty());
@@ -296,7 +296,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
     private void assertNullLoadProjectWithNested(Project root) {
         try {
             // check that we handle exception as expected
-            Assert.assertNull(projectManager.loadProject(root.getId()));
+            Assert.assertNull(projectManager.loadProjectAndUpdateLastOpenedDate(root.getId()));
         } catch (IllegalArgumentException e) {
             // continue checking with child projects
             Optional.ofNullable(root.getNestedProjects())
@@ -315,25 +315,25 @@ public class ProjectManagerTest extends AbstractManagerTest {
                 new ProjectItem(new BiologicalDataItem(testReference.getBioDataItemId()))));
         projectManager.saveProject(project);
 
-        Project loadedProject = projectManager.loadProject(project.getId());
+        Project loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertNotNull(loadedProject);
         Assert.assertEquals(1, loadedProject.getItems().size());
 
         addVcfFileToProject(project.getId(), TEST_VCF_FILE_NAME1, TEST_VCF_FILE_PATH);
         addVcfFileToProject(project.getId(), TEST_VCF_FILE_NAME2, TEST_VCF_FILE_PATH);
 
-        loadedProject = projectManager.loadProject(project.getId());
+        loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertEquals(3, loadedProject.getItems().size());
 
         projectManager.removeProjectItem(project.getId(),
                 ((VcfFile) loadedProject.getItems().get(1).getBioDataItem()).getBioDataItemId());
-        loadedProject = projectManager.loadProject(project.getId());
+        loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertEquals(2, loadedProject.getItems().size());
         Assert.assertEquals(TEST_VCF_FILE_NAME2, loadedProject.getItems().get(1).getBioDataItem().getName());
 
         projectManager.hideProjectItem(project.getId(),
                 ((VcfFile) loadedProject.getItems().get(1).getBioDataItem()).getBioDataItemId());
-        loadedProject = projectManager.loadProject(project.getId());
+        loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertFalse(loadedProject.getItems().isEmpty());
         Assert.assertTrue(loadedProject.getItems().get(1).getHidden());
     }
@@ -355,7 +355,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
                 new ProjectItem(new BiologicalDataItem(testReference.getBioDataItemId()))));
         child1 = projectManager.saveProject(child1, parent.getId());
 
-        parent = projectManager.loadProject(parent.getId());
+        parent = projectManager.loadProjectAndUpdateLastOpenedDate(parent.getId());
         Assert.assertFalse(parent.getNestedProjects().isEmpty());
         Assert.assertEquals(child1.getId(), parent.getNestedProjects().get(0).getId());
 
@@ -365,13 +365,13 @@ public class ProjectManagerTest extends AbstractManagerTest {
                 new ProjectItem(new BiologicalDataItem(testReference.getBioDataItemId()))));
         child2 = projectManager.saveProject(child2);
         projectManager.moveProjectToParent(child2.getId(), parent.getId());
-        parent = projectManager.loadProject(parent.getId());
+        parent = projectManager.loadProjectAndUpdateLastOpenedDate(parent.getId());
 
         Assert.assertEquals(parent.getNestedProjects().size(), 2);
         Assert.assertEquals(child1.getId(), parent.getNestedProjects().get(0).getId());
         Assert.assertEquals(child2.getId(), parent.getNestedProjects().get(1).getId());
 
-        parent = projectManager.loadProject(parent.getId());
+        parent = projectManager.loadProjectAndUpdateLastOpenedDate(parent.getId());
         Assert.assertEquals(parent.getNestedProjects().size(), 2);
         Assert.assertEquals(child1.getId(), parent.getNestedProjects().get(0).getId());
         Assert.assertEquals(child2.getId(), parent.getNestedProjects().get(1).getId());
@@ -463,7 +463,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
                 new ProjectItem(new BiologicalDataItem(testReference.getBioDataItemId()))));
         projectManager.saveProject(project);
 
-        Project loadedProject = projectManager.loadProject(project.getId());
+        Project loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Assert.assertNotNull(loadedProject);
         Assert.assertEquals(1, loadedProject.getItems().size());
 
@@ -516,7 +516,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
         Assert.assertNotNull(mafFile);
         projectManager.addProjectItem(project.getId(), mafFile.getBioDataItemId());
 
-        loadedProject = projectManager.loadProject(project.getId());
+        loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
 
         // Test VCF item
         ProjectItem vcfItem = loadedProject.getItems().stream().filter(i -> i.getBioDataItem().getFormat() ==
@@ -592,7 +592,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
 
         projectManager.saveProject(project);
 
-        Project loadedProject = projectManager.loadProject(project.getId());
+        Project loadedProject = projectManager.loadProjectAndUpdateLastOpenedDate(project.getId());
         Reference projectReference =
             (Reference) loadedProject.getItems().stream()
                 .filter(i -> i.getBioDataItem().getFormat() == BiologicalDataItemFormat.REFERENCE)


### PR DESCRIPTION
# Description

## Background

This PR leads to replace propagation of  transactions for read-only method from REQUIRED to SUPPORTS. Transactions for read-only methods lead only to decreasing of performance, if this methods are used in non-transaction context.

## Changes

Many of DAO an Managers classes which contain read-only methods.

## Acceptance criteria

All tests pass

# Check list

- [ ] Documentation is updated
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Unit tests are provided
