### PR TITLE
Automatic downloading of variation info from db snp

### DIFF
--- a/client/client/app/components/ngbVariantPanel/ngbVariantPanel.controller.js
+++ b/client/client/app/components/ngbVariantPanel/ngbVariantPanel.controller.js
@@ -24,7 +24,7 @@ export default class ngbVariantPanelController extends ngbVariantDetailsControll
 
         let ids = this.variant.id.split(/[;,|\s]/)
                                 .filter(
-                                    id => id.match(/^rs[\d]+/)
+                                    id => id.match(/^rs\d+$/)
                                 );
 
         if (ids[0]) {

--- a/client/client/app/components/ngbVariantPanel/ngbVariantPanel.controller.js
+++ b/client/client/app/components/ngbVariantPanel/ngbVariantPanel.controller.js
@@ -20,8 +20,6 @@ export default class ngbVariantPanelController extends ngbVariantDetailsControll
     }
 
     get rsId() {
-        if(this._rsId !== null) return this._rsId;
-
         let ids = this.variant.id.split(/[;,|\s]/)
                                 .filter(
                                     id => id.match(/^rs\d+$/)
@@ -32,7 +30,6 @@ export default class ngbVariantPanelController extends ngbVariantDetailsControll
         } else {
             this._rsId = null;
         }
-
 
         return this._rsId;
     }

--- a/client/client/app/components/ngbVariantPanel/ngbVariantPanel.controller.js
+++ b/client/client/app/components/ngbVariantPanel/ngbVariantPanel.controller.js
@@ -5,6 +5,8 @@ export default class ngbVariantPanelController extends ngbVariantDetailsControll
         return 'ngbVariantPanelController';
     }
 
+    _rsId = null;
+
     /* @ngInject */
     constructor($scope, $mdDialog) {
         super($scope);
@@ -15,6 +17,24 @@ export default class ngbVariantPanelController extends ngbVariantDetailsControll
 
     close() {
         this.$mdDialog.hide();
+    }
+
+    get rsId() {
+        if(this._rsId !== null) return this._rsId;
+
+        let ids = this.variant.id.split(/[;,|\s]/)
+                                .filter(
+                                    id => id.match(/^rs[\d]+/)
+                                );
+
+        if (ids[0]) {
+            this._rsId = ids[0];
+        } else {
+            this._rsId = null;
+        }
+
+
+        return this._rsId;
     }
 
 }

--- a/client/client/app/components/ngbVariantPanel/ngbVariantPanel.tpl.html
+++ b/client/client/app/components/ngbVariantPanel/ngbVariantPanel.tpl.html
@@ -22,10 +22,10 @@
                 <ngb-variant-info flex variant="$ctrl.variant" variant-request="$ctrl.variantRequest"></ngb-variant-info>
             </md-tab-body>
         </md-tab>
-        <md-tab ng-if="$ctrl.variant.id.indexOf('rs') + 1" id="dbsnp">
+        <md-tab ng-if="$ctrl.rsId" id="dbsnp">
             <md-tab-label>dbSNP</md-tab-label>
             <md-tab-body>
-                <ngb-variant-db-snp flex variant="$ctrl.variant" variant-request="$ctrl.variantRequest"></ngb-variant-db-snp>
+                <ngb-variant-db-snp flex rs-Id="$ctrl.rsId" variant="$ctrl.variant" variant-request="$ctrl.variantRequest"></ngb-variant-db-snp>
             </md-tab-body>
         </md-tab>
     </md-tabs>

--- a/client/client/app/components/ngbVariantPanel/ngbVariantPanel.tpl.html
+++ b/client/client/app/components/ngbVariantPanel/ngbVariantPanel.tpl.html
@@ -22,5 +22,11 @@
                 <ngb-variant-info flex variant="$ctrl.variant" variant-request="$ctrl.variantRequest"></ngb-variant-info>
             </md-tab-body>
         </md-tab>
+        <md-tab ng-if="$ctrl.variant.id.indexOf('rs') + 1" id="dbsnp">
+            <md-tab-label>dbSNP</md-tab-label>
+            <md-tab-body>
+                <ngb-variant-db-snp flex variant="$ctrl.variant" variant-request="$ctrl.variantRequest"></ngb-variant-db-snp>
+            </md-tab-body>
+        </md-tab>
     </md-tabs>
 </div>

--- a/client/client/app/shared/components/ngbVariantDetails/index.js
+++ b/client/client/app/shared/components/ngbVariantDetails/index.js
@@ -3,6 +3,7 @@ import './ngbVariantDetails.scss';
 import './ngbVariantInfo/ngbVariantInfo.scss';
 import './ngbVariantAnnotations/ngbVariantAnnotations.scss';
 import './ngbVariantVisualizer/ngbVariantVisualizer.scss';
+import './ngbVariantDbSnp/ngbVariantDbSnp.scss';
 
 
 import angular from 'angular';
@@ -20,6 +21,10 @@ import ngbVariantVisualizerController from './ngbVariantVisualizer/ngbVariantVis
 import ngbVariantVisualizerComponent from './ngbVariantVisualizer/ngbVariantVisualizer.component';
 import ngbVariantVisualizerService from './ngbVariantVisualizer/ngbVariantVisualizer.service';
 
+import ngbVariantDbSnpController from './ngbVariantDbSnp/ngbVariantDbSnp.controller';
+import ngbVariantDbSnpComponent from './ngbVariantDbSnp/ngbVariantDbSnp.component';
+import ngbVariantDbSnpService from './ngbVariantDbSnp/ngbVariantDbSnp.service';
+
 import ngbVariantDetailsConstants from './ngbVariantDetails.constant.js';
 import dataServices from '../../../../dataServices/angular-module';
 import {capitalizeFilter} from './ngbVariantDetails.controller';
@@ -29,11 +34,14 @@ export default angular.module('ngbVariantDetails' , [dataServices])
     .constant('constants', ngbVariantDetailsConstants)
     .service('ngbVariantInfoService', ngbVariantInfoService.instance)
     .service('ngbVariantVisualizerService', ngbVariantVisualizerService.instance)
+    .service('ngbVariantDbSnpService', ngbVariantDbSnpService.instance)
     .controller(ngbVariantInfoController.UID, ngbVariantInfoController)
     .controller(ngbVariantAnnotationsController.UID, ngbVariantAnnotationsController)
     .controller(ngbVariantVisualizerController.UID, ngbVariantVisualizerController)
+    .controller(ngbVariantDbSnpController.UID, ngbVariantDbSnpController)
     .component('ngbVariantInfo', ngbVariantInfoComponent)
     .component('ngbVariantAnnotations', ngbVariantAnnotationsComponent)
     .component('ngbVariantVisualizer', ngbVariantVisualizerComponent)
+    .component('ngbVariantDbSnp', ngbVariantDbSnpComponent)
     .filter('capitalize', capitalizeFilter)
     .name;

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.component.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.component.js
@@ -6,6 +6,7 @@ export default {
     controller: controller.UID,
     controllerAs: 'ctrl',
     bindings: {
+        rsId: '<',
         variant: '=',
         variantRequest: '='
     }

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.component.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.component.js
@@ -1,0 +1,12 @@
+import controller from './ngbVariantDbSnp.controller.js';
+
+export default {
+    restrict: 'EA',
+    template: require('./ngbVariantDbSnp.tpl.html'),
+    controller: controller.UID,
+    controllerAs: 'ctrl',
+    bindings: {
+        variant: '=',
+        variantRequest: '='
+    }
+};

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.controller.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.controller.js
@@ -12,6 +12,7 @@ export default class ngbVariantDbSnpController extends ngbVariantDetailsControll
     _variantDbSnpService = null;
     _variantDBSnpInfo = null;
     _scope;
+    _rsId;
 
     /* @ngInject */
     constructor($scope, ngbVariantDbSnpService, vcfDataService, constants) {
@@ -21,19 +22,22 @@ export default class ngbVariantDbSnpController extends ngbVariantDetailsControll
         this.INIT();
     }
 
+    get rsId() { return this._rsId; }
+    set rsId(rsId) { this._rsId = rsId; this.INIT(); }
+
     get variantDbSnp() { return this._variantDBSnpInfo; }
     set variantDbSnp(info) { this._variantDBSnpInfo = info; }
 
     INIT(){
-        const hasVariantRequest = !(this.variantRequest === undefined || this.variantRequest === null);
+        const hasRsId = !(this.rsId === undefined || this.rsId === null);
 
         this.isLoading = false;
         this.hasError = false;
 
-        if (hasVariantRequest && this._variantDbSnpService !== null && this._variantDbSnpService !== undefined) {
+        if (hasRsId && this._variantDbSnpService !== null && this._variantDbSnpService !== undefined) {
             this.isLoading = true;
             this._variantDbSnpService
-                .loadVariantSnpInfo(this.variantRequest,
+                .loadVariantSnpInfo(this.rsId,
                     (variantSnpInfo) => {
                         this.variantDbSnp = variantSnpInfo;
 

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.controller.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.controller.js
@@ -1,0 +1,59 @@
+import {ngbVariantDetailsController} from '../ngbVariantDetails.controller';
+
+
+export default class ngbVariantDbSnpController extends ngbVariantDetailsController{
+    static get UID(){
+        return 'ngbVariantDbSnpController';
+    }
+
+    isLoading = false;
+    hasError = false;
+    errorMessage = null;
+    _variantDbSnpService = null;
+    _variantDBSnpInfo = null;
+    _scope;
+
+    /* @ngInject */
+    constructor($scope, ngbVariantDbSnpService, vcfDataService, constants) {
+        super($scope, vcfDataService, constants);
+        this._scope = $scope;
+        this._variantDbSnpService = ngbVariantDbSnpService;
+        this.INIT();
+    }
+
+    get variantDbSnp() { return this._variantDBSnpInfo; }
+    set variantDbSnp(info) { this._variantDBSnpInfo = info; }
+
+    INIT(){
+        const hasVariantRequest = !(this.variantRequest === undefined || this.variantRequest === null);
+
+        this.isLoading = false;
+        this.hasError = false;
+
+        if (hasVariantRequest && this._variantDbSnpService !== null && this._variantDbSnpService !== undefined) {
+            this.isLoading = true;
+            this._variantDbSnpService
+                .loadVariantSnpInfo(this.variantRequest,
+                    (variantSnpInfo) => {
+                        this.variantDbSnp = variantSnpInfo;
+
+                        this.isLoading = false;
+                        if (this._scope !== null && this._scope !== undefined) {
+                            this._scope.$apply();
+                        }
+                    },
+                    ::this._handleError);
+        }
+        else{
+            if (this._constants !== null && this._constants !== undefined)
+                this._handleError(this._constants.errorMessages.errorLoadingVariantInfo);
+        }
+    }
+
+    
+    _handleError(message){
+        this.isLoading = false;
+        this.hasError = true;
+        this.errorMessage = message;
+    }
+}

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.scss
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.scss
@@ -1,0 +1,20 @@
+.md-variant-info-error{
+  text-align:center;
+  color:#FF0000;
+  font-size:smaller;
+}
+.md-variant-properties-table {
+  .ui-grid, .ui-grid-render-container {
+    height: auto !important;
+    max-height: 200px;
+  }
+  collapsible-panel-title{
+    color: rgba(0,0,0,0.87);
+    font-size: 15px;
+    padding-left: 0;
+  }
+  .table-property{
+    font-size: 13px;
+  }
+}
+

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.scss
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.scss
@@ -16,5 +16,18 @@
   .table-property{
     font-size: 13px;
   }
-}
 
+  a{
+    text-decoration: none;
+    font-size: 14px;
+    color: #679edb;
+    & + span{
+      font-size: 14px;
+      color: #666;
+    }
+    &:hover{
+      text-decoration: underline;
+      color: #2165de;
+    }
+  }
+}

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -97,18 +97,21 @@ export default class ngbVariantDbSnpService{
             });
         }
         if (variationExists && snpData.variation.hasOwnProperty('docsum')) {
-            let hgvs = snpData.variation.docsum.slice(snpData.variation.docsum.indexOf('HGVS='))
-                                               .split(/\|/, 1)[0]
-                                               .slice(5),
-                tmpEl = document.createElement('div');
+            let hgvsIndex = snpData.variation.docsum.indexOf('HGVS=');
+            if (hgvsIndex + 1) {
+                let hgvs = snpData.variation.docsum.slice(hgvsIndex)
+                                                    .split(/\|/, 1)[0]
+                                                    .slice(5),
+                    tmpEl = document.createElement('div');
 
-            tmpEl.innerHTML = hgvs;
-            hgvs = tmpEl.childNodes[0].nodeValue;
+                tmpEl.innerHTML = hgvs;
+                hgvs = tmpEl.childNodes[0].nodeValue;
 
-            snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
-                title: 'HGVS Names',
-                values: hgvs.split(/,/)
-            });
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                    title: 'HGVS Names',
+                    values: hgvs.split(/,/)
+                });
+            }
         }
 
         if(variationExists) {
@@ -160,35 +163,41 @@ export default class ngbVariantDbSnpService{
 
 
         if (snpData.hasOwnProperty('ref_seq_gene_mapping')) {
-            snpCollapsiblePanels.push({
-                title: 'RefSeq Gene Mapping',
-                isOpen: false,
-                values: []
-            });
+            let refSeqGeneExists = snpData.ref_seq_gene_mapping.hasOwnProperty('refSeqGene'),
+                geneExists = snpData.ref_seq_gene_mapping.hasOwnProperty('gene'),
+                positionExists = snpData.ref_seq_gene_mapping.hasOwnProperty('position'),
+                alleleExists = snpData.ref_seq_gene_mapping.hasOwnProperty('allele');
 
-            if (snpData.ref_seq_gene_mapping.hasOwnProperty('refSeqGene')) {
-                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
-                    title: 'RefSeqGene',
-                    values: [snpData.ref_seq_gene_mapping.refSeqGene]
+            if (refSeqGeneExists || geneExists || positionExists || alleleExists) {
+                snpCollapsiblePanels.push({
+                    title: 'RefSeq Gene Mapping',
+                    isOpen: false,
+                    values: []
                 });
-            }
-            if (snpData.ref_seq_gene_mapping.hasOwnProperty('gene')) {
-                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
-                    title: 'Gene:ID',
-                    values: [snpData.ref_seq_gene_mapping.gene]
-                });
-            }
-            if (snpData.ref_seq_gene_mapping.hasOwnProperty('position')) {
-                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
-                    title: 'Position',
-                    values: [snpData.ref_seq_gene_mapping.position]
-                });
-            }
-            if (snpData.ref_seq_gene_mapping.hasOwnProperty('allele')) {
-                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
-                    title: 'Allele',
-                    values: [snpData.ref_seq_gene_mapping.allele]
-                });
+                if (refSeqGeneExists) {
+                    snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                        title: 'RefSeqGene',
+                        values: [snpData.ref_seq_gene_mapping.refSeqGene]
+                    });
+                }
+                if (geneExists) {
+                    snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                        title: 'Gene:ID',
+                        values: [snpData.ref_seq_gene_mapping.gene]
+                    });
+                }
+                if (positionExists) {
+                    snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                        title: 'Position',
+                        values: [snpData.ref_seq_gene_mapping.position]
+                    });
+                }
+                if (alleleExists) {
+                    snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                        title: 'Allele',
+                        values: [snpData.ref_seq_gene_mapping.allele]
+                    });
+                }
             }
         }
 

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -1,0 +1,179 @@
+// import {utilities} from '../utilities';
+
+export default class ngbVariantDbSnpService{
+
+    static instance(dispatcher, constants, externaldbDataService) {
+        return new ngbVariantDbSnpService(dispatcher, constants, externaldbDataService);
+    }
+
+    _constants;
+    _dataService;
+    _dispatcher;
+
+    constructor(dispatcher, constants, dataService){
+        this._dataService = dataService;
+        this._constants = constants;
+        this._dispatcher = dispatcher;
+    }
+
+    loadVariantSnpInfo(variantRequest, callback, errorCallback) {
+        let ids = variantRequest.id.slice(variantRequest.id.indexOf('rs')).split(';');
+        const rsId = ids[0];
+
+        this._dataService.getNcbiVariationInfo(rsId)
+            .then(
+                (data) => {
+                    callback(this._mapVariantSnpData(data));
+                },
+                () => {
+                    errorCallback(this._constants.errorMessages.errorLoadingVariantSnpInfo);
+                });
+
+    }
+
+    _mapVariantSnpData(snpData) {
+        let snpProperties = [],
+            variationExists = snpData.hasOwnProperty('variation');
+
+        if(snpData.hasOwnProperty('organism_summary')) {
+            snpProperties.push({
+                title: 'Organism',
+                value: snpData.organism_summary
+            });
+        }
+        if (variationExists) {
+            if (snpData.variation.hasOwnProperty('genomeLabel')) {
+                snpProperties.push({
+                    title: 'Map to Genome Build',
+                    value: snpData.variation.genomeLabel
+                });
+            }
+            if (snpData.variation.hasOwnProperty('snp_class')) {
+                snpProperties.push({
+                    title: 'Variation Class',
+                    value: snpData.variation.snp_class
+                });
+            }
+        }
+        if(snpData.hasOwnProperty('refsnp_alleles')) {
+            snpProperties.push({
+                title: 'RefSNP Alleles',
+                value: snpData.refsnp_alleles
+            });
+        }
+        if (variationExists) {
+            if (snpData.variation.hasOwnProperty('clinical_significance')) {
+                snpProperties.push({
+                    title: 'Clinical Significance',
+                    value: snpData.variation.clinical_significance
+                });
+            }
+            if(snpData.variation.hasOwnProperty('global_maf')) {
+                snpProperties.push({
+                    title: 'MAF/MinorAlleleCount',
+                    value: snpData.variation.global_maf
+                });
+            }
+        }
+        if(snpData.hasOwnProperty('maf_source')) {
+            snpProperties.push({
+                title: 'MAF Source',
+                value: snpData.maf_source
+            });
+        }
+        if (variationExists && snpData.variation.hasOwnProperty('docsum')) {
+            snpProperties.push({
+                title: 'HGVS Names',
+                value: snpData.variation.docsum
+            });
+        }
+
+        if(variationExists) {
+            let genomeLabelExists = snpData.variation.hasOwnProperty('genomeLabel'),
+                chrExists = snpData.variation.hasOwnProperty('chr'),
+                chrposExists = snpData.variation.hasOwnProperty('chrpos'),
+                contigLabelExists = snpData.variation.hasOwnProperty('contigLabel'),
+                contigposExists = snpData.variation.hasOwnProperty('contigpos');
+
+            if (genomeLabelExists || chrExists || chrposExists || contigLabelExists || contigposExists) {
+                snpProperties.push({
+                    title: 'From table with variation location (Primary Assembly Mapping)',
+                    value: ''
+                });
+            }
+
+            if(genomeLabelExists) {
+                snpProperties.push({
+                    title: 'Assembly',
+                    value: snpData.variation.genomeLabel
+                });
+            }
+            if(chrExists) {
+                snpProperties.push({
+                    title: 'Chr',
+                    value: snpData.variation.chr
+                });
+            }
+            if(chrposExists) {
+                snpProperties.push({
+                    title: 'Chr Pos',
+                    value: snpData.variation.chrpos
+                });
+            }
+            if(contigLabelExists) {
+                snpProperties.push({
+                    title: 'Contig',
+                    value: snpData.variation.contigLabel
+                });
+            }
+            if(contigposExists) {
+                snpProperties.push({
+                    title: 'Contig Pos',
+                    value: snpData.variation.contigpos
+                });
+            }
+        }
+
+
+        let ref_seq_geneExists = snpData.hasOwnProperty('ref_seq_gene'),
+            genesExists = variationExists && snpData.variation.hasOwnProperty('genes');
+        if (ref_seq_geneExists || genesExists) {
+            snpProperties.push({
+                title: 'From table RefSeq Gene Mapping',
+                value: ''
+            });
+        }
+        if (ref_seq_geneExists) {
+            snpProperties.push({
+                title: 'RefSeqGene',
+                value: snpData.ref_seq_gene
+            });
+        }
+        if (genesExists) {
+            if (snpData.variation.genes.length > 0) {
+                let genesInfo = '';
+                for (let i = 0; i < snpData.variation.genes.length; i++) {
+                    genesInfo += snpData.variation.genes[i].name + ' (' + snpData.variation.genes[i].gene_id + ')';
+                    if (!(i + 1 === snpData.variation.genes.length || snpData.variation.genes.length === 1)) {
+                        genesInfo += '; ';
+                    }
+                }
+
+                snpProperties.push({
+                    title: 'Gene (ID)',
+                    value: genesInfo
+                });
+            }
+        }
+
+
+        this.isLoading = false;
+        this.hasError = false;
+
+
+        return {
+            snpProperties: snpProperties
+        }
+    }
+
+}

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -16,10 +16,7 @@ export default class ngbVariantDbSnpService{
         this._dispatcher = dispatcher;
     }
 
-    loadVariantSnpInfo(variantRequest, callback, errorCallback) {
-        let ids = variantRequest.id.slice(variantRequest.id.indexOf('rs')).split(';');
-        const rsId = ids[0];
-
+    loadVariantSnpInfo(rsId, callback, errorCallback) {
         this._dataService.getNcbiVariationInfo(rsId)
             .then(
                 (data) => {
@@ -32,57 +29,63 @@ export default class ngbVariantDbSnpService{
     }
 
     _mapVariantSnpData(snpData) {
-        let snpProperties = [],
+        let snpCollapsiblePanels = [],
             variationExists = snpData.hasOwnProperty('variation');
 
+        snpCollapsiblePanels.push({
+            title: 'Summary',
+            isOpen: true,
+            values: []
+        });
+
         if(snpData.hasOwnProperty('organism_summary')) {
-            snpProperties.push({
+            snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'Organism',
                 value: snpData.organism_summary
             });
         }
         if (variationExists) {
             if (snpData.variation.hasOwnProperty('genomeLabel')) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Map to Genome Build',
                     value: snpData.variation.genomeLabel
                 });
             }
             if (snpData.variation.hasOwnProperty('snp_class')) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Variation Class',
                     value: snpData.variation.snp_class
                 });
             }
         }
         if(snpData.hasOwnProperty('refsnp_alleles')) {
-            snpProperties.push({
+            snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'RefSNP Alleles',
                 value: snpData.refsnp_alleles
             });
         }
         if (variationExists) {
             if (snpData.variation.hasOwnProperty('clinical_significance')) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Clinical Significance',
                     value: snpData.variation.clinical_significance
                 });
             }
             if(snpData.variation.hasOwnProperty('global_maf')) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'MAF/MinorAlleleCount',
                     value: snpData.variation.global_maf
                 });
             }
         }
         if(snpData.hasOwnProperty('maf_source')) {
-            snpProperties.push({
+            snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'MAF Source',
                 value: snpData.maf_source
             });
         }
         if (variationExists && snpData.variation.hasOwnProperty('docsum')) {
-            snpProperties.push({
+            snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'HGVS Names',
                 value: snpData.variation.docsum
             });
@@ -96,38 +99,39 @@ export default class ngbVariantDbSnpService{
                 contigposExists = snpData.variation.hasOwnProperty('contigpos');
 
             if (genomeLabelExists || chrExists || chrposExists || contigLabelExists || contigposExists) {
-                snpProperties.push({
+                snpCollapsiblePanels.push({
                     title: 'From table with variation location (Primary Assembly Mapping)',
-                    value: ''
+                    isOpen: false,
+                    values: []
                 });
             }
 
             if(genomeLabelExists) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Assembly',
                     value: snpData.variation.genomeLabel
                 });
             }
             if(chrExists) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Chr',
                     value: snpData.variation.chr
                 });
             }
             if(chrposExists) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Chr Pos',
                     value: snpData.variation.chrpos
                 });
             }
             if(contigLabelExists) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Contig',
                     value: snpData.variation.contigLabel
                 });
             }
             if(contigposExists) {
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Contig Pos',
                     value: snpData.variation.contigpos
                 });
@@ -138,13 +142,14 @@ export default class ngbVariantDbSnpService{
         let ref_seq_geneExists = snpData.hasOwnProperty('ref_seq_gene'),
             genesExists = variationExists && snpData.variation.hasOwnProperty('genes');
         if (ref_seq_geneExists || genesExists) {
-            snpProperties.push({
+            snpCollapsiblePanels.push({
                 title: 'From table RefSeq Gene Mapping',
-                value: ''
+                isOpen: false,
+                values: []
             });
         }
         if (ref_seq_geneExists) {
-            snpProperties.push({
+            snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'RefSeqGene',
                 value: snpData.ref_seq_gene
             });
@@ -159,7 +164,7 @@ export default class ngbVariantDbSnpService{
                     }
                 }
 
-                snpProperties.push({
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Gene (ID)',
                     value: genesInfo
                 });
@@ -172,7 +177,7 @@ export default class ngbVariantDbSnpService{
 
 
         return {
-            snpProperties: snpProperties
+            snpCollapsiblePanels: snpCollapsiblePanels
         }
     }
 

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -85,7 +85,9 @@ export default class ngbVariantDbSnpService{
             });
         }
         if (variationExists && snpData.variation.hasOwnProperty('docsum')) {
-            let hgvs = snpData.variation.docsum.split(/\|/, 1)[0].slice(5),
+            let hgvs = snpData.variation.docsum.slice(snpData.variation.docsum.indexOf('HGVS='))
+                                               .split(/\|/, 1)[0]
+                                               .slice(5),
                 tmpEl = document.createElement('div');
 
             tmpEl.innerHTML = hgvs;

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -85,9 +85,16 @@ export default class ngbVariantDbSnpService{
             });
         }
         if (variationExists && snpData.variation.hasOwnProperty('docsum')) {
+            let hgvs = snpData.variation.docsum.split(/\|/, 1)[0].slice(5),
+                tmpEl = document.createElement('div');
+
+            tmpEl.innerHTML = hgvs;
+            hgvs = tmpEl.childNodes[0].nodeValue;
+
             snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'HGVS Names',
-                value: snpData.variation.docsum
+                valueType: 'array',
+                value: hgvs.split(/,/)
             });
         }
 

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -44,47 +44,57 @@ export default class ngbVariantDbSnpService{
         if(snpData.hasOwnProperty('organism_summary')) {
             snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'Organism',
-                value: snpData.organism_summary
+                values: [snpData.organism_summary]
             });
         }
         if (variationExists) {
             if (snpData.variation.hasOwnProperty('genomeLabel')) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Map to Genome Build',
-                    value: snpData.variation.genomeLabel
+                    values: [snpData.variation.genomeLabel]
                 });
             }
             if (snpData.variation.hasOwnProperty('snp_class')) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Variation Class',
-                    value: snpData.variation.snp_class
+                    values: [snpData.variation.snp_class]
                 });
             }
         }
         if(snpData.hasOwnProperty('refsnp_alleles')) {
             snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'RefSNP Alleles',
-                value: snpData.refsnp_alleles
+                values: [snpData.refsnp_alleles]
             });
         }
         if (variationExists) {
             if (snpData.variation.hasOwnProperty('clinical_significance')) {
-                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                let clinSignificance = {
                     title: 'Clinical Significance',
-                    value: snpData.variation.clinical_significance
-                });
+                    values: [snpData.variation.clinical_significance]
+                };
+
+
+
+
+                if(snpData.variation.clinical_significance === 'Pathogenic') {
+                    clinSignificance.hasLink = true;
+                    clinSignificance.linkHref = `https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsId}`;//ClinVar Link
+                    clinSignificance.linkText = '[ClinVar]';
+                }
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push(clinSignificance);
             }
             if(snpData.variation.hasOwnProperty('global_maf')) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'MAF/MinorAlleleCount',
-                    value: snpData.variation.global_maf
+                    values: [snpData.variation.global_maf]
                 });
             }
         }
         if(snpData.hasOwnProperty('maf_source')) {
             snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'MAF Source',
-                value: snpData.maf_source
+                values: [snpData.maf_source]
             });
         }
         if (variationExists && snpData.variation.hasOwnProperty('docsum')) {
@@ -98,8 +108,7 @@ export default class ngbVariantDbSnpService{
 
             snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'HGVS Names',
-                valueType: 'array',
-                value: hgvs.split(/,/)
+                values: hgvs.split(/,/)
             });
         }
 
@@ -121,31 +130,31 @@ export default class ngbVariantDbSnpService{
             if(genomeLabelExists) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Assembly',
-                    value: snpData.variation.genomeLabel
+                    values: [snpData.variation.genomeLabel]
                 });
             }
             if(chrExists) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Chr',
-                    value: snpData.variation.chr
+                    values: [snpData.variation.chr]
                 });
             }
             if(chrposExists) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Chr Pos',
-                    value: snpData.variation.chrpos
+                    values: [snpData.variation.chrpos]
                 });
             }
             if(contigLabelExists) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Contig',
-                    value: snpData.variation.contigLabel
+                    values: [snpData.variation.contigLabel]
                 });
             }
             if(contigposExists) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Contig Pos',
-                    value: snpData.variation.contigpos
+                    values: [snpData.variation.contigpos]
                 });
             }
         }
@@ -163,7 +172,7 @@ export default class ngbVariantDbSnpService{
         if (ref_seq_geneExists) {
             snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                 title: 'RefSeqGene',
-                value: snpData.ref_seq_gene
+                values: [snpData.ref_seq_gene]
             });
         }
         if (genesExists) {
@@ -178,7 +187,7 @@ export default class ngbVariantDbSnpService{
 
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'Gene (ID)',
-                    value: genesInfo
+                    values: [genesInfo]
                 });
             }
         }

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -69,21 +69,20 @@ export default class ngbVariantDbSnpService{
         }
         if (variationExists) {
             if (snpData.variation.hasOwnProperty('clinical_significance')) {
-                let clinSignificance = {
+
+                let clinicalSignificance = {
                     title: 'Clinical Significance',
                     values: [snpData.variation.clinical_significance]
                 };
 
-
-
-
-                if(snpData.variation.clinical_significance === 'Pathogenic') {
-                    clinSignificance.hasLink = true;
-                    clinSignificance.linkHref = `https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsId}`;//ClinVar Link
-                    clinSignificance.linkText = '[ClinVar]';
+                if(snpData.hasOwnProperty('clinVar') && snpData.clinVar.hasOwnProperty('clinvar_link') && snpData.clinVar.clinvar_link) {
+                    clinicalSignificance.hasLink = true;
+                    clinicalSignificance.linkHref = snpData.clinVar.clinvar_link;//ClinVar Link
+                    clinicalSignificance.linkText = '[ClinVar]';
                 }
-                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push(clinSignificance);
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push(clinicalSignificance);
             }
+
             if(snpData.variation.hasOwnProperty('global_maf')) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
                     title: 'MAF/MinorAlleleCount',
@@ -160,34 +159,35 @@ export default class ngbVariantDbSnpService{
         }
 
 
-        let ref_seq_geneExists = snpData.hasOwnProperty('ref_seq_gene'),
-            genesExists = variationExists && snpData.variation.hasOwnProperty('genes');
-        if (ref_seq_geneExists || genesExists) {
+        if (snpData.hasOwnProperty('ref_seq_gene_mapping')) {
             snpCollapsiblePanels.push({
                 title: 'RefSeq Gene Mapping',
                 isOpen: false,
                 values: []
             });
-        }
-        if (ref_seq_geneExists) {
-            snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
-                title: 'RefSeqGene',
-                values: [snpData.ref_seq_gene]
-            });
-        }
-        if (genesExists) {
-            if (snpData.variation.genes.length > 0) {
-                let genesInfo = '';
-                for (let i = 0; i < snpData.variation.genes.length; i++) {
-                    genesInfo += snpData.variation.genes[i].name + ' (' + snpData.variation.genes[i].gene_id + ')';
-                    if (!(i + 1 === snpData.variation.genes.length || snpData.variation.genes.length === 1)) {
-                        genesInfo += '; ';
-                    }
-                }
 
+            if (snpData.ref_seq_gene_mapping.hasOwnProperty('refSeqGene')) {
                 snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
-                    title: 'Gene (ID)',
-                    values: [genesInfo]
+                    title: 'RefSeqGene',
+                    values: [snpData.ref_seq_gene_mapping.refSeqGene]
+                });
+            }
+            if (snpData.ref_seq_gene_mapping.hasOwnProperty('gene')) {
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                    title: 'Gene:ID',
+                    values: [snpData.ref_seq_gene_mapping.gene]
+                });
+            }
+            if (snpData.ref_seq_gene_mapping.hasOwnProperty('position')) {
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                    title: 'Position',
+                    values: [snpData.ref_seq_gene_mapping.position]
+                });
+            }
+            if (snpData.ref_seq_gene_mapping.hasOwnProperty('allele')) {
+                snpCollapsiblePanels[snpCollapsiblePanels.length - 1].values.push({
+                    title: 'Allele',
+                    values: [snpData.ref_seq_gene_mapping.allele]
                 });
             }
         }

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -109,7 +109,7 @@ export default class ngbVariantDbSnpService{
 
             if (genomeLabelExists || chrExists || chrposExists || contigLabelExists || contigposExists) {
                 snpCollapsiblePanels.push({
-                    title: 'From table with variation location (Primary Assembly Mapping)',
+                    title: 'Primary Assembly Mapping',
                     isOpen: false,
                     values: []
                 });
@@ -152,7 +152,7 @@ export default class ngbVariantDbSnpService{
             genesExists = variationExists && snpData.variation.hasOwnProperty('genes');
         if (ref_seq_geneExists || genesExists) {
             snpCollapsiblePanels.push({
-                title: 'From table RefSeq Gene Mapping',
+                title: 'RefSeq Gene Mapping',
                 isOpen: false,
                 values: []
             });

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.service.js
@@ -20,7 +20,7 @@ export default class ngbVariantDbSnpService{
         this._dataService.getNcbiVariationInfo(rsId)
             .then(
                 (data) => {
-                    callback(this._mapVariantSnpData(data));
+                    callback(this._mapVariantSnpData(data, rsId));
                 },
                 () => {
                     errorCallback(this._constants.errorMessages.errorLoadingVariantSnpInfo);
@@ -28,13 +28,16 @@ export default class ngbVariantDbSnpService{
 
     }
 
-    _mapVariantSnpData(snpData) {
+    _mapVariantSnpData(snpData, rsId) {
         let snpCollapsiblePanels = [],
             variationExists = snpData.hasOwnProperty('variation');
 
+        let snpHref = `https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=${rsId.slice(2)}`;//Snp Link
         snpCollapsiblePanels.push({
             title: 'Summary',
             isOpen: true,
+            snpHref: snpHref,
+            rsId: rsId,
             values: []
         });
 

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
@@ -1,0 +1,35 @@
+<div flex layout="row" layout-wrap class="md-variant-properties-table">
+
+    <div flex="100" ng-show="ctrl.isLoading">
+        <div class="progress" layout-align="center center">
+            <span>Loading information...</span>
+        </div>
+        <md-progress-linear md-mode="query"></md-progress-linear>
+    </div>
+    <div flex="100" layout-fill layout-margin ng-show="ctrl.hasError" class="md-variant-info-error">
+        {{ctrl.errorMessage}}
+    </div>
+
+    <div ng-hide="ctrl.isLoading || crtl.hasError" layout="column"  layout-align="stretch middle" flex="100">
+
+        <collapsible ng-if="ctrl.variantDbSnp.snpProperties">
+            <collapsible-panel is-open="true">
+                <collapsible-panel-title>
+                    Summary
+                </collapsible-panel-title>
+                <collapsible-panel-content>
+                    <div layout="column"  layout-align="stretch middle" flex="100">
+                        <div flex="100" layout="row" layout-wrap class="property-row"
+                             ng-repeat="property in ctrl.variantDbSnp.snpProperties" ng-if="::property.title">
+                            <div flex="30" class="property property-name">{{property.title}}</div>
+                            <div flex="70" class="property property-value">{{property.value}}</div>
+                        </div>
+                    </div>
+
+                </collapsible-panel-content>
+            </collapsible-panel>
+        </collapsible>
+
+    </div>
+
+</div>

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
@@ -12,15 +12,16 @@
 
     <div ng-hide="ctrl.isLoading || crtl.hasError" layout="column"  layout-align="stretch middle" flex="100">
 
-        <collapsible ng-if="ctrl.variantDbSnp.snpProperties">
-            <collapsible-panel is-open="true">
+        <collapsible ng-if="ctrl.variantDbSnp.snpCollapsiblePanels"
+            ng-repeat="collapsible in ctrl.variantDbSnp.snpCollapsiblePanels">
+            <collapsible-panel is-open="collapsible.isOpen">
                 <collapsible-panel-title>
-                    Summary
+                    {{collapsible.title}}
                 </collapsible-panel-title>
                 <collapsible-panel-content>
                     <div layout="column"  layout-align="stretch middle" flex="100">
                         <div flex="100" layout="row" layout-wrap class="property-row"
-                             ng-repeat="property in ctrl.variantDbSnp.snpProperties" ng-if="::property.title">
+                             ng-repeat="property in collapsible.values" ng-if="::property.title">
                             <div flex="30" class="property property-name">{{property.title}}</div>
                             <div flex="70" class="property property-value">{{property.value}}</div>
                         </div>

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
@@ -23,7 +23,16 @@
                         <div flex="100" layout="row" layout-wrap class="property-row"
                              ng-repeat="property in collapsible.values" ng-if="::property.title">
                             <div flex="30" class="property property-name">{{property.title}}</div>
-                            <div flex="70" class="property property-value">{{property.value}}</div>
+                            <div flex="70" class="property property-value">
+                                <div ng-switch="property.valueType">
+                                    <div ng-switch-when="array">
+                                        <div ng-repeat="arrayVal in property.value">
+                                            <div>{{arrayVal}}</div>
+                                        </div>
+                                    </div>
+                                    <div ng-switch-default>{{property.value}}</div>
+                                </div>
+                            </div>
                         </div>
                     </div>
 

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
@@ -34,13 +34,8 @@
                              ng-repeat="property in collapsible.values" ng-if="::property.title">
                             <div flex="30" class="property property-name">{{property.title}}</div>
                             <div flex="70" class="property property-value">
-                                <div ng-switch="property.valueType">
-                                    <div ng-switch-when="array">
-                                        <div ng-repeat="arrayVal in property.value">
-                                            {{arrayVal}}
-                                        </div>
-                                    </div>
-                                    <div ng-switch-default>{{property.value}}</div>
+                                <div ng-repeat="val in property.values">
+                                    {{val}} <a ng-if="::property.hasLink" ng-href="{{property.linkHref}}">{{property.linkText}}</a>
                                 </div>
                             </div>
                         </div>

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
@@ -13,7 +13,7 @@
     <div ng-hide="ctrl.isLoading || crtl.hasError" layout="column"  layout-align="stretch middle" flex="100">
 
         <collapsible ng-if="ctrl.variantDbSnp.snpCollapsiblePanels"
-            ng-repeat="collapsible in ctrl.variantDbSnp.snpCollapsiblePanels">
+            ng-repeat="collapsible in ctrl.variantDbSnp.snpCollapsiblePanels track by $index">
             <collapsible-panel is-open="collapsible.isOpen">
                 <collapsible-panel-title>
                     {{collapsible.title}}
@@ -21,13 +21,23 @@
                 <collapsible-panel-content>
                     <div layout="column"  layout-align="stretch middle" flex="100">
                         <div flex="100" layout="row" layout-wrap class="property-row"
+                             ng-if="$index == 0 && collapsible.snpHref && collapsible.rsId">
+                            <div flex="30" class="property property-name">
+                                <a ng-href="{{collapsible.snpHref}}" target="_blank" title="SNP Database">
+                                    {{collapsible.rsId}}
+                                </a>
+                            </div>
+                            <div flex="70" class="property property-value">
+                            </div>
+                        </div>
+                        <div flex="100" layout="row" layout-wrap class="property-row"
                              ng-repeat="property in collapsible.values" ng-if="::property.title">
                             <div flex="30" class="property property-name">{{property.title}}</div>
                             <div flex="70" class="property property-value">
                                 <div ng-switch="property.valueType">
                                     <div ng-switch-when="array">
                                         <div ng-repeat="arrayVal in property.value">
-                                            <div>{{arrayVal}}</div>
+                                            {{arrayVal}}
                                         </div>
                                     </div>
                                     <div ng-switch-default>{{property.value}}</div>

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDbSnp/ngbVariantDbSnp.tpl.html
@@ -35,7 +35,7 @@
                             <div flex="30" class="property property-name">{{property.title}}</div>
                             <div flex="70" class="property property-value">
                                 <div ng-repeat="val in property.values">
-                                    {{val}} <a ng-if="::property.hasLink" ng-href="{{property.linkHref}}">{{property.linkText}}</a>
+                                    {{val}} <a ng-if="::property.hasLink" ng-href="{{property.linkHref}}" target="_blank">{{property.linkText}}</a>
                                 </div>
                             </div>
                         </div>

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDetails.constant.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDetails.constant.js
@@ -2,6 +2,7 @@ export default{
     displayModes: {common: 'common', wide: 'wide'},
     errorMessages: {
         variantAnnotationsNotFound: 'Variant annotations not found.',
-        errorLoadingVariantInfo: 'Error loading variant information.'
+        errorLoadingVariantInfo: 'Error loading variant information.',
+        errorLoadingVariantSnpInfo: 'Error loading variant information from SNP database.'
     }
 };

--- a/client/client/dataServices/externaldb/externaldb-data-service.js
+++ b/client/client/dataServices/externaldb/externaldb-data-service.js
@@ -19,6 +19,6 @@ export class ExternaldbDataService extends DataService {
     }
 
     getNcbiVariationInfo(id){
-        return this.get(`/externaldb/ncbi/variation/${id}/get`);
+        return this.get(`externaldb/ncbi/variation/${id}/get`);
     }
 }

--- a/client/client/dataServices/externaldb/externaldb-data-service.js
+++ b/client/client/dataServices/externaldb/externaldb-data-service.js
@@ -17,4 +17,8 @@ export class ExternaldbDataService extends DataService {
     getUniprotGeneInfo(id){
         return this.get(`/externaldb/uniprot/${id}/get`);
     }
+
+    getNcbiVariationInfo(id){
+        return this.get(`/externaldb/ncbi/variation/${id}/get`);
+    }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/vo/externaldb/NCBIClinVarVO.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/vo/externaldb/NCBIClinVarVO.java
@@ -52,6 +52,17 @@ public class NCBIClinVarVO {
     @JsonProperty(value = "trait_set")
     private List<NCBITraitSet> traitSet;
 
+    @JsonProperty(value = "clinvar_link")
+    private String clinvarLink;
+
+    public String getClinvarLink() {
+        return clinvarLink;
+    }
+
+    public void setClinvarLink(String clinvarLink) {
+        this.clinvarLink = clinvarLink;
+    }
+
     public NCBIClinicalSignificance getClinicalSignificance() {
         return clinicalSignificance;
     }
@@ -79,6 +90,8 @@ public class NCBIClinVarVO {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class NCBIClinicalSignificance {
 
+        public static final String PATHOGENIC = "Pathogenic";
+
         @JsonProperty(value = "description")
         private String description;
 
@@ -87,6 +100,10 @@ public class NCBIClinVarVO {
 
         @JsonProperty(value = "review_status")
         private String reviewStatus;
+
+        public boolean isPathogenic() {
+            return description.equals(PATHOGENIC);
+        }
 
         public String getDescription() {
             return description;

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/vo/externaldb/NCBIVariationVO.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/vo/externaldb/NCBIVariationVO.java
@@ -50,6 +50,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class NCBIVariationVO {
 
+    public static final String PATHOGENIC = "Pathogenic";
+
     @JsonProperty(value = "variation")
     private NCBIShortVarVO ncbiShortVar;
 
@@ -81,6 +83,10 @@ public class NCBIVariationVO {
 
     public void setNcbiTaxonomy(NCBITaxonomyVO ncbiTaxonomy) {
         this.ncbiTaxonomy = ncbiTaxonomy;
+    }
+
+    public boolean isPathogenic() {
+        return StringUtils.equals(ncbiShortVar.getClinicalSignificance(), PATHOGENIC);
     }
 
     @JsonProperty(value = "organism_summary")

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/vo/externaldb/NCBIVariationVO.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/vo/externaldb/NCBIVariationVO.java
@@ -101,10 +101,20 @@ public class NCBIVariationVO {
         return StringUtils.isNotBlank(fasta) ? regexExtract(Pattern.compile(".*alleles=\"([\\w/]+)\".*"), fasta) : null;
     }
 
-    @JsonProperty(value = "ref_seq_gene")
-    public String getRefSeqGene(){
+    @JsonProperty(value = "ref_seq_gene_mapping")
+    public RefSeqGeneMapping getRefSeqGeneMapping() {
+        RefSeqGeneMapping refSeqGeneMapping = new RefSeqGeneMapping();
         String docsum = ncbiShortVar.getHgvsNames();
-        return StringUtils.isNotBlank(docsum) ? regexExtract(Pattern.compile(".*(NG_\\d+\\.\\d+).*"), docsum) : null;
+        String info = StringUtils.isNotBlank(docsum)
+                ? regexExtract(Pattern.compile(".*(NG_\\d+\\.\\d+:g\\.\\d+\\w+).*"), docsum)
+                : null;
+        if (info != null) {
+            refSeqGeneMapping.setRefSeqGene(regexExtract(Pattern.compile(".*(NG_\\d+\\.\\d+).*"), info));
+            refSeqGeneMapping.setPosition(regexExtract(Pattern.compile(".*:g\\.(\\d+).*"), info));
+            refSeqGeneMapping.setAllele(regexExtract(Pattern.compile(".*:g\\.\\d+(\\w+).*"), info));
+            refSeqGeneMapping.setGene(regexExtract(Pattern.compile(".*GENE=(\\w+:\\d+).*"), docsum));
+        }
+        return refSeqGeneMapping;
     }
 
     @JsonProperty(value = "maf_source")
@@ -132,6 +142,53 @@ public class NCBIVariationVO {
         }
 
         return result;
+    }
+
+    public class RefSeqGeneMapping {
+
+        @JsonProperty
+        private String refSeqGene;
+
+        @JsonProperty
+        private String gene;
+
+        @JsonProperty
+        private String position;
+
+        @JsonProperty
+        private String allele;
+
+        public String getRefSeqGene() {
+            return refSeqGene;
+        }
+
+        public void setRefSeqGene(String refSeqGene) {
+            this.refSeqGene = refSeqGene;
+        }
+
+        public String getGene() {
+            return gene;
+        }
+
+        public void setGene(String gene) {
+            this.gene = gene;
+        }
+
+        public String getPosition() {
+            return position;
+        }
+
+        public void setPosition(String position) {
+            this.position = position;
+        }
+
+        public String getAllele() {
+            return allele;
+        }
+
+        public void setAllele(String allele) {
+            this.allele = allele;
+        }
     }
 }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIClinVarManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIClinVarManager.java
@@ -45,6 +45,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 @Service
 public class NCBIClinVarManager {
 
+    private static final String CLINVAR_LINK_TEMPLATE = "https://www.ncbi.nlm.nih.gov/clinvar/?term=rs%s";
+
     private JsonMapper mapper = new JsonMapper();
 
     @Autowired
@@ -61,7 +63,12 @@ public class NCBIClinVarManager {
             throws ExternalDbUnavailableException {
         try {
             JsonNode root = ncbiAuxiliaryManager.summaryEntityById(NCBIDatabase.CLINVAR.name(), id);
-            return mapper.treeToValue(root, NCBIClinVarVO.class);
+            NCBIClinVarVO ncbiClinVarVO = mapper.treeToValue(root, NCBIClinVarVO.class);
+            if (ncbiClinVarVO.getClinicalSignificance() != null
+                    && ncbiClinVarVO.getClinicalSignificance().isPathogenic()) {
+                ncbiClinVarVO.setClinvarLink(String.format(CLINVAR_LINK_TEMPLATE, id));
+            }
+            return ncbiClinVarVO;
         } catch (JsonProcessingException e) {
             throw new ExternalDbUnavailableException(getMessage(MessagesConstants
                     .ERROR_NO_RESULT_BY_EXTERNAL_DB), e);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIClinVarManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIClinVarManager.java
@@ -45,7 +45,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 @Service
 public class NCBIClinVarManager {
 
-    private static final String CLINVAR_LINK_TEMPLATE = "https://www.ncbi.nlm.nih.gov/clinvar/?term=rs%s";
+    private static final String CLINVAR_LINK_TEMPLATE = "https://www.ncbi.nlm.nih.gov/clinvar?term=rs%s";
 
     private JsonMapper mapper = new JsonMapper();
 
@@ -66,7 +66,7 @@ public class NCBIClinVarManager {
             NCBIClinVarVO ncbiClinVarVO = mapper.treeToValue(root, NCBIClinVarVO.class);
             if (ncbiClinVarVO.getClinicalSignificance() != null
                     && ncbiClinVarVO.getClinicalSignificance().isPathogenic()) {
-                ncbiClinVarVO.setClinvarLink(String.format(CLINVAR_LINK_TEMPLATE, id));
+                generateClinVarLink(id, ncbiClinVarVO);
             }
             return ncbiClinVarVO;
         } catch (JsonProcessingException e) {
@@ -74,6 +74,10 @@ public class NCBIClinVarManager {
                     .ERROR_NO_RESULT_BY_EXTERNAL_DB), e);
         }
 
+    }
+
+    public void generateClinVarLink(String id, NCBIClinVarVO ncbiClinVarVO) {
+        ncbiClinVarVO.setClinvarLink(String.format(CLINVAR_LINK_TEMPLATE, id));
     }
 
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIShortVarManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIShortVarManager.java
@@ -107,6 +107,9 @@ public class NCBIShortVarManager {
 
         if (StringUtils.isNotBlank(snp.getClinicalSignificance())) {
             NCBIClinVarVO ncbiClinVarVO = ncbiClinVarManager.fetchVariationById(id);
+            if (result.isPathogenic()) {
+                ncbiClinVarManager.generateClinVarLink(id, ncbiClinVarVO);
+            }
             result.setNcbiClinVar(ncbiClinVarVO);
         }
 

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/externaldb/NCBIShortVarManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/externaldb/NCBIShortVarManagerTest.java
@@ -159,7 +159,10 @@ public class NCBIShortVarManagerTest {
         Assert.assertEquals("APOE (348)", ncbiVariationVO.getGene());
         Assert.assertEquals("1000GENOMES", ncbiVariationVO.getMafSource());
         Assert.assertEquals("human (Homo sapiens)", ncbiVariationVO.getOrganism());
-        Assert.assertEquals("NG_007084.2", ncbiVariationVO.getRefSeqGene());
+        Assert.assertEquals("NG_007084.2", ncbiVariationVO.getRefSeqGeneMapping().getRefSeqGene());
+        Assert.assertEquals("8041", ncbiVariationVO.getRefSeqGeneMapping().getPosition());
+        Assert.assertEquals("APOE:348", ncbiVariationVO.getRefSeqGeneMapping().getGene());
+        Assert.assertEquals("C", ncbiVariationVO.getRefSeqGeneMapping().getAllele());
 
         Assert.assertNotNull(ncbiVariationVO.getNcbiTaxonomy());
     }


### PR DESCRIPTION
# Description

## Background

Fix for issue #57 

## Changes

Additional tab 'DbSNP' appeared in Variation panel if rsId in variation is specified

## Acceptance criteria

Open a variation info panel (variation's rsId should be available to see tab)

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
