### PR TITLE
Support for VCF files as annotations

### DIFF
--- a/docs/md/cli/command-reference.md
+++ b/docs/md/cli/command-reference.md
@@ -175,8 +175,8 @@ ngb add_ann|an [<REFERENCE_NAME|REFERENCE_ID>] [<FILE_NAMES|FILE_IDS|FILE_PATHS>
 ```
 *Description*
 
-Adds an annotation (GFF, GTF, BED) file to the reference on NGB server. Reference file can be addressed by name or an identifier (retrieved from **reg_ref** command, at registration time or search command).
-If annotation file is already registered on NGb server, it can be addressed by name or by an identifier. Otherwise a path to the annotation file should be provided.
+Adds an annotation (GFF, GTF, BED, VCF) file to the reference on NGB server. Reference file can be addressed by name or an identifier (retrieved from **reg_ref** command, at registration time or search command).
+If annotation file is already registered on NGB server, it can be addressed by name or by an identifier. Otherwise a path to the annotation file should be provided.
 
 *Example*
 ```
@@ -197,7 +197,7 @@ ngb remove_ann|ran [<REFERENCE_NAME|REFERENCE_ID>] [<FILE_NAMES|FILE_IDS|FILE_PA
 ```
 *Description*
 
-Removes an annotation (GFF, GTF, BED) file from the reference on NGB server. Reference file can be addressed by name or an identifier (retrieved from **reg_ref** command, at registration time or search command).
+Removes an annotation (GFF, GTF, BED, VCF) file from the reference on NGB server. Reference file can be addressed by name or an identifier (retrieved from **reg_ref** command, at registration time or search command).
 Annotation file can be addressed by name or by an identifier.
 
 *Example*

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
@@ -30,8 +30,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.epam.catgenome.entity.BaseEntity;
@@ -84,6 +86,13 @@ public class ReferenceGenomeManager {
 
     @Autowired
     private FeatureIndexManager featureIndexManager;
+
+    private static final Set<BiologicalDataItemFormat> ANNOTATION_FORMATS = new HashSet<>();
+    static {
+        ANNOTATION_FORMATS.add(BiologicalDataItemFormat.BED);
+        ANNOTATION_FORMATS.add(BiologicalDataItemFormat.VCF);
+        ANNOTATION_FORMATS.add(BiologicalDataItemFormat.GENE);
+    }
 
     /**
      * Generates and returns ID value, that has to be used to identify each certain reference
@@ -390,9 +399,7 @@ public class ReferenceGenomeManager {
         );
 
         BiologicalDataItem annotationFile = annotationFiles.get(0);
-        Assert.isTrue(
-                annotationFile.getFormat() == BiologicalDataItemFormat.BED
-                        || annotationFile.getFormat() == BiologicalDataItemFormat.GENE,
+        Assert.isTrue(ANNOTATION_FORMATS.contains(annotationFile.getFormat()),
                 getMessage(MessagesConstants.ERROR_ILLEGAL_FEATURE_FILE_FORMAT, annotationFile.getPath())
         );
         return (FeatureFile) annotationFile;

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/bed/BedManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/bed/BedManagerTest.java
@@ -295,12 +295,7 @@ public class BedManagerTest extends AbstractManagerTest {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testDeleteBedWithIndex() throws IOException, InterruptedException, FeatureIndexException {
         Resource resource = context.getResource(GENES_SORTED_BED_PATH);
-
-        FeatureIndexedFileRegistrationRequest request = new FeatureIndexedFileRegistrationRequest();
-        request.setReferenceId(referenceId);
-        request.setPath(resource.getFile().getAbsolutePath());
-
-        BedFile bedFile = bedManager.registerBed(request);
+        BedFile bedFile = registerTestBed(resource, referenceId, bedManager);
         Assert.assertNotNull(bedFile);
         Assert.assertNotNull(bedFile.getId());
         try {
@@ -312,6 +307,15 @@ public class BedManagerTest extends AbstractManagerTest {
             referenceGenomeManager.updateReferenceAnnotationFile(referenceId, bedFile.getBioDataItemId(), true);
             bedFileManager.deleteBedFile(bedFile);
         }
+    }
+
+    public static BedFile registerTestBed(Resource bedFile, Long referenceId, BedManager bedManager)
+            throws IOException {
+        FeatureIndexedFileRegistrationRequest request = new FeatureIndexedFileRegistrationRequest();
+        request.setReferenceId(referenceId);
+        request.setPath(bedFile.getFile().getAbsolutePath());
+
+        return bedManager.registerBed(request);
     }
 
     private void testRegisterInvalidBed(String path, String expectedMessage) throws IOException {

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/reference/ReferenceGenomeManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/reference/ReferenceGenomeManagerTest.java
@@ -2,11 +2,19 @@ package com.epam.catgenome.manager.reference;
 
 import com.epam.catgenome.common.AbstractManagerTest;
 import com.epam.catgenome.controller.vo.registration.FeatureIndexedFileRegistrationRequest;
+import com.epam.catgenome.entity.BiologicalDataItem;
+import com.epam.catgenome.entity.bed.BedFile;
 import com.epam.catgenome.entity.gene.GeneFile;
 import com.epam.catgenome.entity.reference.Chromosome;
 import com.epam.catgenome.entity.reference.Reference;
+import com.epam.catgenome.entity.vcf.VcfFile;
+import com.epam.catgenome.exception.FeatureIndexException;
 import com.epam.catgenome.helper.EntityHelper;
+import com.epam.catgenome.manager.bed.BedManager;
+import com.epam.catgenome.manager.bed.BedManagerTest;
 import com.epam.catgenome.manager.gene.GffManager;
+import com.epam.catgenome.manager.vcf.VcfManager;
+import com.epam.catgenome.manager.vcf.VcfManagerTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,12 +27,16 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class ReferenceGenomeManagerTest extends AbstractManagerTest {
     private static final String CLASSPATH_TEMPLATES_GENES_SORTED = "classpath:templates/genes_sorted.gtf";
+    private static final String GENES_SORTED_BED_PATH = "classpath:templates/genes_sorted.bed";
+    private static final String CLASSPATH_TEMPLATES_FELIS_CATUS_VCF = "classpath:templates/Felis_catus.vcf";
     private static final int TEST_CHROMOSOME_SIZE = 239107476;
 
     @Autowired
@@ -34,11 +46,79 @@ public class ReferenceGenomeManagerTest extends AbstractManagerTest {
     private GffManager gffManager;
 
     @Autowired
+    private BedManager bedManager;
+
+    @Autowired
+    private VcfManager vcfManager;
+
+    @Autowired
     private ApplicationContext context;
 
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testLoadAllReferenceGenomes() throws IOException {
+        registerTestReference();
+
+        Reference g38 = EntityHelper.createG38Reference(referenceGenomeManager.createReferenceId());
+        referenceGenomeManager.register(g38);
+
+        List<Reference> loaded = referenceGenomeManager.loadAllReferenceGenomes();
+        Assert.assertFalse(loaded.isEmpty());
+        Assert.assertEquals(1, loaded.stream().filter(r -> r.getGeneFile() != null &&
+                r.getGeneFile().getId() != null &&
+                r.getGeneFile().getName() != null).count());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void testAddAnnotationFiles() throws IOException, FeatureIndexException {
+        Reference testReference = registerTestReference();
+        List<BiologicalDataItem> emptyAnnotations =
+                referenceGenomeManager.getReferenceAnnotationFiles(testReference.getId());
+        Assert.assertTrue(emptyAnnotations.isEmpty());
+
+        Set<BiologicalDataItem> expectedAnnotations = new HashSet<>();
+
+        //add bed
+        Resource bedFileResource = context.getResource(GENES_SORTED_BED_PATH);
+        BedFile bedFile =
+                BedManagerTest.registerTestBed(bedFileResource, testReference.getId(), bedManager);
+        expectedAnnotations.add(bedFile);
+        referenceGenomeManager.updateReferenceAnnotationFile(testReference.getId(),
+                bedFile.getBioDataItemId(), false);
+        List<BiologicalDataItem> actualAnnotations =
+                referenceGenomeManager.getReferenceAnnotationFiles(testReference.getId());
+        checkAnnotationPresent(expectedAnnotations, actualAnnotations);
+
+        //add vcf
+        Resource vcfFileResource = context.getResource(CLASSPATH_TEMPLATES_FELIS_CATUS_VCF);
+        VcfFile vcfFile = VcfManagerTest.registerVcf(vcfFileResource, testReference.getId(), vcfManager,
+                null);
+        referenceGenomeManager.updateReferenceAnnotationFile(testReference.getId(),
+                vcfFile.getBioDataItemId(), false);
+        expectedAnnotations.add(vcfFile);
+        actualAnnotations =
+                referenceGenomeManager.getReferenceAnnotationFiles(testReference.getId());
+        checkAnnotationPresent(expectedAnnotations, actualAnnotations);
+
+        //remove vcf
+        referenceGenomeManager.updateReferenceAnnotationFile(testReference.getId(),
+                vcfFile.getBioDataItemId(), true);
+        expectedAnnotations.remove(vcfFile);
+        actualAnnotations =
+                referenceGenomeManager.getReferenceAnnotationFiles(testReference.getId());
+        checkAnnotationPresent(expectedAnnotations, actualAnnotations);
+    }
+
+    private void checkAnnotationPresent(Set<BiologicalDataItem> expectedAnnotations,
+            List<BiologicalDataItem> actualAnnotations) {
+        Assert.assertEquals(expectedAnnotations.size(), actualAnnotations.size());
+        actualAnnotations.forEach(annFile -> {
+            Assert.assertTrue(expectedAnnotations.contains(annFile));
+        });
+    }
+
+    private Reference registerTestReference() throws IOException {
         Chromosome testChromosome = EntityHelper.createNewChromosome();
         testChromosome.setSize(TEST_CHROMOSOME_SIZE);
         Reference testReference = EntityHelper.createNewReference(testChromosome,
@@ -56,14 +136,6 @@ public class ReferenceGenomeManagerTest extends AbstractManagerTest {
         GeneFile testGeneFile = gffManager.registerGeneFile(request);
 
         referenceGenomeManager.updateReferenceGeneFileId(testReference.getId(), testGeneFile.getId());
-
-        Reference g38 = EntityHelper.createG38Reference(referenceGenomeManager.createReferenceId());
-        referenceGenomeManager.register(g38);
-
-        List<Reference> loaded = referenceGenomeManager.loadAllReferenceGenomes();
-        Assert.assertFalse(loaded.isEmpty());
-        Assert.assertEquals(1, loaded.stream().filter(r -> r.getGeneFile() != null &&
-                r.getGeneFile().getId() != null &&
-                r.getGeneFile().getName() != null).count());
+        return testReference;
     }
 }

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
@@ -888,11 +888,7 @@ public class VcfManagerTest extends AbstractManagerTest {
 
     private VcfFile testSave(String filePath) throws IOException, InterruptedException {
         Resource resource = context.getResource(filePath);
-        FeatureIndexedFileRegistrationRequest request = new FeatureIndexedFileRegistrationRequest();
-        request.setReferenceId(referenceId);
-        request.setPath(resource.getFile().getAbsolutePath());
-        request.setPrettyName(PRETTY_NAME);
-        return vcfManager.registerVcfFile(request);
+        return registerVcf(resource, referenceId, vcfManager, PRETTY_NAME);
     }
 
     private Track<Variation> testLoad(VcfFile vcfFile, Double scaleFactor, boolean checkBlocks)
@@ -996,6 +992,15 @@ public class VcfManagerTest extends AbstractManagerTest {
         }
         //check that we received an appropriate message
         Assert.assertTrue(errorMessage.contains(expectedMessage));
+    }
+
+    public static VcfFile registerVcf(Resource vcfFile, Long referenceId, VcfManager vcfManager,
+            String prettyName) throws IOException {
+        FeatureIndexedFileRegistrationRequest request = new FeatureIndexedFileRegistrationRequest();
+        request.setReferenceId(referenceId);
+        request.setPath(vcfFile.getFile().getAbsolutePath());
+        request.setPrettyName(prettyName);
+        return vcfManager.registerVcfFile(request);
     }
 
 }


### PR DESCRIPTION
# Description
Support for  VCF files as genomic annotations 
#118

## Background
This PR enables attaching VCF files as annotations to reference genomes using ngb-cli "add_ann|an" command
## Changes
API method for adding annotation files now accepts GFF, GTF, BED and VCF files

## Acceptance 

- register reference file
- attach annotation: "ngb add_ann ref_name /path/to/file.vcf"
- on UI open dropdown menu for annotation files and ensure, that vcf file is present

# Check list

- [x] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [x] Documentation is updated
