### PR TITLE
Show full file name on a track header #93

### DIFF
--- a/client/client/app/components/ngbTracksView/ngbTrack/ngbTrack.tpl.html
+++ b/client/client/app/components/ngbTracksView/ngbTrack/ngbTrack.tpl.html
@@ -15,7 +15,11 @@
             ng-class="{'collapsed': !ctrl.showTracksHeaders }">
 
         <div class="ngb-track-header-type">{{ctrl.track.format}}</div>
-        <div class="ngb-track-header-file-name">{{ctrl.trackNameTruncated}}</div>
+        <div class="ngb-track-header-file-name">{{ctrl.trackNameTruncated}}
+            <md-tooltip md-direction="top">
+                {{ctrl.track.prettyName || ctrl.track.name}}
+            </md-tooltip>
+        </div>
 
         <ngb-track-settings
                 dnd-nodrag


### PR DESCRIPTION
# Description

## Background

Fix for issue #93 

## Changes

Added a tooltip with a full file name when hovering it

## Acceptance criteria

Users see the full file name when they mouse over the track name on a track header.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
