### PR TITLE
Customizable fields list in vcf info table

### DIFF
--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.controller.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.controller.js
@@ -10,14 +10,16 @@ export default class ngbVariantInfoController extends ngbVariantDetailsControlle
     hasError = false;
     errorMessage = null;
     _variantInfoService = null;
+    _localDataService = null;
     _variantInfo = null;
     _scope;
 
     /* @ngInject */
-    constructor($scope, ngbVariantInfoService, vcfDataService, constants) {
+    constructor($scope, ngbVariantInfoService, vcfDataService, constants, localDataService) {
         super($scope, vcfDataService, constants);
         this._scope = $scope;
         this._variantInfoService = ngbVariantInfoService;
+        this._localDataService = localDataService;
         this.INIT();
     }
 
@@ -35,6 +37,10 @@ export default class ngbVariantInfoController extends ngbVariantDetailsControlle
             this._variantInfoService
                 .loadVariantInfo(this.variantRequest,
                     (variantInfo) => {
+                        const excludeColumns = this._localDataService.getExcludeVariantInfoColumns();
+                        variantInfo.properties.forEach((property)=>{
+                            property.selection = excludeColumns.indexOf(property.title) === -1
+                        })
                         this.variantInfo = variantInfo;
                         this.isLoading = false;
                         if (this._scope !== null && this._scope !== undefined) {
@@ -54,5 +60,12 @@ export default class ngbVariantInfoController extends ngbVariantDetailsControlle
         this.isLoading = false;
         this.hasError = true;
         this.errorMessage = message;
+    }
+
+    onVariantInfoColumnsChange(){
+        const excludeVariantInfoColumns = this.variantInfo.properties
+            .filter(property => property.selection === false)
+            .map(m => m.title);
+        this._localDataService.updateExcludeVariantInfoColumns(excludeVariantInfoColumns);
     }
 }

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.controller.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.controller.js
@@ -1,8 +1,8 @@
 import {ngbVariantDetailsController} from '../ngbVariantDetails.controller';
 
 
-export default class ngbVariantInfoController extends ngbVariantDetailsController{
-    static get UID(){
+export default class ngbVariantInfoController extends ngbVariantDetailsController {
+    static get UID() {
         return 'ngbVariantInfoController';
     }
 
@@ -23,10 +23,15 @@ export default class ngbVariantInfoController extends ngbVariantDetailsControlle
         this.INIT();
     }
 
-    get variantInfo() { return this._variantInfo; }
-    set variantInfo(info) { this._variantInfo = info; }
+    get variantInfo() {
+        return this._variantInfo;
+    }
 
-    INIT(){
+    set variantInfo(info) {
+        this._variantInfo = info;
+    }
+
+    INIT() {
         const hasVariantRequest = !(this.variantRequest === undefined || this.variantRequest === null);
 
         this.isLoading = false;
@@ -38,7 +43,7 @@ export default class ngbVariantInfoController extends ngbVariantDetailsControlle
                 .loadVariantInfo(this.variantRequest,
                     (variantInfo) => {
                         const excludeColumns = this._localDataService.getExcludeVariantInfoColumns();
-                        variantInfo.properties.forEach((property)=>{
+                        variantInfo.properties.forEach((property) => {
                             property.selection = excludeColumns.indexOf(property.title) === -1
                         })
                         this.variantInfo = variantInfo;
@@ -49,20 +54,20 @@ export default class ngbVariantInfoController extends ngbVariantDetailsControlle
                     },
                     ::this._handleError);
         }
-        else{
+        else {
             if (this._constants !== null && this._constants !== undefined)
                 this._handleError(this._constants.errorMessages.errorLoadingVariantInfo);
         }
     }
 
-    
-    _handleError(message){
+
+    _handleError(message) {
         this.isLoading = false;
         this.hasError = true;
         this.errorMessage = message;
     }
 
-    onVariantInfoColumnsChange(){
+    onVariantInfoColumnsChange() {
         const excludeVariantInfoColumns = this.variantInfo.properties
             .filter(property => property.selection === false)
             .map(m => m.title);

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.scss
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.scss
@@ -1,28 +1,29 @@
-.md-variant-info-error{
-  text-align:center;
-  color:#FF0000;
-  font-size:smaller;
+.md-variant-info-error {
+  text-align: center;
+  color: #FF0000;
+  font-size: smaller;
 }
+
 .md-variant-properties-table {
   .ui-grid, .ui-grid-render-container {
     height: auto !important;
     max-height: 200px;
   }
-  collapsible-panel-title{
-    color: rgba(0,0,0,0.87);
+  collapsible-panel-title {
+    color: rgba(0, 0, 0, 0.87);
     font-size: 15px;
     padding-left: 0;
   }
-  .table-property{
+  .table-property {
     font-size: 13px;
   }
-  .md-variant-properties-info-table{
+  .md-variant-properties-info-table {
     padding: 5px;
     > div {
       padding-top: 10px;
     }
   }
-  .md-variant-properties-collapse-label{
+  .md-variant-properties-collapse-label {
     color: #6699ff;
     border-bottom: 1px dashed #6699ff;
     cursor: pointer;
@@ -31,4 +32,3 @@
     font-size: 14px;
   }
 }
-

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.scss
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.scss
@@ -16,5 +16,19 @@
   .table-property{
     font-size: 13px;
   }
+  .md-variant-properties-info-table{
+    padding: 5px;
+    > div {
+      padding-top: 10px;
+    }
+  }
+  .md-variant-properties-collapse-label{
+    color: #6699ff;
+    border-bottom: 1px dashed #6699ff;
+    cursor: pointer;
+    outline: none;
+    width: auto;
+    font-size: 14px;
+  }
 }
 

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.tpl.html
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.tpl.html
@@ -8,7 +8,7 @@
         {{ctrl.errorMessage}}
     </div>
 
-    <div flex="100" layout="row" layout-wrap class="md-variant-properties-info">
+    <div flex="100" layout="row" layout-wrap>
         <div ng-hide="ctrl.isLoading || crtl.hasError"
              layout="row"
              ng-repeat="property in ctrl.variantInfo.properties | filter: { selection: true} | orderBy: 'title'"
@@ -33,9 +33,10 @@
             </div>
         </div>
 
-        <div ng-hide="ctrl.isLoading || crtl.hasError" class="md-variant-properties-info-table" layout-wrap flex="100" ng-init="isCollapsed=true">
+        <div ng-hide="ctrl.isLoading || crtl.hasError" class="md-variant-properties-info-table" layout-wrap flex="100"
+             ng-init="isCollapsed=true">
             <span class="md-variant-properties-collapse-label" ng-click="isCollapsed = !isCollapsed">{{isCollapsed ? 'show all' : 'collapse'}}</span>
-            <div  ng-if="!isCollapsed" flex layout="row" layout-wrap>
+            <div ng-if="!isCollapsed" flex layout="row" layout-wrap>
                 <div flex="50" layout="column" ng-repeat="property in ctrl.variantInfo.properties | orderBy: 'title'">
                     <div class="for-md-tooltip-work">
                         <md-checkbox flex

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.tpl.html
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.tpl.html
@@ -7,40 +7,63 @@
     <div flex="100" layout-fill layout-margin ng-show="ctrl.hasError" class="md-variant-info-error">
         {{ctrl.errorMessage}}
     </div>
-    <div ng-hide="ctrl.isLoading || crtl.hasError"
-         ng-repeat="property in ctrl.variantInfo.properties"
-         class="md-variant-property
-       md-variant-property-display-mode-{{property.displayMode}}
-       {{$last ? 'flex' : 'flex-' + property.flex}}">
-        <md-tooltip ng-if="property.type === 'TRIVIAL' || property.type === undefined" md-delay="500" ng-show="property.description.length > 0">{{property.description}}</md-tooltip>
 
-        <div ng-if="property.type === 'TRIVIAL' || property.type === undefined">
-            <div layout="row"
-                 layout-align="start stretch"
-                 flex>
-                <div class="md-variant-property-title" flex="50">{{property.title}}</div>
-                <div class="md-variant-property-values" layout="column" flex="50">
-                    <div ng-repeat="value in property.values track by $index"
-                         class="md-variant-property-single-value">
-                        {{value}}
+    <div flex="100" layout="row" layout-wrap class="md-variant-properties-info">
+        <div ng-hide="ctrl.isLoading || crtl.hasError"
+             layout="row"
+             ng-repeat="property in ctrl.variantInfo.properties | filter: { selection: true} | orderBy: 'title'"
+             class="md-variant-property md-variant-property-display-mode-{{property.displayMode}}
+           {{'flex-' + property.flex}}">
+            <md-tooltip ng-if="property.type === 'TRIVIAL' || property.type === undefined" md-delay="500"
+                        ng-show="property.description.length > 0">{{property.description}}
+            </md-tooltip>
+
+            <div ng-if="property.type === 'TRIVIAL' || property.type === undefined">
+                <div layout="row"
+                     layout-align="start stretch"
+                     flex>
+                    <div class="md-variant-property-title" flex="50">{{property.title}}</div>
+                    <div class="md-variant-property-values" layout="column" flex="50">
+                        <div ng-repeat="value in property.values track by $index"
+                             class="md-variant-property-single-value">
+                            {{value}}
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
 
+        <div ng-hide="ctrl.isLoading || crtl.hasError" class="md-variant-properties-info-table" layout-wrap flex="100" ng-init="isCollapsed=true">
+            <span class="md-variant-properties-collapse-label" ng-click="isCollapsed = !isCollapsed">{{isCollapsed ? 'show all' : 'collapse'}}</span>
+            <div  ng-if="!isCollapsed" flex layout="row" layout-wrap>
+                <div flex="50" layout="column" ng-repeat="property in ctrl.variantInfo.properties | orderBy: 'title'">
+                    <div class="for-md-tooltip-work">
+                        <md-checkbox flex
+                                     layout="row"
+                                     ng-model="property.selection"
+                                     ng-change="ctrl.onVariantInfoColumnsChange()">
+                            {{ property.title }}
+                            <md-tooltip class="z-index-more" md-direction="top">
+                                {{ property.description || property.title }}
+                            </md-tooltip>
+                        </md-checkbox>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <div ng-hide="ctrl.isLoading || crtl.hasError"
          ng-repeat="table in ctrl.variantInfo.tables" flex="100">
-            <collapsible flex>
-                <collapsible-panel is-open="false" tooltip="table.description">
-                    <collapsible-panel-title>{{table.title}}</collapsible-panel-title>
-                    <collapsible-panel-content>
-                        <div class="table-property" ui-grid="table.values"
-                             ui-grid-resize-columns
-                             ui-grid-auto-resize
-                             ui-grid-move-columns></div>
-                    </collapsible-panel-content>
-                </collapsible-panel>
-            </collapsible>
+        <collapsible flex>
+            <collapsible-panel is-open="false" tooltip="table.description">
+                <collapsible-panel-title>{{table.title}}</collapsible-panel-title>
+                <collapsible-panel-content>
+                    <div class="table-property" ui-grid="table.values"
+                         ui-grid-resize-columns
+                         ui-grid-auto-resize
+                         ui-grid-move-columns></div>
+                </collapsible-panel-content>
+            </collapsible-panel>
+        </collapsible>
     </div>
 </div>

--- a/client/client/constants/dev.js
+++ b/client/client/constants/dev.js
@@ -1,4 +1,4 @@
 module.exports = {
     env: 'development',
-    urlPrefix: 'http://localhost:8080/catgenome/'
+    urlPrefix: 'http://10.66.128.3:8080/catgenome/restapi/'
 };

--- a/client/client/constants/dev.js
+++ b/client/client/constants/dev.js
@@ -1,4 +1,4 @@
 module.exports = {
     env: 'development',
-    urlPrefix: 'http://10.66.128.3:8080/catgenome/restapi/'
+    urlPrefix: 'http://localhost:8080/catgenome/'
 };

--- a/client/client/dataServices/local/local-data-service.js
+++ b/client/client/dataServices/local/local-data-service.js
@@ -135,7 +135,7 @@ export default class LocalDataService {
     getExcludeVariantInfoColumns() {
         let columns = angular.fromJson(this._localStorage.excludeVariantInfoColumns);
         if (!columns) {
-           return [];
+            return [];
         }
         return columns;
     }
@@ -146,6 +146,7 @@ export default class LocalDataService {
                 .toString(16)
                 .substring(1);
         }
+
         return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
             s4() + '-' + s4() + s4() + s4();
     }

--- a/client/client/dataServices/local/local-data-service.js
+++ b/client/client/dataServices/local/local-data-service.js
@@ -128,6 +128,18 @@ export default class LocalDataService {
         }
     }
 
+    updateExcludeVariantInfoColumns(columns) {
+        this._localStorage.excludeVariantInfoColumns = angular.toJson(columns);
+    }
+
+    getExcludeVariantInfoColumns() {
+        let columns = angular.fromJson(this._localStorage.excludeVariantInfoColumns);
+        if (!columns) {
+           return [];
+        }
+        return columns;
+    }
+
     static newUUUID() {
         function s4() {
             return Math.floor((1 + Math.random()) * 0x10000)


### PR DESCRIPTION
# Description

## Background

Fix for issue #60

## Changes

Added ability to select displayable fields in VCF info table.
Unchecked fields remain in the Local Storage.

## Acceptance criteria

Open VCF info.
You can see the new link 'show all'. 
![image](https://user-images.githubusercontent.com/31283705/30959384-9ef1d8b6-a448-11e7-884a-1be8562ff0c7.png)
You can uncheck/check fields.
Unchecked fields will not display for all vcf tracks.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
