### PR TITLE
VCF tracks now have a setting for variants displaying range

### DIFF
--- a/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.tpl.html
+++ b/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.tpl.html
@@ -222,8 +222,25 @@
                         </div>
                     </md-content>
                 </md-tab>
+                <md-tab label="VCF">
+                    <md-content class="md-padding">
+                        <div class="column">
+                            <div class="row">
+                                <md-input-container>
+                                    <input name="maxRangeVcf"
+                                           type="number"
+                                           required
+                                           placeholder="maximum variants range(bp)"
+                                           ng-model="ctrl.settings.variantsMaximumRange"/>
+                                    <div ng-messages="settingsForm.maxRangeVcf.$error" role="alert">
+                                        <div ng-message="required">Enter maximum range for displaying variants(bp).</div>
+                                    </div>
+                                </md-input-container>
+                            </div>
+                        </div>
+                    </md-content>
+                </md-tab>
                 <md-tab label="Customize">
-
                     <md-content class="customizations">
                         <div class="md-toolbar-panel">
                             <md-button ng-click="ctrl.setToDefaultCustomizations()" class="set-to-default-btn">

--- a/client/client/dataServices/local/defaultData.js
+++ b/client/client/dataServices/local/defaultData.js
@@ -186,6 +186,7 @@ export default {
         minBpCount: 50,
         shortenedIntronLength: 15,
         shortenedIntronsMaximumRange: 500000,
+        variantsMaximumRange: 100000,
         showCenterLine: true,
         showSoftClippedBase: true
     }

--- a/client/client/dataServices/local/defaultData.js
+++ b/client/client/dataServices/local/defaultData.js
@@ -186,7 +186,7 @@ export default {
         minBpCount: 50,
         shortenedIntronLength: 15,
         shortenedIntronsMaximumRange: 500000,
-        variantsMaximumRange: 100000,
+        variantsMaximumRange: 500000,
         showCenterLine: true,
         showSoftClippedBase: true
     }

--- a/client/client/modules/render/tracks/vcf/internal/renderer/index.js
+++ b/client/client/modules/render/tracks/vcf/internal/renderer/index.js
@@ -1,2 +1,3 @@
 export {StatisticsContainer, VariantContainer, VCFCollapsedRenderer} from './collapsed';
 export {VCFExpandedRenderer} from './expanded';
+export {PlaceholderRenderer} from './placeholderRenderer';

--- a/client/client/modules/render/tracks/vcf/internal/renderer/placeholderRenderer.js
+++ b/client/client/modules/render/tracks/vcf/internal/renderer/placeholderRenderer.js
@@ -1,0 +1,32 @@
+import PIXI from 'pixi.js';
+import {drawingConfiguration} from '../../../../core';
+
+export class PlaceholderRenderer {
+
+    _container = null;
+    _placeholder = null;
+
+    get container() {
+        return this._container;
+    }
+
+    constructor() {
+        this._container = new PIXI.Container();
+    }
+
+    render() {
+
+    }
+
+    init(text, size) {
+        const {height, width} = size;
+        if (this._placeholder) {
+            this._container.removeChild(this._placeholder);
+        }
+        this._placeholder = new PIXI.Text(text, {align: 'center'});
+        this._placeholder.resolution = drawingConfiguration.resolution;
+        this._placeholder.x = width / drawingConfiguration.scale / 2 - this._placeholder.width / 2;
+        this._placeholder.y = height / drawingConfiguration.scale / 2 - this._placeholder.height / 2;
+        this._container.addChild(this._placeholder);
+    }
+}


### PR DESCRIPTION
# Description

## Background

This PR fixes low performance while loading VCF tracks, described in #14 

## Changes

* New global setting added for VCF tracks - 'maximum variants range'. 

## Acceptance criteria

1. Open global settings form, select 'VCF' tab
2. Observe value for maximum variants displaying range
3. Open VCF track(s), select range greater then current maximum one
4. 'Zoom in to see variants' message should be displayed on tracks instead of data
5. Zoom in to fit current maximum range
6. After data loading finished, variants should be displayed
7. Open global setting form, select 'VCF' tab, change value for maximum range
8. Repeat steps 3-6

# Check list

- [-] Unit tests are provided
- [-] Integration tests are provided (if CLI/API was changed)
- [-] Documentation is updated
