### PR TITLE
Limit for lucene index size for /filter and /group API requests

### DIFF
--- a/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfo/ngbVariantDensityDiagram/ngbVariantDensityDiagram.controller.js
+++ b/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfo/ngbVariantDensityDiagram/ngbVariantDensityDiagram.controller.js
@@ -59,7 +59,8 @@ export default class ngbVariantDensityDiagramController {
                         return v;
                     }
                 },
-                y: (d) => d.value
+                y: (d) => d.value,
+                noData: 'No Data Available'
             },
             title: {
                 enable: true,
@@ -95,7 +96,8 @@ export default class ngbVariantDensityDiagramController {
             this.projectContext.variantsDataByChromosomes.length === 0;
         if (this.projectContext.reference && this.projectContext.variantsDataByChromosomes) {
             await this.updateDiagram(this.projectContext.variantsDataByChromosomes,
-                this.projectContext.isVariantsGroupByChromosomesLoading);
+                this.projectContext.isVariantsGroupByChromosomesLoading,
+                this.projectContext.variantsGroupByChromosomesError);
             this.isProgressShown = this.projectContext.isVariantsGroupByChromosomesLoading;
             this._scope.$apply();
         }
@@ -153,12 +155,16 @@ export default class ngbVariantDensityDiagramController {
     }
 
 
-    async updateDiagram(variants, isLoading) {
+    async updateDiagram(variants, isLoading, error) {
         if (isLoading) {
             return;
         }
-        (!variants || variants.length === 0) ?
-            this._scope.data = [] : this._scope.data = this.makeNvD3ChartObjectFromData(variants);
+        if (!variants || variants.length === 0) {
+            this._scope.options.chart.noData = error || 'No Data Available';
+            this._scope.data = [];
+        } else {
+            this._scope.data = this.makeNvD3ChartObjectFromData(variants);
+        }
         this._scope.api && angular.isFunction(this._scope.api.update) ? this._scope.api.update() : '';
     }
 }

--- a/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfo/ngbVariantQualityDiagram/ngbVariantQualityDiagram.controller.js
+++ b/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfo/ngbVariantQualityDiagram/ngbVariantQualityDiagram.controller.js
@@ -44,7 +44,7 @@ export default class ngbVariantQualityDiagramController {
                 yAxis : {
                     tickFormat : (t) => t
                 },
-
+                noData: 'No Data Available'
             },
             title: {
                 enable: true,
@@ -84,7 +84,8 @@ export default class ngbVariantQualityDiagramController {
             this.projectContext.variantsDataByQuality.length === 0;
         if (this.projectContext.reference && this.projectContext.variantsDataByQuality) {
             await this.updateDiagram(this.projectContext.variantsDataByQuality,
-                this.projectContext.isVariantsGroupByQualityLoading);
+                this.projectContext.isVariantsGroupByQualityLoading,
+                this.projectContext.variantsGroupByQualityError);
             this.isProgressShown = this.projectContext.isVariantsGroupByQualityLoading;
             this._scope.$apply();
         }
@@ -136,13 +137,16 @@ export default class ngbVariantQualityDiagramController {
 
     }
 
-    async updateDiagram(variantQualities, isLoading) {
+    async updateDiagram(variantQualities, isLoading, error) {
         if (isLoading) {
             return;
         }
-        (!variantQualities || variantQualities.length === 0) ?
-            this._scope.data = [] : this._scope.data = this.makeNvD3ChartObjectFromData(variantQualities);
-
+        if (!variantQualities || variantQualities.length === 0) {
+            this._scope.options.chart.noData = error || 'No Data Available';
+            this._scope.data = [];
+        } else {
+            this._scope.data = this.makeNvD3ChartObjectFromData(variantQualities);
+        }
         this._scope.api && angular.isFunction(this._scope.api.update) ? this._scope.api.update() : '';
     }
 

--- a/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfo/ngbVariantTypeDiagram/ngbVariantTypeDiagram.controller.js
+++ b/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfo/ngbVariantTypeDiagram/ngbVariantTypeDiagram.controller.js
@@ -54,7 +54,8 @@ export default class ngbVariantTypeDiagramController {
                         return d;
                     }
                 },
-                y: (d)=> d.value
+                y: (d)=> d.value,
+                noData: 'No Data Available'
             },
             title: {
                 enable: true,
@@ -152,17 +153,23 @@ export default class ngbVariantTypeDiagramController {
             this.projectContext.variantsDataByType.length === 0;
         if (this.projectContext.reference && this.projectContext.variantsDataByType) {
             await this.updateDiagram(this.projectContext.variantsDataByType,
-                this.projectContext.isVariantsGroupByTypeLoading);
+                this.projectContext.isVariantsGroupByTypeLoading,
+                this.projectContext.variantsGroupByTypeError);
             this.isProgressShown = this.projectContext.isVariantsGroupByTypeLoading;
             this._scope.$apply();
         }
     }
 
-    async updateDiagram(variants, isLoading) {
+    async updateDiagram(variants, isLoading, error) {
         if (isLoading) {
             return;
         }
-        (!variants || variants.length === 0) ? this._scope.data = [] : this._scope.data = this.makeNvD3ChartObjectFromData(variants);
-        this._scope.api && angular.isFunction(this._scope.api.update) ? this._scope.api.update() : '';		
+        if (!variants || variants.length === 0) {
+            this._scope.options.chart.noData = error || 'No Data Available';
+            this._scope.data = [];
+        } else {
+            this._scope.data = this.makeNvD3ChartObjectFromData(variants);
+        }
+        this._scope.api && angular.isFunction(this._scope.api.update) ? this._scope.api.update() : '';
     }
 }

--- a/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfoPanel.controller.js
+++ b/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfoPanel.controller.js
@@ -17,6 +17,6 @@ export default class ngbProjectInfoPanelController {
     }
 
     get containsVcfFiles() {
-        return this.projectContext.containsVcfFiles;
+        return this.projectContext.containsVcfFiles && !this.projectContext.variantsGroupError;
     }
 }

--- a/client/client/app/components/ngbVariantsTablePanel/index.js
+++ b/client/client/app/components/ngbVariantsTablePanel/index.js
@@ -8,10 +8,10 @@ import ngbVariantsTablePanel from './ngbVariantsTablePanel.component.js';
 import controller from './ngbVariantsTablePanel.controller';
 
 // Import components
+import  ngbVariantsLoadingIndicator from './ngbVariantsLoadingIndicator';
 import  ngbVariantsTable from './ngbVariantsTable';
 import  ngbVariantsTableColumn from './ngbVariantsTableColumn';
 import  ngbVariantsTablePaginate from './ngbVariantsTablePaginate';
-import  ngbVariantsLoadingIndicator from './ngbVariantsLoadingIndicator';
 
 
 // Import external modules

--- a/client/client/app/components/ngbVariantsTablePanel/index.js
+++ b/client/client/app/components/ngbVariantsTablePanel/index.js
@@ -11,10 +11,15 @@ import controller from './ngbVariantsTablePanel.controller';
 import  ngbVariantsTable from './ngbVariantsTable';
 import  ngbVariantsTableColumn from './ngbVariantsTableColumn';
 import  ngbVariantsTablePaginate from './ngbVariantsTablePaginate';
+import  ngbVariantsLoadingIndicator from './ngbVariantsLoadingIndicator';
 
 
 // Import external modules
-export default angular.module('ngbVariantsTablePanel', [ngbVariantsTable,ngbVariantsTableColumn,ngbVariantsTablePaginate])
+export default angular.module('ngbVariantsTablePanel', [
+    ngbVariantsTable,
+    ngbVariantsTableColumn,
+    ngbVariantsTablePaginate,
+    ngbVariantsLoadingIndicator])
     .component('ngbVariantsTablePanel', ngbVariantsTablePanel)
     .controller(controller.UID, controller)
     .name;

--- a/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/index.js
+++ b/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/index.js
@@ -1,0 +1,12 @@
+import angular from 'angular';
+import './ngbVariantsLoadingIndicator.scss';
+
+// Import internal modules
+import component from './ngbVariantsLoadingIndicator.component';
+import controller from './ngbVariantsLoadingIndicator.controller';
+
+// Import external modules
+export default angular.module('ngbVariantsLoadingIndicator', [])
+    .controller(controller.UID, controller)
+    .component('ngbVariantsLoadingIndicator', component)
+    .name;

--- a/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.component.js
+++ b/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.component.js
@@ -1,0 +1,6 @@
+import controller from './ngbVariantsLoadingIndicator.controller';
+
+export default  {
+    controller: controller.UID,
+    template: require('./ngbVariantsLoadingIndicator.tpl.html')
+};

--- a/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.controller.js
+++ b/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.controller.js
@@ -3,7 +3,7 @@ import  baseController from '../../../shared/baseController';
 export default class ngbVariantsLoadingIndicatorController extends baseController {
 
     static get UID() {
-        return 'ngbVariantsTablePaginateController';
+        return 'ngbVariantsLoadingIndicatorController';
     }
 
     projectContext;
@@ -28,10 +28,7 @@ export default class ngbVariantsLoadingIndicatorController extends baseControlle
         'variants:page:loading:started': ::this.refresh
     };
 
-    refresh (updateScope = true) {
+    refresh () {
         this.isProgressShown = this.projectContext.variantsPageLoading;
-        if (updateScope) {
-            this._scope.$apply();
-        }
     }
 }

--- a/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.controller.js
+++ b/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.controller.js
@@ -1,0 +1,37 @@
+import  baseController from '../../../shared/baseController';
+
+export default class ngbVariantsLoadingIndicatorController extends baseController {
+
+    static get UID() {
+        return 'ngbVariantsTablePaginateController';
+    }
+
+    projectContext;
+    isProgressShown = false;
+    _scope;
+
+    constructor(dispatcher, projectContext, $scope) {
+        super(dispatcher);
+        this._scope = $scope;
+        Object.assign(this, {
+            $scope,
+            dispatcher,
+            projectContext
+        });
+
+        this.initEvents();
+        this.refresh(false);
+    }
+
+    events = {
+        'variants:page:loading:finished': ::this.refresh,
+        'variants:page:loading:started': ::this.refresh
+    };
+
+    refresh (updateScope = true) {
+        this.isProgressShown = this.projectContext.variantsPageLoading;
+        if (updateScope) {
+            this._scope.$apply();
+        }
+    }
+}

--- a/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.scss
+++ b/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.scss
@@ -1,0 +1,11 @@
+ngb-variants-loading-indicator {
+  align-self: center;
+  height: 22px;
+  .indicator {
+    margin-right: 10px;
+    margin-top: 4px;
+    md-progress-circular {
+      svg path { stroke: white; }
+    }
+  }
+}

--- a/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.tpl.html
+++ b/client/client/app/components/ngbVariantsTablePanel/ngbVariantsLoadingIndicator/ngbVariantsLoadingIndicator.tpl.html
@@ -1,0 +1,7 @@
+<div class="indicator">
+    <md-progress-circular
+            md-mode="indeterminate"
+            ng-show="$ctrl.isProgressShown"
+            md-diameter="16">
+    </md-progress-circular>
+</div>

--- a/client/client/app/components/ngbVariantsTablePanel/ngbVariantsTable/ngbVariantsTable.controller.js
+++ b/client/client/app/components/ngbVariantsTablePanel/ngbVariantsTable/ngbVariantsTable.controller.js
@@ -251,7 +251,10 @@ export default class ngbVariantsTableController extends baseController {
         this.projectContext.loadVariations(this.projectContext.lastPageVariations).then((data) => {
             this.gridApi.infiniteScroll.saveScrollPercentage();
             this.gridOptions.data = this.gridOptions.data.concat(data);
-            this.gridApi.infiniteScroll.dataLoaded(this.projectContext.firstPageVariations > 1, this.projectContext.lastPageVariations < this.projectContext.totalPagesCountVariations);
+            this.gridApi.infiniteScroll.dataLoaded(
+                this.projectContext.firstPageVariations > 1,
+                (this.projectContext.totalPagesCountVariations === undefined && this.projectContext.hasMoreVariations)
+                || this.projectContext.lastPageVariations < this.projectContext.totalPagesCountVariations);
         });
     }
 
@@ -267,7 +270,10 @@ export default class ngbVariantsTableController extends baseController {
 
             const self = this;
             this.$timeout(function () {
-                self.gridApi.infiniteScroll.dataLoaded(self.projectContext.firstPageVariations > 1, self.projectContext.lastPageVariations < self.projectContext.totalPagesCountVariations);
+                self.gridApi.infiniteScroll.dataLoaded(
+                    self.projectContext.firstPageVariations > 1,
+                    (self.projectContext.totalPagesCountVariations === undefined && self.projectContext.hasMoreVariations)
+                    || self.projectContext.lastPageVariations < self.projectContext.totalPagesCountVariations);
             });
         });
     }
@@ -283,7 +289,10 @@ export default class ngbVariantsTableController extends baseController {
             const self = this;
             this.gridOptions.data = data;
             this.$timeout(function () {
-                self.gridApi.infiniteScroll.resetScroll(self.projectContext.firstPageVariations > 1, self.projectContext.lastPageVariations < self.projectContext.totalPagesCountVariations);
+                self.gridApi.infiniteScroll.resetScroll(
+                    self.projectContext.firstPageVariations > 1,
+                    (self.projectContext.totalPagesCountVariations === undefined && self.projectContext.hasMoreVariations)
+                    || self.projectContext.lastPageVariations < self.projectContext.totalPagesCountVariations);
             });
         });
     }
@@ -311,7 +320,10 @@ export default class ngbVariantsTableController extends baseController {
             const self = this;
             this.gridOptions.data = data;
             this.$timeout(function () {
-                self.gridApi.infiniteScroll.resetScroll(self.projectContext.firstPageVariations > 1, self.projectContext.lastPageVariations < self.projectContext.totalPagesCountVariations);
+                self.gridApi.infiniteScroll.resetScroll(
+                    self.projectContext.firstPageVariations > 1,
+                    (self.projectContext.totalPagesCountVariations === undefined && self.projectContext.hasMoreVariations)
+                    || self.projectContext.lastPageVariations < self.projectContext.totalPagesCountVariations);
             });
         });
     }
@@ -337,7 +349,10 @@ export default class ngbVariantsTableController extends baseController {
 
             const self = this;
             this.$timeout(function () {
-                self.gridApi.infiniteScroll.dataLoaded(self.projectContext.firstPageVariations > 1, self.projectContext.lastPageVariations < self.projectContext.totalPagesCountVariations);
+                self.gridApi.infiniteScroll.dataLoaded(
+                    self.projectContext.firstPageVariations > 1,
+                    (self.projectContext.totalPagesCountVariations === undefined && self.projectContext.hasMoreVariations)
+                    || self.projectContext.lastPageVariations < self.projectContext.totalPagesCountVariations);
             });
         }
     }

--- a/client/client/app/components/ngbVariantsTablePanel/ngbVariantsTablePaginate/ngbVariantsTablePaginate.controller.js
+++ b/client/client/app/components/ngbVariantsTablePanel/ngbVariantsTablePaginate/ngbVariantsTablePaginate.controller.js
@@ -43,7 +43,7 @@ export default class ngbVariantsTablePaginateController extends baseController {
 
     setPage(page, loadData)
     {
-        if (page < 1 || page > this.totalPages) {
+        if (this.totalPages === undefined || page < 1 || page > this.totalPages) {
             return;
         }
 
@@ -57,6 +57,9 @@ export default class ngbVariantsTablePaginateController extends baseController {
     getPages() {
         const totalPages = this.totalPages;
         const currentPage = this.currentPage;
+        if (totalPages === undefined || currentPage === undefined) {
+            return [];
+        }
 
         let minimumPage = Math.max(1, currentPage - 3);
         let maximumPage = Math.min(totalPages, currentPage + 3);

--- a/client/client/app/shared/components/ngbGoldenLayout/ngbViewActions/ngbViewActions.constant.js
+++ b/client/client/app/shared/components/ngbGoldenLayout/ngbViewActions/ngbViewActions.constant.js
@@ -9,6 +9,13 @@ const variantsTablePaginationAction = {
     },
     isDefault: false
 };
+const variantsLoadingIndicatorAction = {
+    name: 'variantsLoadingIndicator',
+    liStyle: {
+        width: 'auto'
+    },
+    isDefault: false
+};
 const closeAllTracksAction = {
     name: 'closeAllTracks',
     isDefault: false
@@ -58,15 +65,16 @@ const genomeAnnotationsAction = {
 export default {
     actions: {
         closeAllTracks: closeAllTracksAction,
-        variantsTableColumn: variantsTableColumnAction,
-        variantsTablePagination: variantsTablePaginationAction,
-        variantsResetFilter: variantsResetFilterActions,
         fitAllTracks: fitAllTracksAction,
+        genomeAnnotations: genomeAnnotationsAction,
         organizeTracks: organizeTracksAction,
-        genomeAnnotations: genomeAnnotationsAction
+        variantsLoadingIndicator: variantsLoadingIndicatorAction,
+        variantsResetFilter: variantsResetFilterActions,
+        variantsTableColumn: variantsTableColumnAction,
+        variantsTablePagination: variantsTablePaginationAction
     },
     viewActions: {
         ngbBrowser: [genomeAnnotationsAction, fitAllTracksAction, organizeTracksAction, closeAllTracksAction],
-        ngbVariantsTablePanel: [variantsTablePaginationAction, variantsResetFilterActions, variantsTableColumnAction]
+        ngbVariantsTablePanel: [variantsTablePaginationAction, variantsLoadingIndicatorAction, variantsResetFilterActions, variantsTableColumnAction]
     }
 };

--- a/client/client/app/shared/components/ngbGoldenLayout/ngbViewActions/ngbViewActions.tpl.html
+++ b/client/client/app/shared/components/ngbGoldenLayout/ngbViewActions/ngbViewActions.tpl.html
@@ -1,6 +1,7 @@
 <li ng-repeat="action in viewActions[viewName] track by $index" ng-style="action.liStyle" ng-if="action.isVisible === undefined || action.isVisible(projectContext)">
     <ngb-variants-table-column ng-if="action === actions.variantsTableColumn"></ngb-variants-table-column>
     <ngb-variants-table-paginate ng-if="action === actions.variantsTablePagination"></ngb-variants-table-paginate>
+    <ngb-variants-loading-indicator ng-if="action === actions.variantsLoadingIndicator"></ngb-variants-loading-indicator>
     <ngb-close-all-tracks ng-if="action === actions.closeAllTracks && tracksAreSelected()"></ngb-close-all-tracks>
     <ngb-genome-annotations ng-if="action === actions.genomeAnnotations && tracksAreSelected() && (action.isVisible === undefined || action.isVisible(projectContext))"></ngb-genome-annotations>
     <ngb-view-action ng-if="action.isDefault && (action.isVisible === undefined || action.isVisible(projectContext))" event="action.event" label="action.label" icon="action.icon"></ngb-view-action>

--- a/client/client/app/shared/projectContext/index.js
+++ b/client/client/app/shared/projectContext/index.js
@@ -283,6 +283,12 @@ export default class projectContext {
         return this._variantsGroupByQualityError;
     }
 
+    get variantsGroupError() {
+        return this.variantsGroupByChromosomesError ||
+            this.variantsGroupByQualityError ||
+            this.variantsGroupByTypeError;
+    }
+
     get variantsPageLoading () {
         return this._variantsPageLoading;
     }

--- a/client/client/app/shared/projectContext/index.js
+++ b/client/client/app/shared/projectContext/index.js
@@ -104,6 +104,7 @@ export default class projectContext {
     _firstPageVariations = FIRST_PAGE;
     _lastPageVariations = FIRST_PAGE;
     _currentPageVariations = FIRST_PAGE;
+    _hasMoreVariations = true;
     _orderByVariations = null;
     _totalPagesCountVariations = null;
 
@@ -159,6 +160,10 @@ export default class projectContext {
 
     get currentPageVariations() {
         return this._currentPageVariations;
+    }
+
+    get hasMoreVariations() {
+        return this._hasMoreVariations;
     }
 
     get hotkeys() {
@@ -1387,6 +1392,9 @@ export default class projectContext {
             this._infoFields = [];
             this._totalPagesCountVariations = 0;
             this._currentPageVariations = FIRST_PAGE;
+            this._lastPageVariations = FIRST_PAGE;
+            this._firstPageVariations = FIRST_PAGE;
+            this._hasMoreVariations = true;
             this._variantsDataByChromosomes = [];
             this._variantsDataByQuality = [];
             this._variantsDataByType = [];
@@ -1583,6 +1591,10 @@ export default class projectContext {
             }
             await this._initializeVariants(onInit);
             if (asDefault) {
+                this.currentPageVariations = FIRST_PAGE;
+                this.firstPageVariations = FIRST_PAGE;
+                this.lastPageVariations = FIRST_PAGE;
+                this._hasMoreVariations = true;
                 this._vcfFilter = {
                     additionalFilters: {},
                     chromosomeIds: [],
@@ -1778,7 +1790,7 @@ export default class projectContext {
         };
         let data = await this.projectDataService.getVcfVariationLoad(filter);
 
-        if (!data.entries && data.totalPagesCount < page) {
+        if (!data.entries && (data.totalPagesCount !== undefined && data.totalPagesCount < page)) {
             filter.page = data.totalPagesCount;
             this.currentPageVariations = data.totalPagesCount || FIRST_PAGE;
             this.firstPageVariations = data.totalPagesCount || FIRST_PAGE;
@@ -1786,6 +1798,8 @@ export default class projectContext {
             if (data.totalPagesCount > 0) {
                 data = await this.projectDataService.getVcfVariationLoad(filter);
             }
+        } else if (!data.entries && data.totalPagesCount === undefined) {
+            this._hasMoreVariations = false;
         }
 
         const infoFieldsObj = {};
@@ -1797,7 +1811,7 @@ export default class projectContext {
             vcfTrackToProjectId[`${vcfTrack.id}`] = vcfTrack.projectId;
         }
 
-        this.totalPagesCountVariations = data.totalPagesCount || 0;
+        this.totalPagesCountVariations = data.totalPagesCount;
         const entries = data.entries ? data.entries : [];
 
         return entries.map(item =>

--- a/client/client/dataServices/project/project-data-service.js
+++ b/client/client/dataServices/project/project-data-service.js
@@ -95,7 +95,7 @@ export class ProjectDataService extends DataService {
 
     getVcfGroupData(filter, groupBy) {
         return new Promise((resolve, reject) => {
-            this.post(`filter/group?groupBy=${groupBy}`, filter).catch(()=>resolve([])).then((data) => {
+            this.post(`filter/group?groupBy=${groupBy}`, filter).catch((response)=>reject(response)).then((data) => {
                 if (data) {
                     resolve(data);
                 } else {

--- a/client/client/dataServices/project/project-data-service.js
+++ b/client/client/dataServices/project/project-data-service.js
@@ -82,7 +82,7 @@ export class ProjectDataService extends DataService {
 
     getVcfVariationLoad(filter) {
         return new Promise((resolve, reject) => {
-            this.post('filter', filter).catch(()=>resolve([])).then((data) => {
+            this.post('filter', filter).catch(()=>resolve({})).then((data) => {
                 if (data) {
                     resolve(data);
                 } else {

--- a/server/catgenome/profiles/desktop/catgenome.properties
+++ b/server/catgenome/profiles/desktop/catgenome.properties
@@ -15,6 +15,10 @@ file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
 # (1000000 entries take about 3Gb in the heap)
 files.vcf.max.entries.in.memory=1000000
 
+# max size of lucene index in bytes to perform group variations and total page count operations
+# default value is 4Gb
+lucene.index.max.size.grouping=
+
 # configuration properties to establish connection with database engine
 database.max.pool.size=10
 database.username=catgenome
@@ -23,3 +27,4 @@ database.initial.pool.size=5
 database.driver.class=org.h2.Driver
 database.jdbc.url=jdbc:h2:file:./H2/catgenome
 #vcf.filter.whitelist=AA,DP,HM2,HM3
+

--- a/server/catgenome/profiles/dev/catgenome.properties
+++ b/server/catgenome/profiles/dev/catgenome.properties
@@ -20,6 +20,11 @@ file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
 # (1000000 entries take about 3Gb in the heap)
 files.vcf.max.entries.in.memory=1000000
 
+# max size of lucene index in bytes to perform group variations and total page count operations
+# default value is 4Gb
+lucene.index.max.size.grouping=
+
+
 # configuration properties to establish connection with database engine
 database.max.pool.size=10
 database.username=catgenome

--- a/server/catgenome/profiles/release/catgenome.properties
+++ b/server/catgenome/profiles/release/catgenome.properties
@@ -15,6 +15,11 @@ file.download.whitelist.host=
 # (1000000 entries take about 3Gb in the heap)
 files.vcf.max.entries.in.memory=1000000
 
+# max size of lucene index in bytes to perform group variations and total page count operations
+# default value is 4Gb
+lucene.index.max.size.grouping=
+
+
 # configuration properties to establish connection with database engine
 database.max.pool.size=25
 database.username=

--- a/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
@@ -118,6 +118,7 @@ public final class MessagesConstants {
     public static final String ERROR_FEATURE_INDEX_NOT_FOUND = "error.feature.index.not.found";
     public static final String INFO_FEATURE_INDEX_LOADING = "info.feature.index.loading";
     public static final String INFO_FEATURE_INDEX_WRITING = "info.feature.index.writing";
+    public static final String ERROR_FEATURE_INEDX_TOO_LARGE = "error.feature.index.too.large";
     public static final String INFO_FEATURE_INDEX_DONE = "info.feature.index.done";
     public static final String ERROR_FEATURE_INDEX_WRITING = "error.feature.index.writing";
     public static final String INFO_FEATURE_INDEX_WRITING_FOR_PROJECT = "info.feature.index.writing.for.project";

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/index/FeatureIndexDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/index/FeatureIndexDao.java
@@ -91,6 +91,7 @@ import org.apache.lucene.util.BytesRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
@@ -143,6 +144,9 @@ public class FeatureIndexDao {
 
     @Autowired
     private VcfManager vcfManager;
+
+    @Value("#{catgenome['lucene.index.max.size.grouping'] ?: 4L * 1024 * 1024 * 1024}")
+    private long luceneIndexMaxSizeForGrouping;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FeatureIndexDao.class);
     private static Pattern viewFieldPattern = Pattern.compile("_.*_v$");
@@ -204,12 +208,12 @@ public class FeatureIndexDao {
      * @throws IOException
      */
     public void writeLuceneIndexForProject(final Long featureFileId, final long projectId,
-                                           final List<? extends FeatureIndexEntry> entries) throws IOException {
+            final List<? extends FeatureIndexEntry> entries) throws IOException {
         try (
-            StandardAnalyzer analyzer = new StandardAnalyzer();
-            Directory index = fileManager.createIndexForProject(projectId);
-            IndexWriter writer = new IndexWriter(index, new IndexWriterConfig(analyzer).setOpenMode(
-                                                                    IndexWriterConfig.OpenMode.CREATE_OR_APPEND))
+                StandardAnalyzer analyzer = new StandardAnalyzer();
+                Directory index = fileManager.createIndexForProject(projectId);
+                IndexWriter writer = new IndexWriter(index, new IndexWriterConfig(analyzer).setOpenMode(
+                        IndexWriterConfig.OpenMode.CREATE_OR_APPEND))
         ) {
             FacetsConfig facetsConfig = new FacetsConfig();
             facetsConfig.setIndexFieldName(FeatureIndexFields.CHR_ID.getFieldName(),
@@ -237,18 +241,18 @@ public class FeatureIndexDao {
      * @throws IOException
      */
     public void writeLuceneIndexForFile(final FeatureFile featureFile,
-                                        final List<? extends FeatureIndexEntry> entries) throws IOException {
+            final List<? extends FeatureIndexEntry> entries) throws IOException {
         try (
-            StandardAnalyzer analyzer = new StandardAnalyzer();
-            Directory index = fileManager.createIndexForFile(featureFile);
-            IndexWriter writer = new IndexWriter(index, new IndexWriterConfig(analyzer).setOpenMode(
-                IndexWriterConfig.OpenMode.CREATE_OR_APPEND))
+                StandardAnalyzer analyzer = new StandardAnalyzer();
+                Directory index = fileManager.createIndexForFile(featureFile);
+                IndexWriter writer = new IndexWriter(index, new IndexWriterConfig(analyzer).setOpenMode(
+                        IndexWriterConfig.OpenMode.CREATE_OR_APPEND))
         ) {
             FacetsConfig facetsConfig = new FacetsConfig();
             facetsConfig.setIndexFieldName(FeatureIndexFields.CHR_ID.getFieldName(),
-                                           FeatureIndexFields.FACET_CHR_ID.getFieldName());
+                    FeatureIndexFields.FACET_CHR_ID.getFieldName());
             facetsConfig.setIndexFieldName(FeatureIndexFields.F_UID.getFieldName(),
-                                           FeatureIndexFields.FACET_UID.getFieldName());
+                    FeatureIndexFields.FACET_UID.getFieldName());
 
             for (FeatureIndexEntry entry : entries) {
                 Document document = new Document();
@@ -263,6 +267,18 @@ public class FeatureIndexDao {
         }
     }
 
+    private long getTotalIndexSize(Directory index) throws IOException {
+        long totalFileSize = 0L;
+        String[] files = index.listAll();
+        if (files == null) {
+            return 0;
+        }
+        for (int i = 0; i < files.length; i++) {
+            totalFileSize += index.fileLength(files[i]);
+        }
+        return totalFileSize;
+    }
+
     /**
      * Searches genes by it's ID in project's gene files. Minimum featureId prefix length == 2
      *
@@ -272,8 +288,8 @@ public class FeatureIndexDao {
      * @throws IOException
      */
     public IndexSearchResult<FeatureIndexEntry> searchFeatures(String featureId,
-                                                               List<? extends FeatureFile> featureFiles,
-                                                               Integer maxResultsCount)
+            List<? extends FeatureFile> featureFiles,
+            Integer maxResultsCount)
             throws IOException {
         if (featureId == null || featureId.length() < 2) {
             return new IndexSearchResult<>(Collections.emptyList(), false, 0);
@@ -382,7 +398,7 @@ public class FeatureIndexDao {
      */
     @Deprecated
     public IndexSearchResult searchLuceneIndexForProject(final long projectId, String query,
-                                                     List<String> vcfInfoFields) throws FeatureIndexException {
+            List<String> vcfInfoFields) throws FeatureIndexException {
         try (Analyzer analyzer = new StandardAnalyzer()) {
             QueryParser queryParser = new QueryParser(FeatureIndexFields.FEATURE_ID.getFieldName(), analyzer);
             return searchLuceneIndexForProject(projectId, queryParser.parse(query), vcfInfoFields);
@@ -403,7 +419,7 @@ public class FeatureIndexDao {
      */
     @Deprecated
     public IndexSearchResult searchLuceneIndexForProject(final long projectId, Query query,
-                                                                     List<String> vcfInfoFields) throws IOException {
+            List<String> vcfInfoFields) throws IOException {
         return searchLuceneIndexForProject(projectId, query, vcfInfoFields, null, null);
     }
 
@@ -418,14 +434,14 @@ public class FeatureIndexDao {
      */
     @Deprecated
     private IndexSearchResult searchLuceneIndexForProject(final long projectId, Query query,
-                                             List<String> vcfInfoFields, Integer maxResultsCount, Sort sort) throws
+            List<String> vcfInfoFields, Integer maxResultsCount, Sort sort) throws
             IOException {
         Map<Integer, FeatureIndexEntry> entryMap = new LinkedHashMap<>();
 
         int totalHits = 0;
         try (
-            Directory index = fileManager.getIndexForProject(projectId);
-            IndexReader reader = DirectoryReader.open(index)
+                Directory index = fileManager.getIndexForProject(projectId);
+                IndexReader reader = DirectoryReader.open(index)
         ) {
             if (reader.numDocs() == 0) {
                 return new IndexSearchResult(Collections.emptyList(), false, 0);
@@ -452,7 +468,7 @@ public class FeatureIndexDao {
         }
 
         return new IndexSearchResult(new ArrayList<>(entryMap.values()), maxResultsCount != null &&
-                                                                         totalHits > maxResultsCount, totalHits);
+                totalHits > maxResultsCount, totalHits);
     }
 
     /**
@@ -465,13 +481,13 @@ public class FeatureIndexDao {
      * @throws FeatureIndexException if something is wrong in the filesystem or query syntax is wrong
      */
     public IndexSearchResult searchFileIndexes(List<? extends FeatureFile> files, String query,
-                                                         List<String> vcfInfoFields) throws FeatureIndexException {
+            List<String> vcfInfoFields) throws FeatureIndexException {
         try (Analyzer analyzer = new StandardAnalyzer()) {
             QueryParser queryParser = new QueryParser(FeatureIndexFields.FEATURE_ID.getFieldName(), analyzer);
             return searchFileIndexes(files, queryParser.parse(query), vcfInfoFields, null, null);
         } catch (IOException | ParseException e) {
             throw new FeatureIndexException("Failed to perform index search for files " +
-                                        files.stream().map(BaseEntity::getName).collect(Collectors.joining(", ")), e);
+                    files.stream().map(BaseEntity::getName).collect(Collectors.joining(", ")), e);
         }
     }
 
@@ -487,9 +503,9 @@ public class FeatureIndexDao {
      * @throws IOException if something is wrong in the filesystem
      */
     public <T extends FeatureIndexEntry> IndexSearchResult<T> searchFileIndexes(List<? extends FeatureFile> files,
-                                                                                Query query, List<String> vcfInfoFields,
-                                                                                Integer maxResultsCount, Sort sort)
-        throws IOException {
+            Query query, List<String> vcfInfoFields,
+            Integer maxResultsCount, Sort sort)
+            throws IOException {
         if (CollectionUtils.isEmpty(files)) {
             return new IndexSearchResult<>(Collections.emptyList(), false, 0);
         }
@@ -514,8 +530,8 @@ public class FeatureIndexDao {
             setBookmarks(foundBookmarkEntries);
 
             return new IndexSearchResult<>(new ArrayList<T>((Collection<? extends T>) entryMap.values()),
-                                           maxResultsCount != null &&
-                                           totalHits > maxResultsCount, totalHits);
+                    maxResultsCount != null &&
+                            totalHits > maxResultsCount, totalHits);
         } finally {
             for (SimpleFSDirectory index : indexes) {
                 IOUtils.closeQuietly(index);
@@ -537,9 +553,9 @@ public class FeatureIndexDao {
      * @throws IOException if something is wrong in the filesystem
      */
     public <T extends FeatureIndexEntry> IndexSearchResult<T> searchFileIndexesPaging(List<? extends FeatureFile> files,
-                                                                  Query query, List<String> vcfInfoFields, Integer page,
-                                                                  Integer pageSize, List<VcfFilterForm.OrderBy> orderBy)
-        throws IOException {
+            Query query, List<String> vcfInfoFields, Integer page,
+            Integer pageSize, List<VcfFilterForm.OrderBy> orderBy)
+            throws IOException {
 
         if (CollectionUtils.isEmpty(files)) {
             return new IndexSearchResult<>(Collections.emptyList(), false, 0);
@@ -558,16 +574,14 @@ public class FeatureIndexDao {
             IndexSearcher searcher = new IndexSearcher(reader);
             GroupingSearch groupingSearch = new GroupingSearch(FeatureIndexFields.UID.fieldName);
             setSorting(orderBy, groupingSearch, files);
-
             TopGroups<String> topGroups = groupingSearch.search(searcher, query,
-                                                                page == null ? 0 : (page - 1) * pageSize,
-                                                                page == null ? reader.numDocs() : pageSize);
+                    page == null ? 0 : (page - 1) * pageSize,
+                    page == null ? reader.numDocs() : pageSize);
 
             final ScoreDoc[] hits = new ScoreDoc[topGroups.groups.length];
             for (int i = 0; i < topGroups.groups.length; i++) {
                 hits[i] = topGroups.groups[i].scoreDocs[0];
             }
-
             entries = new ArrayList<>(hits.length);
             for (ScoreDoc hit : hits) {
                 entries.add(createIndexEntry(hit, new HashMap<>(), searcher, vcfInfoFields));
@@ -587,6 +601,10 @@ public class FeatureIndexDao {
         }
 
         SimpleFSDirectory[] indexes = fileManager.getIndexesForFiles(files);
+        long totalIndexSize = getTotalIndexSize(indexes);
+        if (totalIndexSize > luceneIndexMaxSizeForGrouping) {
+            return 0;
+        }
 
         try (MultiReader reader = openMultiReader(indexes)) {
             if (reader.numDocs() == 0) {
@@ -598,7 +616,7 @@ public class FeatureIndexDao {
             searcher.search(query, facetsCollector);
 
             Facets facets = new SortedSetDocValuesFacetCounts(new DefaultSortedSetDocValuesReaderState(reader,
-                                                           FeatureIndexFields.FACET_UID.fieldName), facetsCollector);
+                    FeatureIndexFields.FACET_UID.fieldName), facetsCollector);
             FacetResult res = facets.getTopChildren(reader.numDocs(), FeatureIndexFields.F_UID.getFieldName());
             if (res == null) {
                 return 0;
@@ -613,15 +631,15 @@ public class FeatureIndexDao {
     }
 
     private void setSorting(List<VcfFilterForm.OrderBy> orderBy, GroupingSearch groupingSearch,
-                            List<? extends FeatureFile> files)
-        throws IOException {
+            List<? extends FeatureFile> files)
+            throws IOException {
         if (CollectionUtils.isNotEmpty(orderBy)) {
             ArrayList<SortField> sortFields = new ArrayList<>();
             for (VcfFilterForm.OrderBy o : orderBy) {
                 IndexSortField sortField = IndexSortField.getByName(o.getField());
                 if (sortField == null) {
                     VcfFilterInfo info = vcfManager.getFiltersInfo(
-                        files.stream().map(BaseEntity::getId).collect(Collectors.toList()));
+                            files.stream().map(BaseEntity::getId).collect(Collectors.toList()));
 
                     InfoItem infoItem = info.getInfoItemMap().get(o.getField());
                     Assert.notNull(infoItem, "Unknown sort field: " + o.getField());
@@ -686,6 +704,10 @@ public class FeatureIndexDao {
         }
 
         SimpleFSDirectory[] indexes = fileManager.getIndexesForFiles(files);
+        long totalIndexSize = getTotalIndexSize(indexes);
+        if (totalIndexSize > luceneIndexMaxSizeForGrouping) {
+            return Collections.emptyList();
+        }
 
         try (MultiReader reader = openMultiReader(indexes)) {
             if (reader.numDocs() == 0) {
@@ -694,13 +716,13 @@ public class FeatureIndexDao {
 
             IndexSearcher searcher = new IndexSearcher(reader);
             AbstractGroupFacetCollector groupedFacetCollector =
-                TermGroupFacetCollector.createTermGroupFacetCollector(FeatureIndexFields.UID.fieldName,
-                                                      getGroupByField(files, groupBy), false, null, GROUP_INITIAL_SIZE);
+                    TermGroupFacetCollector.createTermGroupFacetCollector(FeatureIndexFields.UID.fieldName,
+                            getGroupByField(files, groupBy), false, null, GROUP_INITIAL_SIZE);
             searcher.search(query, groupedFacetCollector); // Computing the grouped facet counts
             TermGroupFacetCollector.GroupedFacetResult groupedResult = groupedFacetCollector.mergeSegmentResults(
-                reader.numDocs(), 1, false);
+                    reader.numDocs(), 1, false);
             List<AbstractGroupFacetCollector.FacetEntry> facetEntries = groupedResult.getFacetEntries(0,
-                                                                                                      reader.numDocs());
+                    reader.numDocs());
             for (AbstractGroupFacetCollector.FacetEntry facetEntry : facetEntries) {
                 res.add(new Group(facetEntry.getValue().utf8ToString(), facetEntry.getCount()));
             }
@@ -713,11 +735,19 @@ public class FeatureIndexDao {
         return res;
     }
 
+    private long getTotalIndexSize(SimpleFSDirectory[] indexes) throws IOException {
+        long totalIndexSize = 0;
+        for (SimpleFSDirectory index : indexes) {
+            totalIndexSize += getTotalIndexSize(index);
+        }
+        return totalIndexSize;
+    }
+
     private String getGroupByField(List<VcfFile> files, String groupBy) throws IOException {
         IndexSortField sortField = IndexSortField.getByName(groupBy);
         if (sortField == null) {
             VcfFilterInfo info = vcfManager.getFiltersInfo(
-                files.stream().map(BaseEntity::getId).collect(Collectors.toList()));
+                    files.stream().map(BaseEntity::getId).collect(Collectors.toList()));
 
             InfoItem infoItem = info.getInfoItemMap().get(groupBy);
             Assert.notNull(infoItem, "Unknown sort field: " + groupBy);
@@ -746,7 +776,7 @@ public class FeatureIndexDao {
     }
 
     private TopDocs performSearch(IndexSearcher searcher, Query query, IndexReader reader, Integer maxResultsCount,
-                                  Sort sort) throws IOException {
+            Sort sort) throws IOException {
         final TopDocs docs;
         int resultsCount = maxResultsCount == null ? reader.numDocs() : maxResultsCount;
         if (sort == null) {
@@ -778,8 +808,8 @@ public class FeatureIndexDao {
         List<Long> chromosomeIds = new ArrayList<>();
 
         try (
-            Directory index = fileManager.getIndexForProject(projectId);
-            IndexReader reader = DirectoryReader.open(index)
+                Directory index = fileManager.getIndexForProject(projectId);
+                IndexReader reader = DirectoryReader.open(index)
         ) {
             if (reader.numDocs() == 0) {
                 return Collections.emptyList();
@@ -814,13 +844,13 @@ public class FeatureIndexDao {
      * @throws IOException
      */
     public List<Long> getChromosomeIdsWhereVariationsPresentFacet(List<? extends FeatureFile> files, String query)
-        throws FeatureIndexException {
+            throws FeatureIndexException {
         try (Analyzer analyzer = new StandardAnalyzer()) {
             QueryParser queryParser = new QueryParser(FeatureIndexFields.FEATURE_ID.getFieldName(), analyzer);
             return getChromosomeIdsWhereVariationsPresentFacet(files, queryParser.parse(query));
         } catch (IOException | ParseException e) {
             throw new FeatureIndexException("Failed to perform facet index search for files " + files.stream()
-                .map(BaseEntity::getName).collect(Collectors.joining(", ")), e);
+                    .map(BaseEntity::getName).collect(Collectors.joining(", ")), e);
         }
     }
 
@@ -834,7 +864,7 @@ public class FeatureIndexDao {
      * @throws IOException
      */
     public List<Long> getChromosomeIdsWhereVariationsPresentFacet(List<? extends FeatureFile> files, Query query)
-        throws IOException {
+            throws IOException {
         if (CollectionUtils.isEmpty(files)) {
             return Collections.emptyList();
         }
@@ -853,7 +883,7 @@ public class FeatureIndexDao {
             searcher.search(query, facetsCollector);
 
             Facets facets = new SortedSetDocValuesFacetCounts(new DefaultSortedSetDocValuesReaderState(reader,
-                                                   FeatureIndexFields.FACET_CHR_ID.getFieldName()), facetsCollector);
+                    FeatureIndexFields.FACET_CHR_ID.getFieldName()), facetsCollector);
             FacetResult res = facets.getTopChildren(FACET_LIMIT, FeatureIndexFields.CHR_ID.getFieldName());
             if (res == null) {
                 return Collections.emptyList();
@@ -895,7 +925,7 @@ public class FeatureIndexDao {
         PrefixQuery geneIdPrefixQuery = new PrefixQuery(new Term(FeatureIndexFields.GENE_ID.getFieldName(),
                 gene.toLowerCase()));
         PrefixQuery geneNamePrefixQuery = new PrefixQuery(new Term(FeatureIndexFields.GENE_NAME.getFieldName(),
-                                                                   gene.toLowerCase()));
+                gene.toLowerCase()));
         BooleanQuery.Builder geneIdOrNameQuery = new BooleanQuery.Builder();
         geneIdOrNameQuery.add(geneIdPrefixQuery, BooleanClause.Occur.SHOULD);
         geneIdOrNameQuery.add(geneNamePrefixQuery, BooleanClause.Occur.SHOULD);
@@ -912,8 +942,8 @@ public class FeatureIndexDao {
         Set<String> geneIds;
 
         try (
-            Directory index = fileManager.getIndexForProject(projectId);
-            IndexReader reader = DirectoryReader.open(index)
+                Directory index = fileManager.getIndexForProject(projectId);
+                IndexReader reader = DirectoryReader.open(index)
         ) {
             if (reader.numDocs() == 0) {
                 return Collections.emptySet();
@@ -940,9 +970,9 @@ public class FeatureIndexDao {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
 
         PrefixQuery geneIdPrefixQuery = new PrefixQuery(new Term(FeatureIndexFields.GENE_ID.getFieldName(),
-                                                                 gene.toLowerCase()));
+                gene.toLowerCase()));
         PrefixQuery geneNamePrefixQuery = new PrefixQuery(new Term(FeatureIndexFields.GENE_NAME.getFieldName(),
-                                                                   gene.toLowerCase()));
+                gene.toLowerCase()));
         BooleanQuery.Builder geneIdOrNameQuery = new BooleanQuery.Builder();
         geneIdOrNameQuery.add(geneIdPrefixQuery, BooleanClause.Occur.SHOULD);
         geneIdOrNameQuery.add(geneNamePrefixQuery, BooleanClause.Occur.SHOULD);
@@ -985,10 +1015,10 @@ public class FeatureIndexDao {
         }
 
         try (
-            StandardAnalyzer analyzer = new StandardAnalyzer();
-            Directory index = fileManager.getIndexForProject(projectId);
-            IndexWriter writer = new IndexWriter(index, new IndexWriterConfig(analyzer).setOpenMode(
-                                                                        IndexWriterConfig.OpenMode.CREATE_OR_APPEND))
+                StandardAnalyzer analyzer = new StandardAnalyzer();
+                Directory index = fileManager.getIndexForProject(projectId);
+                IndexWriter writer = new IndexWriter(index, new IndexWriterConfig(analyzer).setOpenMode(
+                        IndexWriterConfig.OpenMode.CREATE_OR_APPEND))
         ) {
             if (fileManager.indexForProjectExists(projectId)) {
                 for (Pair<FeatureType, Long> id : fileIds) {
@@ -1003,18 +1033,18 @@ public class FeatureIndexDao {
     private void deleteDocumentByTypeAndId(FeatureType type, Long id, IndexWriter writer) throws IOException {
         BooleanQuery.Builder deleteQueryBuilder = new BooleanQuery.Builder();
         TermQuery idQuery = new TermQuery(new Term(FeatureIndexFields.FILE_ID.getFieldName(),
-                                                   id.toString()));
+                id.toString()));
         deleteQueryBuilder.add(idQuery, BooleanClause.Occur.MUST);
 
         if (type != FeatureType.GENE) {
             TermQuery typeQuery = new TermQuery(new Term(FeatureIndexFields.FEATURE_TYPE.getFieldName(),
-                                                         type.getFileValue()));
+                    type.getFileValue()));
             deleteQueryBuilder.add(typeQuery, BooleanClause.Occur.MUST);
         } else {
             deleteQueryBuilder.add(new TermQuery(new Term(FeatureIndexFields.FEATURE_TYPE.getFieldName(),
-                                                  FeatureType.BOOKMARK.getFileValue())), BooleanClause.Occur.MUST_NOT);
+                    FeatureType.BOOKMARK.getFileValue())), BooleanClause.Occur.MUST_NOT);
             deleteQueryBuilder.add(new TermQuery(new Term(FeatureIndexFields.FEATURE_TYPE.getFieldName(),
-                                                FeatureType.VARIATION.getFileValue())), BooleanClause.Occur.MUST_NOT);
+                    FeatureType.VARIATION.getFileValue())), BooleanClause.Occur.MUST_NOT);
         }
 
         writer.deleteDocuments(deleteQueryBuilder.build());
@@ -1039,7 +1069,7 @@ public class FeatureIndexDao {
         vcfIndexEntry.setInfo(new HashMap<>());
 
         String isExonStr = d.get(FeatureIndexFields.IS_EXON.getFieldName()); //TODO: remove, in future only binary
-                                                                                // value will remain
+        // value will remain
         if (isExonStr == null) {
             bytes = d.getBinaryValue(FeatureIndexFields.IS_EXON.getFieldName());
             if (bytes != null) {
@@ -1085,72 +1115,72 @@ public class FeatureIndexDao {
         fieldType.setDocValuesType(DocValuesType.SORTED);
         fieldType.freeze();
         Field field = new Field(FeatureIndexFields.CHROMOSOME_ID.getFieldName(), entry.getChromosome() != null ?
-                                 new BytesRef(entry.getChromosome().getId().toString()) : new BytesRef(""), fieldType);
+                new BytesRef(entry.getChromosome().getId().toString()) : new BytesRef(""), fieldType);
         document.add(field);
         document.add(new SortedStringField(FeatureIndexFields.CHROMOSOME_NAME.getFieldName(),
-                                     entry.getChromosome().getName(), true));
+                entry.getChromosome().getName(), true));
 
         document.add(new SortedIntPoint(FeatureIndexFields.START_INDEX.getFieldName(), entry.getStartIndex()));
         document.add(new StoredField(FeatureIndexFields.START_INDEX.getFieldName(), entry.getStartIndex()));
         document.add(new SortedDocValuesField(FeatureIndexFields.START_INDEX.getGroupName(),
-                                              new BytesRef(entry.getStartIndex().toString())));
+                new BytesRef(entry.getStartIndex().toString())));
 
         document.add(new SortedIntPoint(FeatureIndexFields.END_INDEX.getFieldName(), entry.getEndIndex()));
         document.add(new StoredField(FeatureIndexFields.END_INDEX.getFieldName(), entry.getEndIndex()));
         document.add(new SortedDocValuesField(FeatureIndexFields.END_INDEX.getGroupName(),
-                                              new BytesRef(entry.getStartIndex().toString())));
+                new BytesRef(entry.getStartIndex().toString())));
 
         document.add(new StringField(FeatureIndexFields.FEATURE_TYPE.getFieldName(),
-                     entry.getFeatureType() != null ? entry.getFeatureType().getFileValue() : "", Field.Store.YES));
+                entry.getFeatureType() != null ? entry.getFeatureType().getFileValue() : "", Field.Store.YES));
         document.add(new StringField(FeatureIndexFields.FILE_ID.getFieldName(), featureFileId.toString(),
-                                     Field.Store.YES));
+                Field.Store.YES));
 
         document.add(new StringField(FeatureIndexFields.FEATURE_NAME.getFieldName(),
-                         entry.getFeatureName() != null ? entry.getFeatureName().toLowerCase() : "", Field.Store.YES));
+                entry.getFeatureName() != null ? entry.getFeatureName().toLowerCase() : "", Field.Store.YES));
         document.add(new SortedDocValuesField(FeatureIndexFields.FEATURE_NAME.getFieldName(),
-                                         new BytesRef(entry.getFeatureName() != null ? entry.getFeatureName() : "")));
+                new BytesRef(entry.getFeatureName() != null ? entry.getFeatureName() : "")));
 
         document.add(new SortedSetDocValuesFacetField(FeatureIndexFields.CHR_ID.getFieldName(),
-                                                      entry.getChromosome().getId().toString()));
+                entry.getChromosome().getId().toString()));
 
         document.add(new SortedStringField(FeatureIndexFields.UID.getFieldName(), entry.getUuid().toString()));
         document.add(new SortedSetDocValuesFacetField(FeatureIndexFields.F_UID.getFieldName(),
-                                                      entry.getUuid().toString()));
+                entry.getUuid().toString()));
     }
 
     private void  addVcfDocumentFields(Document document, FeatureIndexEntry entry) {
         VcfIndexEntry vcfIndexEntry = (VcfIndexEntry) entry;
         document.add(new SortedStringField(FeatureIndexFields.VARIATION_TYPE.getFieldName(),
-                                           vcfIndexEntry.getVariationType().name()));
+                vcfIndexEntry.getVariationType().name()));
 
         if (StringUtils.isNotBlank(vcfIndexEntry.getFailedFilter())) {
             document.add(new SortedStringField(FeatureIndexFields.FAILED_FILTER.getFieldName(),
-                                               vcfIndexEntry.getFailedFilter()));
+                    vcfIndexEntry.getFailedFilter()));
         }
 
         document.add(new SortedFloatPoint(FeatureIndexFields.QUALITY.getFieldName(), vcfIndexEntry.getQuality()
-            .floatValue()));
+                .floatValue()));
         document.add(new StoredField(FeatureIndexFields.QUALITY.getFieldName(), vcfIndexEntry.getQuality()
-            .floatValue()));
+                .floatValue()));
         document.add(new SortedDocValuesField(FeatureIndexFields.QUALITY.getGroupName(),
-                                              new BytesRef(vcfIndexEntry.getQuality().toString())));
+                new BytesRef(vcfIndexEntry.getQuality().toString())));
 
         if (StringUtils.isNotBlank(vcfIndexEntry.getGene())) {
             document.add(new StringField(FeatureIndexFields.GENE_ID.getFieldName(),
-                                         vcfIndexEntry.getGene().toLowerCase(), Field.Store.YES));
+                    vcfIndexEntry.getGene().toLowerCase(), Field.Store.YES));
             document.add(new SortedStringField(FeatureIndexFields.GENE_IDS.getFieldName(),
-                                               vcfIndexEntry.getGeneIds(), true));
+                    vcfIndexEntry.getGeneIds(), true));
         }
 
         if (StringUtils.isNotBlank(vcfIndexEntry.getGeneName())) {
             document.add(new StringField(FeatureIndexFields.GENE_NAME.getFieldName(),
-                                         vcfIndexEntry.getGeneName().toLowerCase(), Field.Store.YES));
+                    vcfIndexEntry.getGeneName().toLowerCase(), Field.Store.YES));
             document.add(new SortedStringField(FeatureIndexFields.GENE_NAMES.getFieldName(),
-                                         vcfIndexEntry.getGeneNames(), true));
+                    vcfIndexEntry.getGeneNames(), true));
         }
 
         document.add(new SortedStringField(FeatureIndexFields.IS_EXON.getFieldName(),
-                                     vcfIndexEntry.getExon().toString()));
+                vcfIndexEntry.getExon().toString()));
 
         if (vcfIndexEntry.getInfo() != null) {
             addVcfDocumentInfoFields(document, vcfIndexEntry);
@@ -1168,32 +1198,32 @@ public class FeatureIndexDao {
                 document.add(new SortedIntPoint(info.getKey().toLowerCase(), (Integer) info.getValue()));
                 if (vcfIndexEntry.getInfo().containsKey(viewKey)) {
                     document.add(new StoredField(info.getKey().toLowerCase(), vcfIndexEntry.getInfo()
-                        .get(viewKey).toString()));
+                            .get(viewKey).toString()));
                     document.add(new SortedDocValuesField(FeatureIndexFields.getGroupName(info.getKey().toLowerCase()),
-                                                      new BytesRef(vcfIndexEntry.getInfo().get(viewKey).toString())));
+                            new BytesRef(vcfIndexEntry.getInfo().get(viewKey).toString())));
                 } else {
                     document.add(new StoredField(info.getKey().toLowerCase(),
-                                                 (Integer) info.getValue()));
+                            (Integer) info.getValue()));
                     document.add(new SortedDocValuesField(FeatureIndexFields.getGroupName(info.getKey().toLowerCase()),
-                                                          new BytesRef(info.getValue().toString())));
+                            new BytesRef(info.getValue().toString())));
                 }
             } else if (info.getValue() instanceof Float) {
                 document.add(new SortedFloatPoint(info.getKey().toLowerCase(), (Float) info.getValue()));
 
                 if (vcfIndexEntry.getInfo().containsKey(viewKey)) {
                     document.add(new StoredField(info.getKey().toLowerCase(), vcfIndexEntry.getInfo()
-                        .get(viewKey).toString()));
+                            .get(viewKey).toString()));
                     document.add(new SortedDocValuesField(FeatureIndexFields.getGroupName(info.getKey().toLowerCase()),
-                                                      new BytesRef(vcfIndexEntry.getInfo().get(viewKey).toString())));
+                            new BytesRef(vcfIndexEntry.getInfo().get(viewKey).toString())));
                 } else {
                     document.add(new StoredField(info.getKey().toLowerCase(), (Float) info.getValue()));
                     document.add(new SortedDocValuesField(FeatureIndexFields.getGroupName(info.getKey().toLowerCase()),
-                                                          new BytesRef(info.getValue().toString())));
+                            new BytesRef(info.getValue().toString())));
                 }
             } else {
                 if (vcfIndexEntry.getInfo().containsKey(viewKey)) {
                     document.add(new SortedStringField(info.getKey().toLowerCase(), vcfIndexEntry.getInfo()
-                        .get(viewKey).toString()));
+                            .get(viewKey).toString()));
                 } else {
                     document.add(new SortedStringField(info.getKey().toLowerCase(), info.getValue().toString().trim()));
                 }
@@ -1202,20 +1232,20 @@ public class FeatureIndexDao {
     }
 
     private void createIndexEntries(final ScoreDoc[] hits, Map<Integer, FeatureIndexEntry> entryMap,
-                                    Map<Long, BookmarkIndexEntry> foundBookmarkEntries, IndexSearcher searcher,
-                                    List<String> vcfInfoFields) throws IOException {
+            Map<Long, BookmarkIndexEntry> foundBookmarkEntries, IndexSearcher searcher,
+            List<String> vcfInfoFields) throws IOException {
         for (ScoreDoc hit : hits) {
             FeatureIndexEntry entry = createIndexEntry(hit, foundBookmarkEntries, searcher, vcfInfoFields);
 
             entryMap.put(Objects.hash(entry.getFeatureFileId(), entry.getChromosome() != null ?
-                                                                entry.getChromosome().getId() : null,
-                                      entry.getStartIndex(), entry.getEndIndex(), entry.getFeatureId()), entry);
+                            entry.getChromosome().getId() : null,
+                    entry.getStartIndex(), entry.getEndIndex(), entry.getFeatureId()), entry);
 
         }
     }
 
     private FeatureIndexEntry createIndexEntry(ScoreDoc hit, Map<Long, BookmarkIndexEntry> foundBookmarkEntries,
-                                               IndexSearcher searcher, List<String> vcfInfoFields) throws IOException {
+            IndexSearcher searcher, List<String> vcfInfoFields) throws IOException {
         int docId = hit.doc;
         Document d = searcher.doc(docId);
         FeatureType featureType = FeatureType.forValue(d.get(FeatureIndexFields.FEATURE_TYPE.getFieldName()));
@@ -1227,7 +1257,7 @@ public class FeatureIndexDao {
             case BOOKMARK:
                 BookmarkIndexEntry bookmarkEntry = new BookmarkIndexEntry();
                 foundBookmarkEntries.put(Long.parseLong(d.get(FeatureIndexFields.FILE_ID.getFieldName())),
-                                         bookmarkEntry);
+                        bookmarkEntry);
                 entry = bookmarkEntry;
                 break;
             default:
@@ -1249,7 +1279,7 @@ public class FeatureIndexDao {
         if (!chromosomeId.isEmpty()) {
             entry.setChromosome(new Chromosome(Long.parseLong(chromosomeId)));
             entry.getChromosome().setName(d.getBinaryValue(FeatureIndexFields.CHROMOSOME_NAME.getFieldName())
-                                              .utf8ToString());
+                    .utf8ToString());
         }
 
         return entry;

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/index/FeatureIndexDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/index/FeatureIndexDao.java
@@ -24,6 +24,8 @@
 
 package com.epam.catgenome.dao.index;
 
+import static com.epam.catgenome.component.MessageHelper.getMessage;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -96,7 +98,6 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
-import com.epam.catgenome.component.MessageHelper;
 import com.epam.catgenome.constant.MessagesConstants;
 import com.epam.catgenome.dao.index.field.IndexSortField;
 import com.epam.catgenome.dao.index.field.SortedIntPoint;
@@ -463,7 +464,7 @@ public class FeatureIndexDao {
             createIndexEntries(hits, entryMap, foundBookmarkEntries, searcher, vcfInfoFields);
             setBookmarks(foundBookmarkEntries);
         } catch (IOException e) {
-            LOGGER.error(MessageHelper.getMessage(MessagesConstants.ERROR_FEATURE_INDEX_SEARCH_FAILED), e);
+            LOGGER.error(getMessage(MessagesConstants.ERROR_FEATURE_INDEX_SEARCH_FAILED), e);
             return new IndexSearchResult(Collections.emptyList(), false, 0);
         }
 
@@ -706,7 +707,7 @@ public class FeatureIndexDao {
         SimpleFSDirectory[] indexes = fileManager.getIndexesForFiles(files);
         long totalIndexSize = getTotalIndexSize(indexes);
         if (totalIndexSize > luceneIndexMaxSizeForGrouping) {
-            return Collections.emptyList();
+            throw new IllegalArgumentException(getMessage(MessagesConstants.ERROR_FEATURE_INEDX_TOO_LARGE));
         }
 
         try (MultiReader reader = openMultiReader(indexes)) {
@@ -955,7 +956,7 @@ public class FeatureIndexDao {
 
             geneIds = fetchGeneIds(hits, searcher);
         } catch (IOException e) {
-            LOGGER.error(MessageHelper.getMessage(MessagesConstants.ERROR_FEATURE_INDEX_SEARCH_FAILED), e);
+            LOGGER.error(getMessage(MessagesConstants.ERROR_FEATURE_INDEX_SEARCH_FAILED), e);
             return Collections.emptySet();
         }
 
@@ -995,7 +996,7 @@ public class FeatureIndexDao {
 
             geneIds = fetchGeneIds(hits, searcher);
         } catch (IOException e) {
-            LOGGER.error(MessageHelper.getMessage(MessagesConstants.ERROR_FEATURE_INDEX_SEARCH_FAILED), e);
+            LOGGER.error(getMessage(MessagesConstants.ERROR_FEATURE_INDEX_SEARCH_FAILED), e);
             return Collections.emptySet();
         }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
@@ -659,13 +659,7 @@ public class FeatureIndexManager {
      */
     public void writeLuceneIndexForFile(final FeatureFile featureFile, final List<? extends FeatureIndexEntry> entries)
             throws IOException {
-        writeLuceneIndexForFile(featureFile, entries, false);
-    }
-
-    public void writeLuceneIndexForFile(final FeatureFile featureFile, final List<? extends FeatureIndexEntry> entries,
-            final boolean optimize)
-            throws IOException {
-        featureIndexDao.writeLuceneIndexForFile(featureFile, entries, optimize);
+        featureIndexDao.writeLuceneIndexForFile(featureFile, entries);
     }
 
     public void makeIndexForBedReader(BedFile bedFile, AbstractFeatureReader<BEDFeature, LineIterator> reader,
@@ -728,7 +722,7 @@ public class FeatureIndexManager {
                 Utils.chromosomeMapContains(chromosomeMap, currentKey)) {
                 List<VcfIndexEntry> processedEntries = postProcessIndexEntries(allEntries, geneFiles,
                                        Utils.getFromChromosomeMap(chromosomeMap, currentKey), vcfHeader, vcfFileReader);
-                featureIndexDao.writeLuceneIndexForFile(vcfFile, processedEntries, true);
+                featureIndexDao.writeLuceneIndexForFile(vcfFile, processedEntries);
                 processedEntries.clear();
                 LOGGER.info(MessageHelper.getMessage(MessagesConstants.INFO_FEATURE_INDEX_CHROMOSOME_WROTE,
                                                      currentKey));

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -610,7 +610,7 @@ public class VcfManager {
 
                     writeEntriesForChromosome(allEntries, geneFiles,
                                               Utils.getFromChromosomeMap(chromosomeMap, currentKey), vcfFile, vcfHeader,
-                                              vcfFileReader, doIndex, false);
+                                              vcfFileReader, doIndex);
                 }
 
                 startPosition = variantContext.getStart();
@@ -633,7 +633,7 @@ public class VcfManager {
         // Put the last one
         if (variantContext != null && checkMetaMapKey(chromosomeMap, currentKey)) {
             writeEntriesForChromosome(allEntries, geneFiles, Utils.getFromChromosomeMap(chromosomeMap, currentKey),
-                                      vcfFile, vcfHeader, vcfFileReader, doIndex, true);
+                                      vcfFile, vcfHeader, vcfFileReader, doIndex);
         }
 
         return metaMap;
@@ -651,14 +651,13 @@ public class VcfManager {
 
     private void writeEntriesForChromosome(List<VcfIndexEntry> allEntries, List<GeneFile> geneFiles,
                                            Chromosome currentChromosome, VcfFile vcfFile,
-                                           VCFHeader vcfHeader, VcfFileReader vcfFileReader, boolean doIndex,
-                                           boolean lastEntry)
+                                           VCFHeader vcfHeader, VcfFileReader vcfFileReader, boolean doIndex)
         throws GeneReadingException, IOException {
         if (doIndex) {
             List<VcfIndexEntry> processedEntries = featureIndexManager.postProcessIndexEntries(allEntries, geneFiles,
                                                                                            currentChromosome,
                                                                                            vcfHeader, vcfFileReader);
-            featureIndexManager.writeLuceneIndexForFile(vcfFile, processedEntries, lastEntry);
+            featureIndexManager.writeLuceneIndexForFile(vcfFile, processedEntries);
             processedEntries.clear();
             LOGGER.info(getMessage(MessagesConstants.INFO_FEATURE_INDEX_CHROMOSOME_WROTE, currentChromosome.getName()));
             allEntries.clear();

--- a/server/catgenome/src/main/resources/catgenome-messages.properties
+++ b/server/catgenome/src/main/resources/catgenome-messages.properties
@@ -175,6 +175,7 @@ debug.feature.index.query.time=Performed Lucene query for project {0}, took {1} 
 error.feature.index.search.failed=Error: Exception while searching through index:
 error.feature.index.writing=Error while writing feature index
 error.feature.index.invalid.number.format=Illegal number format: ''{0}''
+error.feature.index.too.large=Feature index is too large to perform request.
 
 # S3
 error.not.s3.bucket=This bucket is wrong.


### PR DESCRIPTION
# Description
This pull request provides a solution for performance of /filter and /group requests for large (more than 500Mb) VCF files
## Background
For large VCF files Lucene index becomes too large and some requests take too long. To resolve this issue, we suggest to check Lucene index size before making request to it and cancel requests if index is too large.
## Changes
,Appropriate changes are done to FeatureIndexDao and application property "lucene.index.max.size.grouping" is added to catgenome.properties to control max index size. Default value is 4Gb. 
## Acceptance criteria
Register 500Mb VCF file and check that /group request doesn't return any data and /filter request doesn't return  as totalPagesCount value.
 
# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
