### PR TITLE
Transcript fetch won't fail if any of entries isn't found in Uniprot DB

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -1083,10 +1083,14 @@ public class GffManager {
         final List<Transcript> transcriptList = ExtenalDBUtils.ensemblEntryVO2Transcript(vo);
         for (Transcript transcript : transcriptList) {
             if (transcript.getBioType().equals(PROTEIN_CODING)) {
-                final Uniprot un = uniprotDataManager.fetchUniprotEntry(transcript.getId());
-                ExtenalDBUtils.fillDomain(un, transcript);
-                ExtenalDBUtils.fillPBP(un, transcript);
-                ExtenalDBUtils.fillSecondaryStructure(un, transcript);
+                try {
+                    final Uniprot un = uniprotDataManager.fetchUniprotEntry(transcript.getId());
+                    ExtenalDBUtils.fillDomain(un, transcript);
+                    ExtenalDBUtils.fillPBP(un, transcript);
+                    ExtenalDBUtils.fillSecondaryStructure(un, transcript);
+                } catch (ExternalDbUnavailableException e) {
+                    LOGGER.debug(e.getMessage(), e);
+                }
             }
         }
         return transcriptList;


### PR DESCRIPTION
# Description

## Background

In order to build SV visualization we fetch the transcripts data from Ensembl and then for each transcript query Uniprot. If transcript isn't found in Uniprot transcript processing stops with exception. If such exception occurs at first transcript entry, we won't get any data for visualization at all.

## Changes

If Uniprot entry for a transcript isn't found or any exception occurs, we proceed with the next transcript.

## Acceptance criteria

Check that SV visualization for ALK gene is built correctly.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
