### PR TITLE
Description refinement of reference name at registration reference sequence

### DIFF
--- a/docs/md/cli/command-reference.md
+++ b/docs/md/cli/command-reference.md
@@ -59,7 +59,7 @@ ngb search sample_1.bam
 ngb reg_ref|rr [<PATH_TO_GENOME_FASTA>] [options]
 
 //Options:
-//-n (--name) [value]       Use specified value for reference sequence name. If not specified - fasta file name will be used. Should be unique
+//-n (--name) [value]       Use specified value for reference sequence name. If not specified - fasta file name will be used. Should be unique and mustn't be a number (it will be recognized as ID).
 //-t (--table)              Print result as a human-readable table
 //-j (--json)               Print result as a JSON string
 //-g (--genes) [value]      Add a gene (gtf or gff) file to the reference. If file is already registered, it can be addressed by name or an identifier. Otherwise a path to the file should be provided.

--- a/docs/md/cli/command-reference.md
+++ b/docs/md/cli/command-reference.md
@@ -212,7 +212,7 @@ ngb remove_ann grch38 annotation.gtf
 ngb reg_file|rf [<REFERENCE_NAME>|<REFERENCE_ID>] [<PATH_TO_NGS_FILE>] [options]
 
 //Options:
-//-n (--name)   [value]     Use specified value for file name. If not specified - filesystem name will be used. Should be unique
+//-n (--name)   [value]     Use specified value for file name. If not specified - filesystem name will be used. Should be unique and mustn't be a number (it will be recognized as ID).
 //-ni (--no_index)          Defines if a feature index should not be built during file registration (could be used to speed up registration process)
 //-t (--table)              Print result as a human-readable table
 //-j (--json)               Print result as a JSON string


### PR DESCRIPTION
# Description

## Background

**Issue: https://github.com/epam/NGB/issues/21**
NGB allows to use specified value for reference sequence name through `-n (--name) [value]` option. But if one registers file using number as name, file registration shall not work with number name reference.

## Changes

The general commands description was supplemented by "Specified value for reference sequence name mustn't be a number (it will be recognized as ID)".

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [x] Documentation is updated
