### PR TITLE
Fixed text strings overlap

### DIFF
--- a/client/client/app/assets/scss/md-components/md-list.scss
+++ b/client/client/app/assets/scss/md-components/md-list.scss
@@ -23,8 +23,10 @@ md-list.md-dense {
       &__sm {
         font-size: $caption-font-size-base;
         min-height: 18px;
-        height: 18px;
         padding: 0;
+      }
+      &__sm::before {
+        min-height: 18px;
       }
 
       &__nospace {

--- a/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfo/ngbProjectSummary/ngbProjectSummary.scss
+++ b/client/client/app/components/ngbProjectInfoPanel/ngbProjectInfo/ngbProjectSummary/ngbProjectSummary.scss
@@ -18,4 +18,8 @@ ngb-project-summary {
   .project-summary-layout {
     height:100%;
   }
+
+  md-list-item {
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
# Description

## Background

Fix for issue #100 

## Changes

Names of files overlap when their length more than width of rectangle on main panel in case of multi BAM/VCF selection was fixed

## Acceptance criteria

Open files with names longer than width of rectangle on main panel in case of multi BAM/VCF selection

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
