### PR TITLE
Fix stuck loading indicator for bigWig/bedGraph tracks

### DIFF
--- a/client/client/dataServices/wig/wig-data-service.js
+++ b/client/client/dataServices/wig/wig-data-service.js
@@ -44,6 +44,8 @@ export class WigDataService extends DataService {
                     const code = 'WIG Data Service', message = 'WIG Data Service: error loading wig track';
                     reject({code, message});
                 }
+            }).catch(() => {
+                resolve([]);
             });
         });
     }


### PR DESCRIPTION
# Description

## Background

Fix for issue #33

## Changes

Added errors handling

## Acceptance criteria

1.Rregister .bw file, in this file should be absent data for one or more chromosome
2. Add this file in dataset
3. Open dataset
4. Open browser console
5. Select chromosome which absent in .bw

# Check list

- [ ] ~~Unit tests are provided~~
- [ ] ~~Integration tests are provided (if CLI/API was changed)~~
- [ ] ~~Documentation is updated~~
