### PR TITLE
Registration files using relative paths support

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
@@ -321,10 +321,12 @@ public class BedManager {
             LOG.debug("Making BED histogram took {} ms", time2 - time1);
             LOG.info(getMessage(MessagesConstants.INFO_GENE_REGISTER, bedFile.getId(),
                     bedFile.getPath()));
-            if(NgbFileUtils.isLocalFilePath(bedFile.getIndex().getPath())) {
-                bedFile.getIndex().setPath(NgbFileUtils.convertToRelativePath(bedFile.getIndex().getPath(), fileManager.getBaseDirPath()));
+            BiologicalDataItem bedFileIndex = bedFile.getIndex();
+            if(NgbFileUtils.isLocalFilePath(bedFileIndex.getPath())) {
+                bedFileIndex.setPath(NgbFileUtils
+                        .convertToRelativePath(bedFileIndex.getPath(), fileManager.getBaseDirPath()));
             }
-            biologicalDataItemManager.createBiologicalDataItem(bedFile.getIndex());
+            biologicalDataItemManager.createBiologicalDataItem(bedFileIndex);
             bedFileManager.createBedFile(bedFile);
             return bedFile;
         } finally {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
@@ -24,28 +24,6 @@
 
 package com.epam.catgenome.manager.bed;
 
-import static com.epam.catgenome.component.MessageHelper.getMessage;
-
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
-
 import com.epam.catgenome.constant.MessagesConstants;
 import com.epam.catgenome.controller.vo.registration.IndexedFileRegistrationRequest;
 import com.epam.catgenome.entity.BaseEntity;
@@ -60,12 +38,12 @@ import com.epam.catgenome.entity.track.Track;
 import com.epam.catgenome.entity.wig.Wig;
 import com.epam.catgenome.exception.FeatureFileReadingException;
 import com.epam.catgenome.exception.FeatureIndexException;
-import com.epam.catgenome.manager.FeatureIndexManager;
 import com.epam.catgenome.exception.HistogramReadingException;
 import com.epam.catgenome.exception.HistogramWritingException;
 import com.epam.catgenome.exception.RegistrationException;
 import com.epam.catgenome.manager.BiologicalDataItemManager;
 import com.epam.catgenome.manager.DownloadFileManager;
+import com.epam.catgenome.manager.FeatureIndexManager;
 import com.epam.catgenome.manager.FileManager;
 import com.epam.catgenome.manager.TrackHelper;
 import com.epam.catgenome.manager.bed.parser.NggbBedFeature;
@@ -73,13 +51,35 @@ import com.epam.catgenome.manager.reference.ReferenceGenomeManager;
 import com.epam.catgenome.util.AuthUtils;
 import com.epam.catgenome.util.HistogramUtils;
 import com.epam.catgenome.util.IOHelper;
+import com.epam.catgenome.util.NgbFileUtils;
 import com.epam.catgenome.util.Utils;
-import htsjdk.tribble.bed.BEDCodec;
-import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
+import htsjdk.tribble.bed.BEDCodec;
+import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.readers.LineIterator;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.epam.catgenome.component.MessageHelper.getMessage;
 
 /**
  * Provides service for handling {@code BedFile}: CRUD operations and loading data from the files
@@ -321,6 +321,9 @@ public class BedManager {
             LOG.debug("Making BED histogram took {} ms", time2 - time1);
             LOG.info(getMessage(MessagesConstants.INFO_GENE_REGISTER, bedFile.getId(),
                     bedFile.getPath()));
+            if(NgbFileUtils.isLocalFilePath(bedFile.getIndex().getPath())) {
+                bedFile.getIndex().setPath(NgbFileUtils.convertToRelativePath(bedFile.getIndex().getPath(), fileManager.getBaseDirPath()));
+            }
             biologicalDataItemManager.createBiologicalDataItem(bedFile.getIndex());
             bedFileManager.createBedFile(bedFile);
             return bedFile;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneFileManager.java
@@ -24,24 +24,25 @@
 
 package com.epam.catgenome.manager.gene;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import com.epam.catgenome.dao.reference.ReferenceGenomeDao;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Assert;
-
 import com.epam.catgenome.component.MessageHelper;
 import com.epam.catgenome.constant.MessagesConstants;
 import com.epam.catgenome.dao.BiologicalDataItemDao;
 import com.epam.catgenome.dao.gene.GeneFileDao;
 import com.epam.catgenome.dao.project.ProjectDao;
+import com.epam.catgenome.dao.reference.ReferenceGenomeDao;
 import com.epam.catgenome.entity.BaseEntity;
 import com.epam.catgenome.entity.gene.GeneFile;
 import com.epam.catgenome.entity.project.Project;
+import com.epam.catgenome.util.NgbFileUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Source:      GeneFileManager
@@ -68,6 +69,9 @@ public class GeneFileManager {
 
     @Autowired
     private ReferenceGenomeDao referenceGenomeDao;
+
+    @Value("${files.base.directory.path}")
+    private String baseDirPath;
 
     /**
      * Persists {@code GeneFile} record to the database
@@ -121,6 +125,7 @@ public class GeneFileManager {
     public GeneFile loadGeneFile(long geneFileId) {
         GeneFile geneFile = geneFileDao.loadGeneFile(geneFileId);
         Assert.notNull(geneFile, MessageHelper.getMessage(MessagesConstants.ERROR_FILE_NOT_FOUND, geneFileId));
+        NgbFileUtils.resolveRelativeIfNeeded(geneFile, baseDirPath);
         return geneFile;
     }
 
@@ -148,6 +153,8 @@ public class GeneFileManager {
      */
     @Transactional(propagation = Propagation.SUPPORTS)
     public List<GeneFile> loadGeneFilesByReferenceId(long referenceId) {
-        return geneFileDao.loadGeneFilesByReferenceId(referenceId);
+        List<GeneFile> geneFiles = geneFileDao.loadGeneFilesByReferenceId(referenceId);
+        geneFiles.forEach(geneFile -> NgbFileUtils.resolveRelativeIfNeeded(geneFile, baseDirPath));
+        return geneFiles;
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneRegisterer.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneRegisterer.java
@@ -365,8 +365,10 @@ public class GeneRegisterer {
         index = (TabixIndex) transcriptIndexCreator.finalizeIndex(transcriptPosition);
         index.write(transcriptIndexFile);
 
-        geneFile.setIndex(doIndex ? createIndexItem(NgbFileUtils.convertToRelativePath(indexFile.getAbsolutePath(), fileManager.getBaseDirPath())) :
-                createIndexItem(request.getIndexPath()));
+        geneFile.setIndex(doIndex
+                ? createIndexItem(NgbFileUtils
+                .convertToRelativePath(indexFile.getAbsolutePath(), fileManager.getBaseDirPath()))
+                : createIndexItem(request.getIndexPath()));
     }
 
     private BiologicalDataItem createIndexItem(String indexPath) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneRegisterer.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneRegisterer.java
@@ -24,26 +24,6 @@
 
 package com.epam.catgenome.manager.gene;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.http.util.TextUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.epam.catgenome.component.MessageHelper;
 import com.epam.catgenome.constant.MessagesConstants;
 import com.epam.catgenome.controller.vo.registration.FeatureIndexedFileRegistrationRequest;
@@ -64,6 +44,7 @@ import com.epam.catgenome.manager.gene.parser.GffCodec;
 import com.epam.catgenome.manager.reference.ReferenceGenomeManager;
 import com.epam.catgenome.util.AuthUtils;
 import com.epam.catgenome.util.IndexUtils;
+import com.epam.catgenome.util.NgbFileUtils;
 import com.epam.catgenome.util.PositionalOutputStream;
 import com.epam.catgenome.util.Utils;
 import htsjdk.samtools.util.BlockCompressedInputStream;
@@ -75,6 +56,25 @@ import htsjdk.tribble.index.tabix.TabixIndexCreator;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.tribble.readers.PositionalBufferedStream;
 import htsjdk.tribble.util.LittleEndianOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.util.TextUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 /**
@@ -365,7 +365,7 @@ public class GeneRegisterer {
         index = (TabixIndex) transcriptIndexCreator.finalizeIndex(transcriptPosition);
         index.write(transcriptIndexFile);
 
-        geneFile.setIndex(doIndex ? createIndexItem(indexFile.getAbsolutePath()) :
+        geneFile.setIndex(doIndex ? createIndexItem(NgbFileUtils.convertToRelativePath(indexFile.getAbsolutePath(), fileManager.getBaseDirPath())) :
                 createIndexItem(request.getIndexPath()));
     }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
@@ -24,7 +24,35 @@
 
 package com.epam.catgenome.manager.reference;
 
-import static com.epam.catgenome.component.MessageHelper.getMessage;
+import com.epam.catgenome.component.MessageCode;
+import com.epam.catgenome.constant.MessagesConstants;
+import com.epam.catgenome.dao.BiologicalDataItemDao;
+import com.epam.catgenome.dao.gene.GeneFileDao;
+import com.epam.catgenome.dao.project.ProjectDao;
+import com.epam.catgenome.dao.reference.ReferenceGenomeDao;
+import com.epam.catgenome.entity.BaseEntity;
+import com.epam.catgenome.entity.BiologicalDataItem;
+import com.epam.catgenome.entity.BiologicalDataItemFormat;
+import com.epam.catgenome.entity.BiologicalDataItemResourceType;
+import com.epam.catgenome.entity.FeatureFile;
+import com.epam.catgenome.entity.gene.GeneFile;
+import com.epam.catgenome.entity.project.Project;
+import com.epam.catgenome.entity.reference.Chromosome;
+import com.epam.catgenome.entity.reference.Reference;
+import com.epam.catgenome.exception.FeatureIndexException;
+import com.epam.catgenome.manager.FeatureIndexManager;
+import com.epam.catgenome.util.AuthUtils;
+import com.epam.catgenome.util.ListMapCollector;
+import com.epam.catgenome.util.NgbFileUtils;
+import com.epam.catgenome.util.Utils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,33 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.epam.catgenome.entity.BaseEntity;
-import com.epam.catgenome.entity.BiologicalDataItem;
-import com.epam.catgenome.entity.BiologicalDataItemFormat;
-import com.epam.catgenome.entity.BiologicalDataItemResourceType;
-import com.epam.catgenome.entity.FeatureFile;
-import com.epam.catgenome.entity.gene.GeneFile;
-import com.epam.catgenome.exception.FeatureIndexException;
-import com.epam.catgenome.manager.FeatureIndexManager;
-import com.epam.catgenome.util.AuthUtils;
-import com.epam.catgenome.util.ListMapCollector;
-import org.apache.commons.collections4.CollectionUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Assert;
-
-import com.epam.catgenome.component.MessageCode;
-import com.epam.catgenome.constant.MessagesConstants;
-import com.epam.catgenome.dao.BiologicalDataItemDao;
-import com.epam.catgenome.dao.gene.GeneFileDao;
-import com.epam.catgenome.dao.project.ProjectDao;
-import com.epam.catgenome.dao.reference.ReferenceGenomeDao;
-import com.epam.catgenome.entity.project.Project;
-import com.epam.catgenome.entity.reference.Chromosome;
-import com.epam.catgenome.entity.reference.Reference;
-import org.springframework.util.StringUtils;
+import static com.epam.catgenome.component.MessageHelper.getMessage;
 
 /**
  * {@code ReferenceManager} represents a service class designed to encapsulate all business
@@ -84,6 +86,9 @@ public class ReferenceGenomeManager {
 
     @Autowired
     private FeatureIndexManager featureIndexManager;
+
+    @Value("${files.base.directory.path}")
+    private String baseDirPath;
 
     /**
      * Generates and returns ID value, that has to be used to identify each certain reference
@@ -113,7 +118,13 @@ public class ReferenceGenomeManager {
         Assert.isTrue(CollectionUtils.isNotEmpty(reference.getChromosomes()),
                 getMessage("error.reference.aborted.saving.chromosomes"));
         Assert.notNull(reference.getId(), getMessage(MessageCode.UNKNOWN_REFERENCE_ID));
-        biologicalDataItemDao.createBiologicalDataItem(reference.getIndex());
+        BiologicalDataItem referenceIndex = reference.getIndex();
+        String referenceIndexPath = referenceIndex.getPath();
+        if(!referenceIndexPath.isEmpty()
+                && !reference.getPath().contains(Utils.removeFileExtension(referenceIndexPath, ".fai"))) {
+            referenceIndex.setPath(NgbFileUtils.convertToRelativePath(referenceIndexPath, baseDirPath));
+        }
+        biologicalDataItemDao.createBiologicalDataItem(referenceIndex);
         if (reference.getCreatedDate() == null) {
             reference.setCreatedDate(new Date());
         }
@@ -170,12 +181,14 @@ public class ReferenceGenomeManager {
     public Reference loadReferenceGenome(final Long referenceId) {
         final Reference reference = referenceGenomeDao.loadReferenceGenome(referenceId);
         Assert.notNull(reference, getMessage(MessageCode.NO_SUCH_REFERENCE));
-
+        NgbFileUtils.resolveRelativeIfNeeded(reference, baseDirPath);
         final List<Chromosome> chromosomes = referenceGenomeDao.loadAllChromosomesByReferenceId(referenceId);
         reference.setChromosomes(chromosomes);
 
         if (reference.getGeneFile() != null) {
-            reference.setGeneFile(geneFileDao.loadGeneFile(reference.getGeneFile().getId()));
+            GeneFile geneFile = geneFileDao.loadGeneFile(reference.getGeneFile().getId());
+            NgbFileUtils.resolveRelativeIfNeeded(geneFile, baseDirPath);
+            reference.setGeneFile(geneFile);
         }
 
         reference.setAnnotationFiles(
@@ -206,8 +219,10 @@ public class ReferenceGenomeManager {
     public Reference loadReferenceGenomeByBioItemId(final Long dataItemId) {
         final Reference reference = referenceGenomeDao.loadReferenceGenomeByBioItemId(dataItemId);
         Assert.notNull(reference, getMessage(MessageCode.NO_SUCH_REFERENCE));
-
-        reference.setGeneFile(geneFileDao.loadGeneFile(reference.getGeneFile().getId()));
+        NgbFileUtils.resolveRelativeIfNeeded(reference, baseDirPath);
+        GeneFile geneFile = geneFileDao.loadGeneFile(reference.getGeneFile().getId());
+        NgbFileUtils.resolveRelativeIfNeeded(geneFile, baseDirPath);
+        reference.setGeneFile(geneFile);
         reference.setAnnotationFiles(getAnnotationFilesByReferenceId(reference.getId()));
         return reference;
     }
@@ -229,18 +244,26 @@ public class ReferenceGenomeManager {
     public List<Reference> loadAllReferenceGenomes(String referenceName) {
         if (!StringUtils.isEmpty(referenceName)) {
             Reference reference = referenceGenomeDao.loadReferenceGenomeByName(referenceName.toLowerCase());
+            NgbFileUtils.resolveRelativeIfNeeded(reference, baseDirPath);
             if (reference.getGeneFile() != null && reference.getGeneFile().getId() != null) {
                 GeneFile geneFile = geneFileDao.loadGeneFile(reference.getGeneFile().getId());
+                NgbFileUtils.resolveRelativeIfNeeded(geneFile, baseDirPath);
                 reference.setGeneFile(geneFile);
                 reference.setAnnotationFiles(getAnnotationFilesByReferenceId(reference.getId()));
             }
             return Collections.singletonList(reference);
         }
         List<Reference> references = referenceGenomeDao.loadAllReferenceGenomes();
+        references.forEach(reference -> {
+            if(reference.getIndex() != null) {
+                NgbFileUtils.resolveRelativeIfNeeded(reference, baseDirPath);
+            }
+        });
         Map<Long, List<Reference>> referenceToGeneIds = references.stream().collect(new ListMapCollector<>(
             reference -> reference.getGeneFile() != null ? reference.getGeneFile().getId() : null));
 
         List<GeneFile> geneFiles = geneFileDao.loadGeneFiles(referenceToGeneIds.keySet());
+        geneFiles.forEach(geneFile -> NgbFileUtils.resolveRelativeIfNeeded(geneFile, baseDirPath));
         List<Reference> result = new ArrayList<>(references.size());
         for (GeneFile geneFile : geneFiles) {
             referenceToGeneIds.get(geneFile.getId()).forEach(r -> {
@@ -300,7 +323,7 @@ public class ReferenceGenomeManager {
      * @return {@code List}
      */
     @Transactional(propagation = Propagation.SUPPORTS)
-    public List<BaseEntity> loadAllFile(final Long referenceId) {
+    private List<BaseEntity> loadAllFile(final Long referenceId) {
         return referenceGenomeDao.loadAllFileByReferenceId(referenceId);
     }
 
@@ -317,6 +340,7 @@ public class ReferenceGenomeManager {
         Assert.notNull(referenceId, getMessage(MessageCode.NO_SUCH_REFERENCE));
         final Reference reference = referenceGenomeDao.loadReferenceGenome(referenceId);
         Assert.notNull(reference, getMessage(MessageCode.NO_SUCH_REFERENCE));
+        NgbFileUtils.resolveRelativeIfNeeded(reference, baseDirPath);
         return reference;
     }
 
@@ -324,9 +348,10 @@ public class ReferenceGenomeManager {
     public Reference updateReferenceGeneFileId(long referenceId, Long geneFileId) {
         final Reference reference = referenceGenomeDao.loadReferenceGenome(referenceId);
         Assert.notNull(reference, getMessage(MessageCode.NO_SUCH_REFERENCE));
-
         referenceGenomeDao.updateReferenceGeneFileId(referenceId, geneFileId);
-        return loadReferenceGenome(referenceId);
+        Reference loadReferenceGenome = loadReferenceGenome(referenceId);
+        NgbFileUtils.resolveRelativeIfNeeded(reference, baseDirPath);
+        return loadReferenceGenome;
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/BedGraphProcessor.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/BedGraphProcessor.java
@@ -87,6 +87,7 @@ public class BedGraphProcessor extends AbstractWigProcessor {
     protected void prepareWigFileToWork(WigFile wigFile) throws IOException {
         wigFile.setCompressed(IOHelper.isGZIPFile(wigFile.getPath()));
         fileManager.makeBedGraphIndex(wigFile);
+        wigFile.getIndex().setPath(NgbFileUtils.convertToRelativePath(wigFile.getIndex().getPath(), fileManager.getBaseDirPath()));
         biologicalDataItemManager.createBiologicalDataItem(wigFile.getIndex());
     }
 
@@ -95,6 +96,7 @@ public class BedGraphProcessor extends AbstractWigProcessor {
     @Override
     protected void splitByChromosome(WigFile wigFile, Map<String, Chromosome> chromosomeMap) throws IOException {
         List<BedGraphFeature> sectionList = new ArrayList<>();
+        NgbFileUtils.resolveRelativeIfNeeded(wigFile, fileManager.getBaseDirPath());
         for (Chromosome chromosome : chromosomeMap.values()) {
             try (PeekableIterator<BedGraphFeature> query = new PeekableIterator<>(
                     new BedGraphReader(wigFile.getPath(), wigFile.getIndex().getPath()).query(

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/BedGraphProcessor.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/BedGraphProcessor.java
@@ -25,6 +25,7 @@
 package com.epam.catgenome.manager.wig;
 
 import com.epam.catgenome.constant.MessagesConstants;
+import com.epam.catgenome.entity.BiologicalDataItem;
 import com.epam.catgenome.entity.reference.Chromosome;
 import com.epam.catgenome.entity.track.Track;
 import com.epam.catgenome.entity.wig.Wig;
@@ -87,8 +88,9 @@ public class BedGraphProcessor extends AbstractWigProcessor {
     protected void prepareWigFileToWork(WigFile wigFile) throws IOException {
         wigFile.setCompressed(IOHelper.isGZIPFile(wigFile.getPath()));
         fileManager.makeBedGraphIndex(wigFile);
-        wigFile.getIndex().setPath(NgbFileUtils.convertToRelativePath(wigFile.getIndex().getPath(), fileManager.getBaseDirPath()));
-        biologicalDataItemManager.createBiologicalDataItem(wigFile.getIndex());
+        BiologicalDataItem wigFileIndex = wigFile.getIndex();
+        wigFileIndex.setPath(NgbFileUtils.convertToRelativePath(wigFileIndex.getPath(), fileManager.getBaseDirPath()));
+        biologicalDataItemManager.createBiologicalDataItem(wigFileIndex);
     }
 
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/NgbFileUtils.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/NgbFileUtils.java
@@ -1,13 +1,15 @@
 package com.epam.catgenome.util;
 
+import com.epam.catgenome.entity.BiologicalDataItemFormat;
+import com.epam.catgenome.entity.IndexedDataItem;
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.io.FilenameUtils;
-
-import com.epam.catgenome.entity.BiologicalDataItemFormat;
 
 /**
  * Source:      FileUtils
@@ -146,5 +148,27 @@ public final class NgbFileUtils {
 
     public static boolean isGzCompressed(String fileName) {
         return fileName.endsWith(GZ_EXTENSION);
+    }
+
+    public static void resolveRelativeIfNeeded(IndexedDataItem file, String baseDirPath) {
+        String indexPath = file.getIndex().getPath();
+        indexPath.trim();
+        if(!isFileIndexPathAbsolute(indexPath) && isLocalFilePath(indexPath)) {
+            file.getIndex().setPath(baseDirPath + File.separator + indexPath);
+        }
+    }
+
+    private static boolean isFileIndexPathAbsolute(String filePath) {
+        return filePath.startsWith("/");
+    }
+
+    public static boolean isLocalFilePath(String filePath) {
+        return !filePath.matches("^(http|https|ftp|S3|ftsp)://.*$");
+    }
+
+    public static String convertToRelativePath(String absoluteFilePath, String baseDirPath) {
+        return Paths.get(baseDirPath)
+                .relativize(Paths.get(absoluteFilePath))
+                .toString();
     }
 }


### PR DESCRIPTION
# Description

## Background
**Issue: https://github.com/epam/NGB/issues/15**
NGB allows to configure a path where all caches and indexes are stored using `files.base.directory.path` in a configuration files. But when files are registered - absolute path is written to the index DB, thus changing `files.base.directory.path` value - results into FileNotFound errors.

## Changes

Support for storage of caches and indexes relative paths has been added. 
It contains: 
* Files paths are stored in a DB using relative paths (relative to `files.base.directory.path`).
* Full paths are resolved when a file is requested
* Backward compatibility is provided: if a file in a DB is absolute (e.g. starting with ` /`) - it aren't be resolved using `files.base.directory.path`

## Acceptance criteria

* Create a new DB and fill it with files of various formats: REF, GENE, BED, SEG, MAF, VCF, BED graph.
* Move base directory and set `files.base.directory.path` value.
* Check availability of this files and his indexes through web-client and manual debugging. 

# Check list

The available tests are sensitive to the changes made.

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
