### PR TITLE
Fix for negative number in "maximum variants range"

### DIFF
--- a/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.tpl.html
+++ b/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.tpl.html
@@ -237,10 +237,11 @@
                                     <input name="maxRangeVcf"
                                            type="number"
                                            required
+                                           ng-min="0"
                                            placeholder="maximum variants range(bp)"
                                            ng-model="ctrl.settings.variantsMaximumRange"/>
                                     <div ng-messages="settingsForm.maxRangeVcf.$error" role="alert">
-                                        <div ng-message="required">Enter maximum range for displaying variants(bp).</div>
+                                        <div ng-message="required,min">Enter maximum range for displaying variants(bp). Value must be greater than 0.</div>
                                     </div>
                                 </md-input-container>
                             </div>


### PR DESCRIPTION
# Description

## Background

Fix for issue #32

## Changes

Added checking the "maximum variants range(bp)" field

## Acceptance criteria

1. Open NGB
2. Click "SETTINGS" icon
3. Click "VCF" tab
4. Enter negative number in "maximum variants range(bp)" field
5. Click "SAVE" button
6. Expected: warning message

# Check list

- [ ] ~~Unit tests are provided~~
- [ ] ~~Integration tests are provided (if CLI/API was changed)~~
- [ ] ~~Documentation is updated~~
