### PR TITLE
Fix for OutOfMemory exception when registering 1Gb+ VCF files

### DIFF
--- a/docs/md/installation/binaries.md
+++ b/docs/md/installation/binaries.md
@@ -83,6 +83,13 @@ echo "file.browsing.allowed=true" >> $CATGENOME_CONF_DIR/catgenome.properties
 echo "ngs.data.root.path=/opt/catgenome" >> $CATGENOME_CONF_DIR/catgenome.properties
 ```
 
+If you want to specify max number of VcfIndexEntries keeping in memory during vcf loading, add the following property. For files, which produce more entries then the number, extra entries will be spilled to disk (temp directory).
+* **files.vcf.max.entries.in.memory=1000000** - 1000000 entries take about 3Gb in the heap
+
+```
+echo "files.vcf.max.entries.in.memory=1000000" >> $CATGENOME_CONF_DIR/catgenome.properties
+```
+
 Set Tomcat configuration in the file **$CATALINA_HOME/conf/server.xml** by adding the 
  following values to the **"Connector"** XML node
  

--- a/docs/md/installation/standalone.md
+++ b/docs/md/installation/standalone.md
@@ -81,6 +81,9 @@ If this property is not set, root will be set to the root of file system.
 If you want to configure default options for tracks visualization on a client side, add the following properties:
 * **config.path=/opt/catgenome/configs** path to a directory that contains `json` configuration files for NGB client
 
+If you want to specify max number of VcfIndexEntries keeping in memory during vcf loading, add the following property. For files, which produce more entries then the number, extra entries will be spilled to disk (temp directory).
+* **files.vcf.max.entries.in.memory=1000000** - 1000000 entries take about 3Gb in the heap
+
 You should put **catgenome.properties** in **config** folder in the runtime folder or provide path to folder with properties file from command line:
  
 ```

--- a/server/catgenome/profiles/desktop/catgenome.properties
+++ b/server/catgenome/profiles/desktop/catgenome.properties
@@ -9,6 +9,12 @@ files.download.max.m.byte.size=50
 files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
+
+# max number of VcfIndexEntries keeping in memory during vcf loading. For files, which produce more entries then
+# the number, extra entries will be spilled to disk (temp directory)
+# (1000000 entries take about 3Gb in the heap)
+files.vcf.max.entries.in.memory=1000000
+
 # configuration properties to establish connection with database engine
 database.max.pool.size=10
 database.username=catgenome

--- a/server/catgenome/profiles/dev/catgenome.properties
+++ b/server/catgenome/profiles/dev/catgenome.properties
@@ -15,6 +15,10 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
 
+# max number of VcfIndexEntries keeping in memory during vcf loading. For files, which produce more entries then
+# the number, extra entries will be spilled to disk (temp directory)
+# (1000000 entries take about 3Gb in the heap)
+files.vcf.max.entries.in.memory=1000000
 
 # configuration properties to establish connection with database engine
 database.max.pool.size=10
@@ -42,3 +46,5 @@ bam.max.reads.count=500000
 bam.regions.count=20
 # the real path in the file system to default configuration files
 config.path=@rootDirPath@/config
+
+

--- a/server/catgenome/profiles/h2/test-catgenome.properties
+++ b/server/catgenome/profiles/h2/test-catgenome.properties
@@ -11,6 +11,10 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=
 
+# max number of VcfIndexEntries keeping in memory during vcf loading. For files, which produce more entries then
+# the number, extra entries will be spilled to disk (temp directory)
+# (1000000 entries take about 3Gb in the heap)
+files.vcf.max.entries.in.memory=5
 
 # configuration properties to establish connection with database engine
 database.max.pool.size=10

--- a/server/catgenome/profiles/jar/catgenome.properties
+++ b/server/catgenome/profiles/jar/catgenome.properties
@@ -8,6 +8,10 @@ ngs.data.root.path=/
 # flag determines if file browsing is allowed
 file.browsing.allowed=true
 
+# max number of VcfIndexEntries keeping in memory during vcf loading. For files, which produce more entries then
+# the number, extra entries will be spilled to disk (temp directory)
+# (1000000 entries take about 3Gb in the heap)
+files.vcf.max.entries.in.memory=1000000
 
 # max download file size in MB
 files.download.max.m.byte.size=50

--- a/server/catgenome/profiles/postgres/test-catgenome.properties
+++ b/server/catgenome/profiles/postgres/test-catgenome.properties
@@ -9,6 +9,10 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=
 
+# max number of VcfIndexEntries keeping in memory during vcf loading. For files, which produce more entries then
+# the number, extra entries will be spilled to disk (temp directory)
+# (1000000 entries take about 3Gb in the heap)
+files.vcf.max.entries.in.memory=1000000
 
 # configuration properties to establish connection with database engine
 database.max.pool.size=10

--- a/server/catgenome/profiles/release/catgenome.properties
+++ b/server/catgenome/profiles/release/catgenome.properties
@@ -10,6 +10,11 @@ files.download.max.minutes=
 # white list for download file from url
 file.download.whitelist.host=
 
+# max number of VcfIndexEntries keeping in memory during vcf loading. For files, which produce more entries then
+# the number, extra entries will be spilled to disk (temp directory)
+# (1000000 entries take about 3Gb in the heap)
+files.vcf.max.entries.in.memory=1000000
+
 # configuration properties to establish connection with database engine
 database.max.pool.size=25
 database.username=

--- a/server/catgenome/profiles/staging/catgenome.properties
+++ b/server/catgenome/profiles/staging/catgenome.properties
@@ -10,6 +10,8 @@ files.download.max.minutes=
 # white list for download file from url
 file.download.whitelist.host=
 
+files.vcf.max.entries.in.memory=
+
 # configuration properties to establish connection with database engine
 database.max.pool.size=25
 database.username=

--- a/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
@@ -112,7 +112,7 @@ public final class MessagesConstants {
     public static final String ERROR_ANNOTATION_FILE_ALREADY_EXIST = "error.annotation.file.feature.already.exist";
     public static final String ERROR_ANNOTATION_FILE_NOT_EXIST = "error.annotation.file.feature.not.exist";
     public static final String ERROR_ILLEGAL_REFERENCE_FOR_ANNOTATION = "error.illegal.reference.for.annotation";
-    public static final String ERROR_UNSUPPORTED_OPERATION = "error.illegal.reference.for.annotation";
+    public static final String ERROR_UNSUPPORTED_OPERATION = "error.unsupported.operation";
 
     //Feature index
     public static final String ERROR_FEATURE_INDEX_NOT_FOUND = "error.feature.index.not.found";

--- a/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 EPAM Systems
+ * Copyright (c) 2017 EPAM Systems
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -112,6 +112,7 @@ public final class MessagesConstants {
     public static final String ERROR_ANNOTATION_FILE_ALREADY_EXIST = "error.annotation.file.feature.already.exist";
     public static final String ERROR_ANNOTATION_FILE_NOT_EXIST = "error.annotation.file.feature.not.exist";
     public static final String ERROR_ILLEGAL_REFERENCE_FOR_ANNOTATION = "error.illegal.reference.for.annotation";
+    public static final String ERROR_UNSUPPORTED_OPERATION = "error.illegal.reference.for.annotation";
 
     //Feature index
     public static final String ERROR_FEATURE_INDEX_NOT_FOUND = "error.feature.index.not.found";

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/BaseEntity.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/BaseEntity.java
@@ -24,6 +24,8 @@
 
 package com.epam.catgenome.entity;
 
+import java.io.Serializable;
+
 /**
  * Source:      BaseEntity.java
  * Created:     10/2/15, 3:39 PM
@@ -36,7 +38,7 @@ package com.epam.catgenome.entity;
  * It should be used to process data from any dictionary and/or can be extended by any other
  * models which have more complex structure.
  */
-public class BaseEntity {
+public class BaseEntity implements Serializable {
 
     /**
      * {@code Long} represents an entity's identifier.

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/BaseEntity.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/BaseEntity.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 EPAM Systems
+ * Copyright (c) 2017 EPAM Systems
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/index/FeatureIndexEntry.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/index/FeatureIndexEntry.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 EPAM Systems
+ * Copyright (c) 2017 EPAM Systems
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/index/FeatureIndexEntry.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/index/FeatureIndexEntry.java
@@ -24,6 +24,7 @@
 
 package com.epam.catgenome.entity.index;
 
+import java.io.Serializable;
 import java.util.UUID;
 
 import com.epam.catgenome.entity.reference.Chromosome;
@@ -38,7 +39,7 @@ import com.epam.catgenome.entity.reference.Chromosome;
  * Represents a feature in a feature index
  * </p>
  */
-public class FeatureIndexEntry {
+public class FeatureIndexEntry implements Serializable {
 
     /**
      * {@code Integer} represents the ending interval index, inclusive.

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/index/VcfIndexEntry.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/index/VcfIndexEntry.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 EPAM Systems
+ * Copyright (c) 2017 EPAM Systems
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
@@ -480,7 +480,8 @@ public class FeatureIndexManager {
      * @param chromosome a {@code Chromosome}, from which entries came
      * @param vcfHeader a header of VCF file
      * @param vcfReader a reader for VCF file
-     * @return a list of post-processed index entries, ready to write into index
+     * @return a list of post-processed index entries, ready to write into index, must be cleared
+     * after use because disk-based implementation could be returned
      * @throws GeneReadingException if an exception was thrown when reading genes information
      */
     public List<VcfIndexEntry> postProcessIndexEntries(List<VcfIndexEntry> entries, List<GeneFile> geneFiles,
@@ -722,6 +723,7 @@ public class FeatureIndexManager {
                 List<VcfIndexEntry> processedEntries = postProcessIndexEntries(allEntries, geneFiles,
                                        Utils.getFromChromosomeMap(chromosomeMap, currentKey), vcfHeader, vcfFileReader);
                 featureIndexDao.writeLuceneIndexForFile(vcfFile, processedEntries);
+                processedEntries.clear();
                 LOGGER.info(MessageHelper.getMessage(MessagesConstants.INFO_FEATURE_INDEX_CHROMOSOME_WROTE,
                                                      currentKey));
                 allEntries.clear();
@@ -739,6 +741,7 @@ public class FeatureIndexManager {
             List<VcfIndexEntry> processedEntries = postProcessIndexEntries(allEntries, geneFiles,
                                        Utils.getFromChromosomeMap(chromosomeMap, currentKey), vcfHeader, vcfFileReader);
             featureIndexDao.writeLuceneIndexForFile(vcfFile, processedEntries);
+            processedEntries.clear();
             LOGGER.info(MessageHelper.getMessage(MessagesConstants
                                                      .INFO_FEATURE_INDEX_CHROMOSOME_WROTE, currentKey));
             allEntries.clear();

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.epam.catgenome.manager.bed.BedManager;
+import com.epam.catgenome.util.DiskBasedList;
 import htsjdk.variant.vcf.VCFHeaderLineCount;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -152,6 +153,9 @@ public class FeatureIndexManager {
 
     @Value("#{catgenome['search.features.max.results'] ?: 100}")
     private Integer maxFeatureSearchResultsCount;
+
+    @Value("#{catgenome['files.vcf.max.entries.in.memory'] ?: 3000000}")
+    private int maxVcfIndexEntriesInMemory;
 
     /**
      * Deletes features from specified feature files from project's index
@@ -482,7 +486,8 @@ public class FeatureIndexManager {
     public List<VcfIndexEntry> postProcessIndexEntries(List<VcfIndexEntry> entries, List<GeneFile> geneFiles,
                                                     Chromosome chromosome, VCFHeader vcfHeader, VcfFileReader vcfReader)
         throws GeneReadingException {
-        List<VcfIndexEntry> processedEntries = new ArrayList<>();
+        List<VcfIndexEntry> processedEntries =
+                new DiskBasedList<VcfIndexEntry>(maxVcfIndexEntriesInMemory / 2).adaptToList();
         int start = chromosome.getSize();
         int end = 0;
         for (FeatureIndexEntry entry : entries) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -157,7 +157,6 @@ public class VcfManager {
 
     private InfoFieldParser infoFieldParser;
 
-    // Will spill to disk after ~10Gb entries in memory by default
     @Value("#{catgenome['files.vcf.max.entries.in.memory'] ?: 3000000}")
     private int maxVcfIndexEntriesInMemory;
 
@@ -597,7 +596,7 @@ public class VcfManager {
         VcfFileReader vcfFileReader = new VcfFileReader(fileManager, referenceGenomeManager);
         VCFHeader vcfHeader = (VCFHeader) reader.getHeader();
 
-        List<VcfIndexEntry> allEntries = new DiskBasedList<VcfIndexEntry>(maxVcfIndexEntriesInMemory).adaptToList();
+        List<VcfIndexEntry> allEntries = new DiskBasedList<VcfIndexEntry>(maxVcfIndexEntriesInMemory / 2).adaptToList();
 
         List<GeneFile> geneFiles  = reference.getGeneFile() != null ?
                                     Collections.singletonList(reference.getGeneFile()) : Collections.emptyList();

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -658,6 +658,7 @@ public class VcfManager {
                                                                                            currentChromosome,
                                                                                            vcfHeader, vcfFileReader);
             featureIndexManager.writeLuceneIndexForFile(vcfFile, processedEntries);
+            processedEntries.clear();
             LOGGER.info(getMessage(MessagesConstants.INFO_FEATURE_INDEX_CHROMOSOME_WROTE, currentChromosome.getName()));
             allEntries.clear();
         }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -157,7 +157,8 @@ public class VcfManager {
 
     private InfoFieldParser infoFieldParser;
 
-    @Value("#{catgenome['files.vcf.max.entries.in.memory']}")
+    // Will spill to disk after ~10Gb entries in memory by default
+    @Value("#{catgenome['files.vcf.max.entries.in.memory'] ?: 3000000}")
     private int maxVcfIndexEntriesInMemory;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VcfManager.class);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -157,6 +157,9 @@ public class VcfManager {
 
     private InfoFieldParser infoFieldParser;
 
+    @Value("#{catgenome['files.vcf.max.entries.in.memory']}")
+    private int maxVcfIndexEntriesInMemory;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(VcfManager.class);
 
     /**
@@ -593,7 +596,7 @@ public class VcfManager {
         VcfFileReader vcfFileReader = new VcfFileReader(fileManager, referenceGenomeManager);
         VCFHeader vcfHeader = (VCFHeader) reader.getHeader();
 
-        List<VcfIndexEntry> allEntries = new DiskBasedList<VcfIndexEntry>().adaptToList();
+        List<VcfIndexEntry> allEntries = new DiskBasedList<VcfIndexEntry>(maxVcfIndexEntriesInMemory).adaptToList();
 
         List<GeneFile> geneFiles  = reference.getGeneFile() != null ?
                                     Collections.singletonList(reference.getGeneFile()) : Collections.emptyList();

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 EPAM Systems
+ * Copyright (c) 2017 EPAM Systems
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.epam.catgenome.dao.index.FeatureIndexDao;
+import com.epam.catgenome.util.AuthUtils;
+import com.epam.catgenome.util.DiskBasedList;
+import com.epam.catgenome.util.IOHelper;
 import com.epam.catgenome.util.InfoFieldParser;
+import com.epam.catgenome.util.Utils;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLineType;
@@ -104,9 +108,6 @@ import com.epam.catgenome.manager.vcf.reader.AbstractVcfReader;
 import com.epam.catgenome.manager.vcf.reader.VcfFileReader;
 import com.epam.catgenome.manager.vcf.reader.VcfGa4ghReader;
 import com.epam.catgenome.manager.vcf.reader.VcfReader;
-import com.epam.catgenome.util.AuthUtils;
-import com.epam.catgenome.util.IOHelper;
-import com.epam.catgenome.util.Utils;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.FeatureReader;
@@ -591,7 +592,9 @@ public class VcfManager {
         VcfFilterInfo info = getFiltersInfo(reader);
         VcfFileReader vcfFileReader = new VcfFileReader(fileManager, referenceGenomeManager);
         VCFHeader vcfHeader = (VCFHeader) reader.getHeader();
-        List<VcfIndexEntry> allEntries = new ArrayList<>();
+
+        List<VcfIndexEntry> allEntries = new DiskBasedList<VcfIndexEntry>().adaptToList();
+
         List<GeneFile> geneFiles  = reference.getGeneFile() != null ?
                                     Collections.singletonList(reference.getGeneFile()) : Collections.emptyList();
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -896,4 +896,8 @@ public class VcfManager {
         }
         return infoFieldParser;
     }
+
+    public void setMaxVcfIndexEntriesInMemory(int maxVcfIndexEntriesInMemory) {
+        this.maxVcfIndexEntriesInMemory = maxVcfIndexEntriesInMemory;
+    }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/DiskBasedList.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/DiskBasedList.java
@@ -1,0 +1,304 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.util;
+
+import com.epam.catgenome.constant.MessagesConstants;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.samtools.util.TempStreamFactory;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.*;
+
+import static com.epam.catgenome.component.MessageHelper.getMessage;
+
+/**
+ * Simple disk based collection based on ArrayList buffer. Provides simple interface adding,
+ * iterating and clearing items stored.
+ * @param <T> - class of items to be stored
+ */
+public class DiskBasedList<T> implements Iterable<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiskBasedList.class);
+
+    private static final int DEFAULT_IN_MEMORY_COUNT = 100000;
+    private static final int BUFFER_SIZE = 256 * 1024;
+
+    private final int maxInMemoryItemsCount;
+    private ArrayList<T> buffer;
+    private ArrayList<File> batchFiles;
+
+    private TempStreamFactory tempStreamFactory = new TempStreamFactory();
+
+    public DiskBasedList(int maxInMemoryItemsCount) {
+        this.maxInMemoryItemsCount = maxInMemoryItemsCount;
+        this.buffer = new ArrayList<>();
+        this.batchFiles = new ArrayList<>();
+    }
+
+    public DiskBasedList() {
+        this(DEFAULT_IN_MEMORY_COUNT);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        if (batchFiles.isEmpty()) {
+            return buffer.iterator();
+        } else {
+            return new DiskBasedListIterator();
+        }
+    }
+
+    public void add(T item) {
+        buffer.add(item);
+
+        if (buffer.size() >= maxInMemoryItemsCount) {
+            spillBuffer();
+        }
+    }
+
+    public void clear() {
+        buffer.clear();
+        batchFiles.forEach(File::delete);
+        batchFiles.clear();
+    }
+
+    /**
+     * Adapts current instance to the {@link List} interface
+     * @return adapted to the {@link List} interface {@link DiskBasedList} instance
+     */
+    public List<T> adaptToList() {
+        return new DiskBasedListToListAdapter<>(this);
+    }
+
+    private void spillBuffer() {
+        LOGGER.debug("spilling...");
+
+        try {
+            File batchFile = File.createTempFile(this.getClass().getName(), ".batch");
+            batchFile.deleteOnExit();
+
+            try (ObjectOutputStream oos = new ObjectOutputStream(
+                    tempStreamFactory.wrapTempOutputStream(new FileOutputStream(batchFile), BUFFER_SIZE))) {
+                for (T item : buffer) {
+                    oos.writeObject(item);
+                }
+                oos.flush();
+            }
+
+            batchFiles.add(batchFile);
+            LOGGER.debug("spilled {} items to the file ({} Kb)", buffer.size(), batchFile.length() / 1024);
+            buffer.clear();
+
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    private class DiskBasedListIterator implements Iterator<T> {
+
+        private final Iterator<File> batchFilesIterator = batchFiles.iterator();
+        private final Iterator<T> restBufferIterator = buffer.iterator();
+
+        //Must be null if empty
+        private ObjectInputStream currentBatchFileInputStream;
+        private int objectsAlreadyReadFromFile;
+
+        @Override
+        public boolean hasNext() {
+            return hasMoreInCurrentFile()
+                    || batchFilesIterator.hasNext()
+                    || restBufferIterator.hasNext();
+
+        }
+
+        @Override
+        public T next() {
+            try {
+                if (!hasMoreInCurrentFile()) {
+                    if (batchFilesIterator.hasNext()) {
+                        currentBatchFileInputStream = new ObjectInputStream(
+                                tempStreamFactory.wrapTempInputStream(
+                                        new FileInputStream(batchFilesIterator.next()), BUFFER_SIZE));
+                        objectsAlreadyReadFromFile = 0;
+                        return next();
+                    } else {
+                        return restBufferIterator.next();
+                    }
+                } else {
+                    T deserializedItem = (T) currentBatchFileInputStream.readObject();
+                    objectsAlreadyReadFromFile++;
+                    return deserializedItem;
+                }
+            } catch (IOException | ClassNotFoundException e) {
+                throw new RuntimeIOException(e);
+            }
+        }
+
+        private boolean hasMoreInCurrentFile() {
+            return currentBatchFileInputStream != null && objectsAlreadyReadFromFile < maxInMemoryItemsCount;
+        }
+    }
+
+    private static class DiskBasedListToListAdapter<T> implements List<T> {
+
+        private DiskBasedList<T> diskBasedList;
+
+        DiskBasedListToListAdapter(DiskBasedList<T> diskBasedList) {
+            this.diskBasedList = diskBasedList;
+        }
+
+        @Override
+        public int size() {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public boolean isEmpty() {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @NotNull
+        @Override
+        public Iterator<T> iterator() {
+            return diskBasedList.iterator();
+        }
+
+        @NotNull
+        @Override
+        public Object[] toArray() {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @NotNull
+        @Override
+        public <T1> T1[] toArray(@NotNull T1[] a) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public boolean add(T t) {
+            diskBasedList.add(t);
+            return true;
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public boolean containsAll(@NotNull Collection<?> c) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public boolean addAll(@NotNull Collection<? extends T> c) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public boolean addAll(int index, @NotNull Collection<? extends T> c) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public boolean removeAll(@NotNull Collection<?> c) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public boolean retainAll(@NotNull Collection<?> c) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public void clear() {
+            diskBasedList.clear();
+        }
+
+        @Override
+        public T get(int index) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public T set(int index, T element) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public void add(int index, T element) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public T remove(int index) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public int indexOf(Object o) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @Override
+        public int lastIndexOf(Object o) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @NotNull
+        @Override
+        public ListIterator<T> listIterator() {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @NotNull
+        @Override
+        public ListIterator<T> listIterator(int index) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+        @NotNull
+        @Override
+        public List<T> subList(int fromIndex, int toIndex) {
+            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+        }
+
+    }
+
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/DiskBasedList.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/DiskBasedList.java
@@ -129,7 +129,6 @@ public class DiskBasedList<T> implements Iterable<T> {
         private final Iterator<File> batchFilesIterator = batchFiles.iterator();
         private final Iterator<T> restBufferIterator = buffer.iterator();
 
-        //Must be null if empty
         private ObjectInputStream currentBatchFileInputStream;
         private int objectsAlreadyReadFromFile;
 
@@ -228,7 +227,10 @@ public class DiskBasedList<T> implements Iterable<T> {
 
         @Override
         public boolean addAll(@NotNull Collection<? extends T> c) {
-            throw new UnsupportedOperationException(getMessage(MessagesConstants.ERROR_UNSUPPORTED_OPERATION));
+            for (T t : c) {
+                add(t);
+            }
+            return true;
         }
 
         @Override

--- a/server/catgenome/src/main/resources/catgenome-messages.properties
+++ b/server/catgenome/src/main/resources/catgenome-messages.properties
@@ -76,6 +76,7 @@ error.annotation.file.feature.already.exist=Annotation file ''{0}'' for genome '
 error.annotation.file.feature.not.exist=Annotation file ''{0}'' for genome ''{1}'' not exist.
 error.illegal.reference.for.annotation=Feature file was registered for reference ''{0}'' and can''t be used \
   as annotation for ''{1}''.
+error.unsupported.operation=This is DiskBasedList adapted to the List interface.
 
 # VCF
 info.vcf.upload.done=Your VCF ''{0}'' has been successfully processed and now it is available in the system.

--- a/server/catgenome/src/main/resources/catgenome-messages.properties
+++ b/server/catgenome/src/main/resources/catgenome-messages.properties
@@ -76,7 +76,7 @@ error.annotation.file.feature.already.exist=Annotation file ''{0}'' for genome '
 error.annotation.file.feature.not.exist=Annotation file ''{0}'' for genome ''{1}'' not exist.
 error.illegal.reference.for.annotation=Feature file was registered for reference ''{0}'' and can''t be used \
   as annotation for ''{1}''.
-error.unsupported.operation=This is DiskBasedList adapted to the List interface.
+error.unsupported.operation=This operation is not supported for the DiskBasedList to java.util.List adapter.
 
 # VCF
 info.vcf.upload.done=Your VCF ''{0}'' has been successfully processed and now it is available in the system.

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
@@ -192,6 +192,9 @@ public class VcfManagerTest extends AbstractManagerTest {
     @Value("${vcf.extended.info.patterns}")
     private String infoTemplate;
 
+    @Value("${files.vcf.max.entries.in.memory}")
+    private int maxEntriesInMemory;
+
     private long referenceId;
     private long referenceIdGA4GH;
     private Reference testReference;
@@ -226,6 +229,7 @@ public class VcfManagerTest extends AbstractManagerTest {
         referenceGenomeManager.register(testReferenceGA4GH);
         referenceIdGA4GH = testReferenceGA4GH.getId();
         vcfManager.setExtendedInfoTemplates(infoTemplate);
+        vcfManager.setMaxVcfIndexEntriesInMemory(maxEntriesInMemory);
     }
 
     @Test

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/DiskBasedListTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/DiskBasedListTest.java
@@ -1,3 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
 package com.epam.catgenome.util;
 
 import com.epam.catgenome.dao.index.FeatureIndexDao;
@@ -55,6 +80,13 @@ public class DiskBasedListTest {
             }
         }
 
+        for (int i = 0; i < 3; i++) {
+            assertLists(writtenEntries, diskBasedList);
+        }
+
+    }
+
+    private void assertLists(List<VcfIndexEntry> writtenEntries, List<VcfIndexEntry> diskBasedList) {
         Iterator<VcfIndexEntry> writtenEntriesIterator = writtenEntries.iterator();
         for (VcfIndexEntry fromDiskBasedList : diskBasedList) {
             VcfIndexEntry writtenEntry = writtenEntriesIterator.next();
@@ -77,7 +109,6 @@ public class DiskBasedListTest {
             Assert.assertEquals(deserializedVariantContext.getAlleles(), writtenVariantContext.getAlleles());
             Assert.assertEquals(deserializedVariantContext.getAlleles(), writtenVariantContext.getAlleles());
         }
-
     }
 
     @NotNull

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/DiskBasedListTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/DiskBasedListTest.java
@@ -1,0 +1,100 @@
+package com.epam.catgenome.util;
+
+import com.epam.catgenome.dao.index.FeatureIndexDao;
+import com.epam.catgenome.entity.index.VcfIndexEntry;
+import com.epam.catgenome.entity.vcf.VariationEffect;
+import com.epam.catgenome.entity.vcf.VariationImpact;
+import com.epam.catgenome.entity.vcf.VariationType;
+import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.FeatureReader;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFCodec;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.testng.Assert;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration()
+@ContextConfiguration({"classpath:applicationContext-test.xml", "classpath:catgenome-servlet-test.xml"})
+public class DiskBasedListTest {
+
+    private static final int MAX_IN_MEMORY_ITEMS_COUNT = 10;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void serialisationTest() throws IOException, ClassNotFoundException {
+        Resource resource = context.getResource("classpath:templates/samples.vcf");
+        List<VcfIndexEntry> writtenEntries = new ArrayList<>();
+        List<VcfIndexEntry> diskBasedList = new DiskBasedList<VcfIndexEntry>(MAX_IN_MEMORY_ITEMS_COUNT).adaptToList();
+
+        try (FeatureReader<VariantContext> reader = AbstractFeatureReader
+                .getFeatureReader(resource.getFile().getAbsolutePath(), new VCFCodec(), false)
+        ) {
+
+            for (VariantContext variantContext : reader.iterator()) {
+
+                VcfIndexEntry vcfIndexEntry = createTestEntry(variantContext);
+
+                writtenEntries.add(vcfIndexEntry);
+                diskBasedList.add(vcfIndexEntry);
+            }
+        }
+
+        Iterator<VcfIndexEntry> writtenEntriesIterator = writtenEntries.iterator();
+        for (VcfIndexEntry fromDiskBasedList : diskBasedList) {
+            VcfIndexEntry writtenEntry = writtenEntriesIterator.next();
+
+            Assert.assertEquals(fromDiskBasedList.getVariationType(), writtenEntry.getVariationType());
+            Assert.assertEquals(fromDiskBasedList.getGene(), writtenEntry.getGene());
+            Assert.assertEquals(fromDiskBasedList.getGeneIds(), writtenEntry.getGeneIds());
+            Assert.assertEquals(fromDiskBasedList.getGeneName(), writtenEntry.getGeneName());
+            Assert.assertEquals(fromDiskBasedList.getImpact(), writtenEntry.getImpact());
+            Assert.assertEquals(fromDiskBasedList.getEffect(), writtenEntry.getEffect());
+
+            Assert.assertEquals(
+                    fromDiskBasedList.getInfo().get(FeatureIndexDao.FeatureIndexFields.IS_EXON.getFieldName()),
+                    writtenEntry.getInfo().get(FeatureIndexDao.FeatureIndexFields.IS_EXON.getFieldName()));
+
+            VariantContext deserializedVariantContext = fromDiskBasedList.getVariantContext();
+            VariantContext writtenVariantContext = writtenEntry.getVariantContext();
+
+            Assert.assertEquals(deserializedVariantContext.getContig(), writtenVariantContext.getContig());
+            Assert.assertEquals(deserializedVariantContext.getAlleles(), writtenVariantContext.getAlleles());
+            Assert.assertEquals(deserializedVariantContext.getAlleles(), writtenVariantContext.getAlleles());
+        }
+
+    }
+
+    @NotNull
+    private VcfIndexEntry createTestEntry(VariantContext variantContext) {
+        VcfIndexEntry vcfIndexEntry = new VcfIndexEntry();
+
+        vcfIndexEntry.setVariationType(VariationType.DEL);
+        vcfIndexEntry.setGene("TestGene");
+        vcfIndexEntry.setGeneIds("TestGeneIsd");
+        vcfIndexEntry.setGeneName("TestGeneName");
+        vcfIndexEntry.setImpact(VariationImpact.HIGH);
+        vcfIndexEntry.setEffect(VariationEffect.INTRON);
+
+        vcfIndexEntry.setInfo(new HashMap<>());
+        vcfIndexEntry.getInfo().put(FeatureIndexDao.FeatureIndexFields.IS_EXON.getFieldName(), true);
+
+        vcfIndexEntry.setVariantContext(variantContext);
+        return vcfIndexEntry;
+    }
+}


### PR DESCRIPTION
# Description

## Background
Fix for the Issue https://github.com/epam/NGB/issues/14
Loading VCF files up to 500Mb leads to OutOfMemory exception. That's because during processing loaded VCF `VcfIndexEntry`s for each contig are stored in the memory.

## Changes
`ArrayList` collection for storing `VcfIndexEntry` is replaced by disk-based implementation: `DiskBasedList` (could be adapted to `java.util.List`). `DiskBasedList` has in-memory buffer of given length and if the buffer is overfilled, it will be spilled to temp file in the temp directory, from which items will be read during iteration. 

Items, which stored in `DiskBasedList` are serialized/deserialized by `java.io.Object*Streams` and deflated/inflated by *Snappy* lib (from *htsjdk* dependency). It leads to about x1.7 slowdown (compared to the case we have enough RAM).

If there is no overfilling, `DiskBasedList` acts exact as `ArrayList`.

There is a property to configure max entries in memory for VCF loading:
```bash
# max number of VcfIndexEntries keeping in memory during vcf loading. 
# For files, which produce more entries then
# the number, extra entries will be spilled to disk (temp directory)
# (1000000 entries take about 3Gb in the heap)
files.vcf.max.entries.in.memory=1000000
```

## Acceptance criteria

- 1Gb+ VCF files should be loaded successfully with no OutOfMemory exception
- There is no spilling if VCF has less entries then specified in `files.vcf.max.entries.in.memory` (spilling is logged by `DiskBasedList` class)
- Both cases below loads the same result
   - VCF does not fit in the memory and is partly spilled
   - VCF does fit in the memory (no spilling) 
- Current version should not show slow down compare to develop version if there is no spilling

# Check list

- [x] Unit tests are provided
- [ ] ~~Integration tests are provided (if CLI/API was changed)~~
- [x] Documentation is updated
