### PR TITLE
Fix "Open from URL" to open all supported file types

### DIFF
--- a/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFileFromUrl/ngbOpenFileFromUrl.controller.js
+++ b/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFileFromUrl/ngbOpenFileFromUrl.controller.js
@@ -48,7 +48,14 @@ export default class ngbOpenFileFromUrlController {
 
     get trackNeedsIndexFile() {
         const extension = this.fileExtension();
-        return extension === 'bam' || extension === 'vcf';
+        return extension === 'bam' ||
+            extension === 'cram' ||
+            extension === 'vcf' ||
+            extension === 'bed' ||
+            extension === 'gff' ||
+            extension === 'gff3' ||
+            extension === 'gtf';
+
     }
 
     fileExtension() {
@@ -76,7 +83,12 @@ export default class ngbOpenFileFromUrlController {
         if (extension) {
             switch (extension.toLowerCase()) {
                 case 'bam': return 'BAM';
+                case 'cram': return 'BAM';
                 case 'vcf': return 'VCF';
+                case 'bed': return 'BED';
+                case 'gff': return 'GENE';
+                case 'gff3': return 'GENE';
+                case 'gtf': return 'GENE';
             }
         }
         return null;

--- a/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFileFromUrl/ngbOpenFileFromUrl.controller.js
+++ b/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFileFromUrl/ngbOpenFileFromUrl.controller.js
@@ -49,7 +49,6 @@ export default class ngbOpenFileFromUrlController {
     get trackNeedsIndexFile() {
         const extension = this.fileExtension();
         return extension === 'bam' ||
-            extension === 'cram' ||
             extension === 'vcf' ||
             extension === 'bed' ||
             extension === 'gff' ||
@@ -83,7 +82,6 @@ export default class ngbOpenFileFromUrlController {
         if (extension) {
             switch (extension.toLowerCase()) {
                 case 'bam': return 'BAM';
-                case 'cram': return 'BAM';
                 case 'vcf': return 'VCF';
                 case 'bed': return 'BED';
                 case 'gff': return 'GENE';

--- a/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFileFromUrl/ngbOpenFileFromUrl.tpl.html
+++ b/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFileFromUrl/ngbOpenFileFromUrl.tpl.html
@@ -28,7 +28,7 @@
         </div>
     </md-input-container>
     <md-input-container class="md-block">
-        <label for="indexFilePath">Index file path (required for .bam, .cram, .vcf, .bed, .gff, .gff3, .gtf files)</label>
+        <label for="indexFilePath">Index file path (required for .bam, .vcf, .bed, .gff, .gff3, .gtf files)</label>
         <input id="indexFilePath"
                name="indexFilePath"
                aria-label="index file path"

--- a/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFileFromUrl/ngbOpenFileFromUrl.tpl.html
+++ b/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFileFromUrl/ngbOpenFileFromUrl.tpl.html
@@ -28,7 +28,7 @@
         </div>
     </md-input-container>
     <md-input-container class="md-block">
-        <label for="indexFilePath">Index file path (required for .bam & .vcf files)</label>
+        <label for="indexFilePath">Index file path (required for .bam, .cram, .vcf, .bed, .gff, .gff3, .gtf files)</label>
         <input id="indexFilePath"
                name="indexFilePath"
                aria-label="index file path"


### PR DESCRIPTION
# Description

## Background

Fix for issue #39 

## Changes

Added check  file extension.

## Acceptance criteria

We open BED/GFF(GFF3)/GTF/CRAM files

# Check list

- [ ] ~~Unit tests are provided~~
- [ ] ~~Integration tests are provided (if CLI/API was changed)~~
- [ ] ~~Documentation is updated~~
