### PR TITLE
Display reference letters in BAM coverage graph using gray color #61

### DIFF
--- a/client/client/modules/render/tracks/bam/internal/renderer/features/coverageRenderer.js
+++ b/client/client/modules/render/tracks/bam/internal/renderer/features/coverageRenderer.js
@@ -23,7 +23,10 @@ export class CoverageRenderer extends WIGRenderer {
                     const min = this._getYValue(cache.baseAxis, coordinateSystem) -1;
                     let prevPercentage = 0;
                     for (let k = barOrders.length - 1; k >= 0; k--) {
-                        const color = this._bamConfig.colors[barOrders[k]];
+                        let color = this._bamConfig.colors[barOrders[k]];
+                        if(point.dataItem.locusLetter.toLowerCase() === barOrders[k].toLowerCase()) {
+                            color = this._bamConfig.colors.base;
+                        }
                         const value = point.dataItem.locusInfo && point.dataItem.locusInfo[barOrders[k].toLowerCase()] ?
                             point.dataItem.locusInfo[barOrders[k].toLowerCase()] : 0;
                         if (value === 0) {

--- a/client/client/modules/render/tracks/bam/internal/transformers/bamReadsCoverageTransformer.js
+++ b/client/client/modules/render/tracks/bam/internal/transformers/bamReadsCoverageTransformer.js
@@ -76,6 +76,7 @@ export default class BamReadsCoverageTransformer extends WIGTransformer {
             locusInfo = null;
         }
 
+        item.locusLetter = locusLetter;
         item.locusInfo = locusInfo;
     }
 }


### PR DESCRIPTION
# Description

## Background

Fix for issue #61

## Changes

Reference letters in BAM coverage graph display gray color

## Acceptance criteria

Open BAM track.
If there are mismathes and a letter at this position are the same as in reference, then it displayed by gray color.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
