### PR TITLE
Moved expand symbol in variation info to left in variation info (isuue 56)

### DIFF
--- a/client/client/app/assets/scss/base/buttons.scss
+++ b/client/client/app/assets/scss/base/buttons.scss
@@ -16,6 +16,16 @@ $icon-button-width: rem(4.000) !default;
   }
 }
 
+.md-button__icon-left {
+  .control-label {
+    display: block;
+    margin-left: 20px;
+  }
+  ng-md-icon {
+    float: left;
+  }
+}
+
 .md-button__right {
   float: right;
 }

--- a/client/client/app/shared/components/widgets/collapsiblePanel/collapsiblePanel.tpl.html
+++ b/client/client/app/shared/components/widgets/collapsiblePanel/collapsiblePanel.tpl.html
@@ -1,4 +1,4 @@
-<md-button class="md-button_block md-button__icon-right"
+<md-button class="md-button_block md-button__icon-left"
            ng-click="$ctrl.onClick()"
            ng-disabled="$ctrl.disabled">
     <ng-md-icon size="18"


### PR DESCRIPTION
# Description

## Background

## Changes

Expand symbol in variation info was moved to left

## Acceptance criteria

Open a variation info tab

# Check list
