### PR TITLE
PhantomJS causes GUI build to fail in certain cases #63

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,6 @@
     "eslint-plugin-flowtype": "^2.3.0",
     "expose-loader": "^0.7.1",
     "extract-text-webpack-plugin": "^0.8.2",
-    "favicons-webpack-plugin": "0.0.7",
     "file-loader": "^0.8.5",
     "html-loader": "0.4.3",
     "html-webpack-plugin": "^2.17.0",

--- a/client/webpack.config.babel/webpack.plugins.js
+++ b/client/webpack.config.babel/webpack.plugins.js
@@ -1,7 +1,6 @@
 import webpack, { optimize } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
-import FaviconsWebpackPlugin from 'favicons-webpack-plugin';
 
 const DEV = global.buildOptions.dev;
 const globals = {
@@ -27,26 +26,8 @@ const prodPlugins = [
 
 export default [
     new webpack.DefinePlugin(globals),
-    new FaviconsWebpackPlugin({
-        logo: './client/app/assets/icons/ngb-logo.png',
-        prefix: 'icons-[hash]/',
-        emitStats: false,
-        persistentCache: true,
-        inject: true,
-        icons: {
-            android: false,
-            appleIcon: false,
-            appleStartup: false,
-            coast: false,
-            favicons: true,
-            firefox: false,
-            opengraph: false,
-            twitter: false,
-            yandex: false,
-            windows: false
-        }
-    }),
     new HtmlWebpackPlugin({
+        favicon: './client/app/assets/icons/ngb-logo.png',
         template: './client/index.html.ejs',
         inject: 'body'
     }),


### PR DESCRIPTION
# Description

## Background

Fix for issue #63

## Changes

Removed the "favicons-webpack-plugin" package.
Changed the favicon adding logic

## Acceptance criteria

1. Run ‘npm install’
2. Open ‘node_modules’ folder 
3. This folder should not contain ‘phantomjs-prebuilt’  folder.

Check favicon:
1. Open NGB
2. Tab of the browser contains favicon
 ![image](https://user-images.githubusercontent.com/31283705/30215870-fef53f3a-94b9-11e7-902b-607fde8d8878.png)

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
