### PR TITLE
Windows desktop application fix

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
@@ -47,7 +47,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1927,7 +1926,7 @@ public class FileManager {
         List<File> parentDirs = new ArrayList<>();
         if (path == null) {
             if ("/".equals(ngsDataRootPath)) {
-                parentDirs = Arrays.asList(File.listRoots());
+                parentDirs = getExistingRootDirs();
             } else {
                 parentDirs.add(new File(ngsDataRootPath));
             }
@@ -1979,6 +1978,16 @@ public class FileManager {
         }
 
         return items;
+    }
+
+    private List<File> getExistingRootDirs() {
+        List<File> existingRootDirs = new ArrayList<>();
+        for (File file : File.listRoots()) {
+            if (file.exists()) {
+                existingRootDirs.add(file);
+            }
+        }
+        return existingRootDirs;
     }
 
     /**


### PR DESCRIPTION
# Description

## Background

NGB allows to build desktop application. Application packed for Windows OS did not work properly: file working tree did not show while choosing files from NGB server.

## Changes

Added filtering of nonexistent root directories.

## Acceptance criteria

* Build NGB desktop application.
* Run application for Windows under coressponding OS.
* Click "Open" -> "From NGB server".
* Check that list of files is present in a table.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
