### PR TITLE
Support for AWS S3 URI enabled for tracks from URL

### DIFF
--- a/server/catgenome/build.gradle
+++ b/server/catgenome/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     // Flyway database migration to update embedded database when application starts
     compile group: "org.flywaydb", name: "flyway-core", version: "3.2.1"
     //Amazon s3
-    compile group: "com.amazonaws", name: "aws-java-sdk-s3", version: "1.10.51"
+    compile group: "com.amazonaws", name: "aws-java-sdk-s3", version: "1.11.128"
 
     compile 'commons-fileupload:commons-fileupload:1.3.1'
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/exception/S3ReadingException.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/exception/S3ReadingException.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 EPAM Systems
+ * Copyright (c) 2017 EPAM Systems
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,30 +24,9 @@
 
 package com.epam.catgenome.exception;
 
-import java.io.IOException;
+public class S3ReadingException extends RuntimeException {
 
-import com.epam.catgenome.component.MessageHelper;
-import com.epam.catgenome.constant.MessagesConstants;
-
-/**
- * Source:      FeatureReadingException
- * Created:     02.03.16, 15:05
- * Project:     CATGenome Browser
- * Make:        IntelliJ IDEA 14.1.4, JDK 1.8
- *
- * <p>
- * A custom exception, indicating that error occurred while reading FeatureFile. A superclass of VcfReadingException
- * and GeneReadingException
- * </p>
- */
-public class FeatureFileReadingException extends IOException {
-
-    public FeatureFileReadingException(Long id, Throwable cause) {
-        super(MessageHelper.getMessage(MessagesConstants.ERROR_FEATURE_FILE_READING, id), cause);
+    public S3ReadingException(String path, Throwable cause) {
+        super(String.format("Failed to read s3 path: '%s'", path), cause);
     }
-
-    public FeatureFileReadingException(String path, Throwable cause) {
-        super(MessageHelper.getMessage(MessagesConstants.ERROR_FEATURE_FILE_READING, path), cause);
-    }
-
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
@@ -98,6 +98,7 @@ import com.epam.catgenome.util.IndexUtils;
 import com.epam.catgenome.util.NgbFileUtils;
 import com.epam.catgenome.util.PositionalOutputStream;
 import com.epam.catgenome.util.Utils;
+import com.epam.catgenome.util.feature.reader.AbstractEnhancedFeatureReader;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import htsjdk.samtools.util.BlockCompressedInputStream;
@@ -689,12 +690,14 @@ public class FileManager {
             Assert.isTrue(indexFile.exists(), getMessage(MessagesConstants.ERROR_FILE_NOT_FOUND,
                                                          vcfFile.getIndex().getPath()));
             time1 = Utils.getSystemTimeMilliseconds();
-            reader = AbstractFeatureReader.getFeatureReader(vcfFile.getPath(), vcfFile.getIndex().getPath(),
+            reader = AbstractEnhancedFeatureReader
+                    .getFeatureReader(vcfFile.getPath(), vcfFile.getIndex().getPath(),
                                                             new VCFCodec(), true);
             time2 = Utils.getSystemTimeMilliseconds();
         } else {
             time1 = Utils.getSystemTimeMilliseconds();
-            reader = AbstractFeatureReader.getFeatureReader(vcfFile.getPath(), new VCFCodec(), false);
+            reader = AbstractEnhancedFeatureReader
+                    .getFeatureReader(vcfFile.getPath(), new VCFCodec(), false);
             time2 = Utils.getSystemTimeMilliseconds();
         }
         LOGGER.debug(getMessage(MessagesConstants.DEBUG_FILE_OPENING, vcfFile.getPath(), time2 - time1));
@@ -1172,7 +1175,7 @@ public class FileManager {
         Assert.notNull(extension, getMessage(MessagesConstants.ERROR_UNSUPPORTED_GENE_FILE_EXTESION));
 
         AsciiFeatureCodec<GeneFeature> codec = new GffCodec(GffCodec.GffType.forExt(extension));
-        return AbstractFeatureReader.getFeatureReader(path, index, codec, useIndex);
+        return AbstractEnhancedFeatureReader.getFeatureReader(path, index, codec, useIndex);
     }
 
     /**
@@ -1556,7 +1559,7 @@ public class FileManager {
      */
     public AbstractFeatureReader<NggbBedFeature, LineIterator> makeBedReader(final BedFile bedFile) {
         NggbBedCodec nggbBedCodec = new NggbBedCodec();
-        return AbstractFeatureReader.getFeatureReader(bedFile.getPath(), bedFile.getIndex().getPath(),
+        return AbstractEnhancedFeatureReader.getFeatureReader(bedFile.getPath(), bedFile.getIndex().getPath(),
                 nggbBedCodec, true);
     }
 
@@ -1595,10 +1598,11 @@ public class FileManager {
     public AbstractFeatureReader<SegFeature, LineIterator> makeSegReader(final SegFile segFile) {
         SegCodec segCodec = new SegCodec();
         if (segFile.getIndex() != null) {
-            return AbstractFeatureReader.getFeatureReader(segFile.getPath(), segFile.getIndex().getPath(), segCodec,
+            return AbstractEnhancedFeatureReader
+                    .getFeatureReader(segFile.getPath(), segFile.getIndex().getPath(), segCodec,
                     true);
         } else {
-            return AbstractFeatureReader.getFeatureReader(segFile.getPath(), segCodec, false);
+            return AbstractEnhancedFeatureReader.getFeatureReader(segFile.getPath(), segCodec, false);
         }
     }
 
@@ -1697,10 +1701,11 @@ public class FileManager {
     public AbstractFeatureReader<MafFeature, LineIterator> makeMafReader(final MafFile mafFile) {
         MafCodec mafCodec = new MafCodec(mafFile.getPath());
         if (mafFile.getIndex() != null) {
-            return AbstractFeatureReader.getFeatureReader(mafFile.getPath(), mafFile.getIndex().getPath(), mafCodec,
+            return AbstractEnhancedFeatureReader
+                    .getFeatureReader(mafFile.getPath(), mafFile.getIndex().getPath(), mafCodec,
                     true);
         } else {
-            return AbstractFeatureReader.getFeatureReader(mafFile.getPath(), mafCodec, false);
+            return AbstractEnhancedFeatureReader.getFeatureReader(mafFile.getPath(), mafCodec, false);
         }
     }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamManager.java
@@ -222,7 +222,7 @@ public class BamManager {
         if (query.getId() != null) {
             bamFile= bamFileManager.loadBamFile(query.getId());
         } else {
-            bamFile = bamHelper.makeUrlBamFile(fileUrl, indexUrl, chromosome.getReferenceId());
+            bamFile = bamHelper.makeUrlBamFile(fileUrl, indexUrl, chromosome);
         }
         return getReadFromBamFile(query, chromosome, bamFile);
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.epam.catgenome.util.feature.reader.AbstractEnhancedFeatureReader;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -557,7 +558,8 @@ public class BedManager {
         try {
             fileManager.deleteFileFeatureIndex(bedFile);
             try (AbstractFeatureReader<BEDFeature, LineIterator> reader =
-                         AbstractFeatureReader.getFeatureReader(bedFile.getPath(), new BEDCodec(), false)) {
+                    AbstractEnhancedFeatureReader
+                                 .getFeatureReader(bedFile.getPath(), new BEDCodec(), false)) {
                 featureIndexManager.makeIndexForBedReader(bedFile, reader, chromosomeMap);
             }
         } catch (IOException e) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -48,6 +48,7 @@ import com.epam.catgenome.exception.HistogramReadingException;
 import com.epam.catgenome.exception.HistogramWritingException;
 import com.epam.catgenome.exception.RegistrationException;
 import com.epam.catgenome.manager.gene.parser.GffCodec;
+import com.epam.catgenome.util.feature.reader.AbstractEnhancedFeatureReader;
 import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.FeatureReader;
 import org.apache.commons.collections4.CollectionUtils;
@@ -309,7 +310,7 @@ public class GffManager {
         GffCodec.GffType gffType = GffCodec.GffType.forExt(extension);
         AsciiFeatureCodec<GeneFeature> codec = new GffCodec(gffType);
 
-        try (FeatureReader<GeneFeature> reader = AbstractFeatureReader.getFeatureReader(request.getPath(),
+        try (FeatureReader<GeneFeature> reader = AbstractEnhancedFeatureReader.getFeatureReader(request.getPath(),
                 request.getIndexPath(), codec, true)) {
             geneFile = createGeneFile(request);
             boolean hasGenes = false;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/reader/VcfFileReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/reader/VcfFileReader.java
@@ -35,6 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.epam.catgenome.util.feature.reader.AbstractEnhancedFeatureReader;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
@@ -60,7 +61,6 @@ import com.epam.catgenome.manager.FileManager;
 import com.epam.catgenome.manager.reference.ReferenceGenomeManager;
 import com.epam.catgenome.util.Utils;
 import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.Genotype;
@@ -112,7 +112,7 @@ public class VcfFileReader extends AbstractVcfReader {
     public Track<Variation> readVariations(VcfFile vcfFile, final Track<Variation> track, Chromosome chromosome,
                                            final Integer sampleIndex, final boolean loadInfo, final boolean collapse)
             throws VcfReadingException {
-        try (FeatureReader<VariantContext> reader = AbstractFeatureReader.getFeatureReader(vcfFile.getPath(),
+        try (FeatureReader<VariantContext> reader = AbstractEnhancedFeatureReader.getFeatureReader(vcfFile.getPath(),
                 vcfFile.getIndex().getPath(), new VCFCodec(), true)) {
             if (checkBounds(vcfFile, track, chromosome, loadInfo)) {
                 return track;
@@ -136,7 +136,7 @@ public class VcfFileReader extends AbstractVcfReader {
         if (isOutOfBounds(fromPosition, forward, end)) { // no next features
             return null;
         }
-        try (FeatureReader<VariantContext> reader = AbstractFeatureReader.getFeatureReader(vcfFile.getPath(),
+        try (FeatureReader<VariantContext> reader = AbstractEnhancedFeatureReader.getFeatureReader(vcfFile.getPath(),
                 vcfFile.getIndex().getPath(), new VCFCodec(), true)) {
             return readNextOrPreviousVariation(fromPosition, vcfFile, sampleIndex, chromosome,
                     forward, end, reader);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/reader/BedGraphReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/reader/BedGraphReader.java
@@ -24,7 +24,7 @@
 
 package com.epam.catgenome.manager.wig.reader;
 
-import htsjdk.tribble.AbstractFeatureReader;
+import com.epam.catgenome.util.feature.reader.AbstractEnhancedFeatureReader;
 import htsjdk.tribble.FeatureReader;
 
 import java.io.Closeable;
@@ -39,7 +39,7 @@ public class BedGraphReader implements Closeable {
     private FeatureReader<BedGraphFeature> reader;
 
     public BedGraphReader(String wigFile, String index) {
-        reader = AbstractFeatureReader.getFeatureReader(
+        reader = AbstractEnhancedFeatureReader.getFeatureReader(
                 wigFile,
                 index,
                 new BedGraphCodec(),

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/Utils.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/Utils.java
@@ -28,31 +28,31 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import com.epam.catgenome.entity.BaseEntity;
-import com.epam.catgenome.entity.reference.Reference;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.epam.catgenome.constant.Constants;
+import com.epam.catgenome.entity.BaseEntity;
 import com.epam.catgenome.entity.BiologicalDataItem;
 import com.epam.catgenome.entity.BiologicalDataItemResourceType;
 import com.epam.catgenome.entity.FeatureFile;
 import com.epam.catgenome.entity.reference.Chromosome;
+import com.epam.catgenome.entity.reference.Reference;
 import com.epam.catgenome.entity.track.Block;
 import com.epam.catgenome.entity.track.Track;
+import com.epam.catgenome.util.aws.S3Manager;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.LineIterator;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.time.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Source:      Utils.java
@@ -70,6 +70,9 @@ public final class Utils {
     private static final int RESULT_HASH_SIZE = 6;
     private static final String DELIMITER = "/";
     private static final String GZ_EXTENSION = ".gz";
+    private static final String S3_SCHEME = "s3://";
+    //in minutes
+    private static final int S3_LINK_EXPIRATION = 60;
 
     private Utils() {
         // no operations by default
@@ -106,7 +109,7 @@ public final class Utils {
      * @return a {@link Date} object, representing time for S3 URL access
      */
     public static Date getTimeForS3URL() {
-        return new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
+        return DateUtils.addMinutes(new Date(), S3_LINK_EXPIRATION);
     }
 
     /**
@@ -384,16 +387,23 @@ public final class Utils {
             InvocationTargetException e) {
             throw new InvocationTargetException(e, "Cannot instantiate object of class " + c);
         }
-        notRegisteredFile.setPath(fileUrl);
+        notRegisteredFile.setPath(processUrl(fileUrl));
         notRegisteredFile.setCompressed(false);
         notRegisteredFile.setType(BiologicalDataItemResourceType.URL);
         notRegisteredFile.setReferenceId(chromosome.getReferenceId());
 
         BiologicalDataItem index = new BiologicalDataItem();
-        index.setPath(indexUrl);
+        index.setType(BiologicalDataItemResourceType.URL);
+        index.setPath(processUrl(indexUrl));
         notRegisteredFile.setIndex(index);
-
         return notRegisteredFile;
+    }
+
+    public static String processUrl(String inputUrl) {
+        if (!inputUrl.startsWith(S3_SCHEME)) {
+            return inputUrl;
+        }
+        return new S3Manager().generateSingedUrl(inputUrl);
     }
 
     public static Map<String, Chromosome> makeChromosomeMap(Reference reference) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/aws/S3Manager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/aws/S3Manager.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+package com.epam.catgenome.util.aws;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.epam.catgenome.exception.S3ReadingException;
+import com.epam.catgenome.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for work with AWS S3 buckets
+ */
+public class S3Manager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3Manager.class);
+    private static final String DELIMITER = "/";
+
+    public String generateSingedUrl(String inputUrl) {
+        try  {
+            AmazonS3 client = getClient();
+            URI parsedUrl = new URI(inputUrl);
+            URL url = client.generatePresignedUrl(parsedUrl.getHost(),
+                    normalizePath(parsedUrl.getPath()), Utils.getTimeForS3URL());
+            return url.toExternalForm();
+        } catch (AmazonClientException | URISyntaxException e) {
+            LOGGER.error(e.getMessage(), e);
+            throw new S3ReadingException(inputUrl, e);
+        }
+    }
+
+    private String normalizePath(String path) {
+        if (path.startsWith(DELIMITER)) {
+            return path.substring(1);
+        } else {
+            return path;
+        }
+    }
+
+    AmazonS3 getClient() {
+        return AmazonS3ClientBuilder.defaultClient();
+    }
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/AbstractEnhancedFeatureReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/AbstractEnhancedFeatureReader.java
@@ -1,0 +1,162 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.util.feature.reader;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import htsjdk.tribble.*;
+import htsjdk.tribble.index.Index;
+import htsjdk.tribble.util.ParsingUtils;
+import htsjdk.tribble.util.TabixUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Feature reader extended from HTSJDK library ro support signed S3 URLs
+ * @param <T>
+ * @param <S>
+ */
+public abstract class AbstractEnhancedFeatureReader<T extends Feature, S> extends AbstractFeatureReader<T, S> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractEnhancedFeatureReader.class);
+
+    protected AbstractEnhancedFeatureReader(String path, FeatureCodec<T, S> codec) {
+        super(path, codec);
+    }
+
+    private static ComponentMethods methods = new ComponentMethods();
+
+    /**
+     * Calls {@link #getFeatureReader(String, FeatureCodec, boolean)} with {@code requireIndex} = true
+     */
+    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(
+            final String featureFile, final FeatureCodec<FEATURE, SOURCE> codec) throws
+            TribbleException {
+        return getFeatureReader(featureFile, codec, true);
+    }
+
+    /**
+     * {@link #getFeatureReader(String, String, FeatureCodec, boolean)} with {@code null} for indexResource
+     * @throws TribbleException
+     */
+    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(
+            final String featureResource, final FeatureCodec<FEATURE, SOURCE> codec, final boolean requireIndex)
+            throws TribbleException {
+        return getFeatureReader(featureResource, null, codec, requireIndex);
+    }
+
+    /**
+     *
+     * @param featureResource the feature file to create from
+     * @param indexResource   the index for the feature file. If null, will auto-generate (if necessary)
+     * @param codec
+     * @param requireIndex    whether an index is required for this file
+     * @return
+     * @throws TribbleException
+     */
+    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(
+            final String featureResource, String indexResource,
+            final FeatureCodec<FEATURE, SOURCE> codec, final boolean requireIndex) throws TribbleException {
+        ParsingUtils.registerHelperClass(EnhancedUrlHelper.class);
+        try {
+            // Test for tabix index
+            if (methods.isTabix(featureResource, indexResource)) {
+                if (!(codec instanceof AsciiFeatureCodec)) {
+                    throw new TribbleException("Tabix indexed files only work with ASCII codecs, "
+                            + "but received non-Ascii codec " + codec.getClass().getSimpleName());
+                }
+                return new TabixFeatureReader<>(featureResource, indexResource, (AsciiFeatureCodec) codec);
+            } else {
+                // Not tabix => tribble index file (might be gzipped, but not block gzipped)
+                return new TribbleIndexedFeatureReader<>(featureResource, indexResource, codec, requireIndex);
+            }
+        } catch (IOException e) {
+            throw new TribbleException.MalformedFeatureFile("Unable to create"
+                    + "BasicFeatureReader using feature file ", featureResource, e);
+        } catch (TribbleException e) {
+            e.setSource(featureResource);
+            throw e;
+        }
+    }
+
+    /**
+     * Return a reader with a supplied index.
+     *
+     * @param featureResource the path to the source file containing the features
+     * @param codec used to decode the features
+     * @param index index of featureResource
+     * @return a reader for this data
+     * @throws TribbleException
+     */
+    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(
+            final String featureResource, final FeatureCodec<FEATURE, SOURCE>  codec, final Index index)
+            throws TribbleException {
+        try {
+            return new TribbleIndexedFeatureReader<>(featureResource, codec, index);
+        } catch (IOException e) {
+            throw new TribbleException.MalformedFeatureFile("Unable to create "
+                    + "AbstractFeatureReader using feature file ", featureResource, e);
+        }
+
+    }
+    /**
+     * Whether a filename ends in one of the BLOCK_COMPRESSED_EXTENSIONS
+     * @param fileName
+     * @return
+     */
+    public static boolean hasBlockCompressedExtension(final String fileName) {
+        if (isBlockCompressed(fileName)) {
+            return true;
+        }
+        try {
+            URL url = new URL(fileName);
+            return isBlockCompressed(url.getPath());
+        } catch (MalformedURLException e) {
+            LOGGER.trace(e.getMessage(), e);
+        }
+        return false;
+    }
+
+    private static boolean isBlockCompressed(String path) {
+        for (final String extension : BLOCK_COMPRESSED_EXTENSIONS) {
+            if (path.toLowerCase().endsWith(extension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static class ComponentMethods{
+
+        public boolean isTabix(String resourcePath, String indexPath) throws IOException{
+            if(indexPath == null){
+                indexPath = ParsingUtils.appendToPath(resourcePath, TabixUtils.STANDARD_INDEX_EXTENSION);
+            }
+            return hasBlockCompressedExtension(resourcePath) && ParsingUtils.resourceExists(indexPath);
+        }
+    }
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/EnhancedUrlHelper.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/EnhancedUrlHelper.java
@@ -1,0 +1,115 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.util.feature.reader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.regex.Pattern;
+
+import htsjdk.tribble.util.FTPHelper;
+import htsjdk.tribble.util.HTTPHelper;
+import htsjdk.tribble.util.URLHelper;
+
+/**
+ * URL Helper class that supports S3 singed url handling
+ */
+public class EnhancedUrlHelper implements URLHelper {
+
+    private static final Pattern S3_PATTERN = Pattern.compile(".*s3\\..*\\.amazonaws\\.com");
+
+    private URLHelper wrappedHelper;
+
+    public EnhancedUrlHelper(URL url) {
+        String protocol = url.getProtocol().toLowerCase();
+        if (S3_PATTERN.matcher(url.getHost()).matches()) {
+            this.wrappedHelper = new S3Helper(url);
+        } else if (protocol.startsWith("http")) {
+            this.wrappedHelper = new HTTPHelper(url);
+        } else if (protocol.startsWith("ftp")) {
+            this.wrappedHelper = new FTPHelper(url);
+        } else {
+            throw new IllegalArgumentException(
+                    "Unable to create helper for url with protocol " + protocol);
+        }
+    }
+
+    @Override public URL getUrl() {
+        return this.wrappedHelper.getUrl();
+    }
+
+    @Override public long getContentLength() throws IOException {
+        return this.wrappedHelper.getContentLength();
+    }
+
+    @Override public InputStream openInputStream() throws IOException {
+        return this.wrappedHelper.openInputStream();
+    }
+
+    @Override
+    @Deprecated public InputStream openInputStreamForRange(long start, long end)
+            throws IOException {
+        return this.wrappedHelper.openInputStreamForRange(start, end);
+    }
+
+    @Override public boolean exists() throws IOException {
+        return this.wrappedHelper.exists();
+    }
+
+    /**
+     * Inner helper class for handling S3 signed URLs. We sign URLs for GET requests so
+     * HEAD request will return 403, this is considered to be OK in this case
+     */
+    public static class S3Helper extends HTTPHelper {
+
+        public S3Helper(URL url) {
+            super(url);
+        }
+
+        @Override public boolean exists() throws IOException {
+            return urlExists();
+        }
+
+        private boolean urlExists() {
+            HttpURLConnection con = null;
+            try {
+                URL url = getUrl();
+                con = (HttpURLConnection) url.openConnection();
+                con.setRequestMethod("HEAD");
+                //we allow 403 code since AWS URL will return FORBIDDEN for signed urls HEAD request
+                return (con.getResponseCode() == HttpURLConnection.HTTP_OK
+                        || con.getResponseCode() == HttpURLConnection.HTTP_FORBIDDEN);
+            } catch (IOException e) {
+                // This is what we are testing for, so its not really an exception
+                return false;
+            } finally {
+                if (con != null) {
+                    con.disconnect();
+                }
+            }
+        }
+    }
+}

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/gene/GffManagerUnitTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/gene/GffManagerUnitTest.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.epam.catgenome.util.feature.reader.AbstractEnhancedFeatureReader;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,8 @@ public class GffManagerUnitTest {
     public void setup() throws IOException {
         MockitoAnnotations.initMocks(this);
         Resource resource = context.getResource("classpath:templates/genes_sorted.gtf");
-        try (AbstractFeatureReader<GeneFeature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(
+        try (AbstractFeatureReader<GeneFeature, LineIterator> reader = AbstractEnhancedFeatureReader
+                .getFeatureReader(
             resource.getFile().getAbsolutePath(), new GffCodec(
             GffCodec.GffType.GTF), false)) {
             featureList = reader.iterator().toList();

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/tools/SortTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/tools/SortTest.java
@@ -28,6 +28,7 @@ import com.epam.catgenome.common.AbstractJUnitTest;
 import com.epam.catgenome.controller.tools.FeatureFileSortRequest;
 import com.epam.catgenome.manager.gene.parser.GffCodec;
 import com.epam.catgenome.util.NgbFileUtils;
+import com.epam.catgenome.util.feature.reader.AbstractEnhancedFeatureReader;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.Feature;
@@ -137,7 +138,7 @@ public class SortTest extends AbstractJUnitTest {
         int numlines = 0;
 
         AbstractFeatureReader<F, S> reader =
-                AbstractFeatureReader.getFeatureReader(ofile.getAbsolutePath(), codec, false);
+                AbstractEnhancedFeatureReader.getFeatureReader(ofile.getAbsolutePath(), codec, false);
         CloseableTribbleIterator<F> iterator = reader.iterator();
 
         final Map<String, Feature> visitedChromos = new HashMap<>(40);

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/aws/S3ManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/aws/S3ManagerTest.java
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.util.aws;
+
+import static org.junit.Assert.*;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Date;
+
+import com.amazonaws.services.s3.AmazonS3;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class S3ManagerTest {
+
+    private static final String TEST_URL = "s3://bucket/file.bam";
+    private static final String TEST_SIGNED_URL =
+            "https://bucket.s3.eu-central-1.amazonaws.com/file.bam?X-Amz-Algorithm";
+
+    @Test
+    public void testGenerateUrl() throws MalformedURLException {
+        AmazonS3 mockClient = Mockito.mock(AmazonS3.class);
+        S3Manager s3Manager = Mockito.spy(S3Manager.class);
+        Mockito.doReturn(new URL(TEST_SIGNED_URL))
+                .when(mockClient)
+                .generatePresignedUrl(
+                        Mockito.eq("bucket"),
+                        Mockito.eq("file.bam"),
+                        Mockito.any(Date.class));
+        Mockito.doReturn(mockClient).when(s3Manager).getClient();
+        String result = s3Manager.generateSingedUrl(TEST_URL);
+        assertEquals(TEST_SIGNED_URL, result);
+    }
+
+}


### PR DESCRIPTION
# Description
Support for AWS S3 URI enabled for tracks from URL (unregistered files): BAM, VCF, BED, GENE

## Background
This PR provides feature requested in issue #117 . Files from S3 buckets may be viewed using S3 URI, e.g. "s3://bucket/test.vcf.gz". This feature works for BAM, BED, VCF, GENE files opened via URL (non registered files). NGB server uses default AWS credentials to access S3 buckets, so make sure that you have them on NGB server instance.

## Changes
For all files opened via URL a processing is applied: if URI scheme is s3://, URI is replaced with a singed S3 url. The matching AWS credentials must be enabled on NGB server to gain access to buckets.

## Acceptance criteria
- Install AWS credentials according to this [article](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) on NGB server and upload files to a S3 bucket available for this credentials
- Open "Open file from URL" window
- Insert path to feature file ans it's index into paths inputs using s3 paths, e.g. "s3://bucket/test.bam",
"s3://bucket/test.bam.bai"
- Navigate to the region of interest and check track data presence

# Check list

- [x] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
