### PR TITLE
.seg file "jumps" when dragging the track and Seg data invisible after session sharing

### DIFF
--- a/client/client/modules/render/core/track/cachedTrack/cachedTrackRenderer.js
+++ b/client/client/modules/render/core/track/cachedTrack/cachedTrackRenderer.js
@@ -24,6 +24,13 @@ export default class CachedTrackRenderer{
     get viewport() { return this._viewport; }
 
     render(viewport, cache, forseRedraw = false, _gffShowNumbersAminoacid, _showCenterLine){
+        this.renderCenterLine(viewport, {
+            config: this._config,
+            graphics: this._centerLineGraphics,
+            height: this._height,
+            shouldRender: _showCenterLine
+        });
+
         if (cache === null || cache === undefined || cache.viewport === undefined)
             return;
         const factor = viewport.factor / cache.viewport.factor;
@@ -40,12 +47,6 @@ export default class CachedTrackRenderer{
             this.containerIsReady = true;
             cache.isNew = false;
         }
-        this.renderCenterLine(viewport, {
-            config: this._config,
-            graphics: this._centerLineGraphics,
-            height: this._height,
-            shouldRender: _showCenterLine
-        });
     }
 
     translateContainer(viewport, cache){

--- a/client/client/modules/render/tracks/seg/index.js
+++ b/client/client/modules/render/tracks/seg/index.js
@@ -71,8 +71,8 @@ export class SEGTrack extends CachedTrack {
     }
 
     onScroll({delta}) {
-        this._renderer.scroll(this.viewport, delta);
         this.tooltip.hide();
+        this._renderer.scroll(this.viewport, delta);
         this.updateScene();
     }
 

--- a/client/client/modules/render/tracks/seg/segRenderer.js
+++ b/client/client/modules/render/tracks/seg/segRenderer.js
@@ -72,18 +72,7 @@ export default class SegRenderer extends CachedTrackRenderer {
         const showCenterLineChanged = this._showCenterLine !== _showCenterLine;
         this._showCenterLine = _showCenterLine;
         const isRedraw = showCenterLineChanged;
-        if (!isRedraw && heightChanged) {
-            this.scroll(viewport, 0);
-            this.renderCenterLine(viewport, {
-                config: this._config,
-                graphics: this._centerLineGraphics,
-                height: this._height,
-                shouldRender: _showCenterLine
-            });
-        }
-        else {
-            super.render(viewport, cache, isRedraw, null, _showCenterLine);
-        }
+        super.render(viewport, cache, isRedraw, null, _showCenterLine);
     }
 
     rebuildContainer(viewport, cache) {


### PR DESCRIPTION
Seg data invisible after session sharing #103

# Description

## Background

Fix for issues #102 and #103 

## Changes

Updated: seg tack rendering 
Updated: center line rendering for all tracks

## Acceptance criteria

1. Open the .seg file
2. Select the chromosome
3. Zoom in to view 15-45 mbp on the screen
4. Find the region been written in .seg file
5. Drag the track to the left or to the right
6. Seg track moves smoothly
7. Copy either the full session URL or the session URL alias to clipboard
8. Paste the URL to the new tab
9. Seg track data is visible

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
