### PR TITLE
Blat search resulting region highlighting

### DIFF
--- a/client/client/app/components/ngbBlatSearchPanel/ngbBlatSearch/ngbBlatSearch.controller.js
+++ b/client/client/app/components/ngbBlatSearchPanel/ngbBlatSearch/ngbBlatSearch.controller.js
@@ -139,9 +139,15 @@ export default class ngbBlatSearchController extends baseController {
 
     rowClick(row) {
         const entity = row.entity;
-        const chromosomeName = entity.chr;
         const chromosome = this.projectContext.currentChromosome ?
             this.projectContext.currentChromosome.name : null;
+
+        let chromosomeName;
+        if (chromosome.toLowerCase().includes('chr')) {
+            chromosomeName = entity.chr;
+        } else {
+            chromosomeName = `${entity.chr.slice(3)}`.toLowerCase();
+        }
 
         const addition = (entity.endIndex - entity.startIndex) * 0.1;
         const viewport = {

--- a/client/client/app/components/ngbBlatSearchPanel/ngbBlatSearch/ngbBlatSearch.controller.js
+++ b/client/client/app/components/ngbBlatSearchPanel/ngbBlatSearch/ngbBlatSearch.controller.js
@@ -139,7 +139,7 @@ export default class ngbBlatSearchController extends baseController {
 
     rowClick(row) {
         const entity = row.entity;
-        const chromosomeName = `${entity.chr.slice(3)}`.toLowerCase();
+        const chromosomeName = entity.chr;
         const chromosome = this.projectContext.currentChromosome ?
             this.projectContext.currentChromosome.name : null;
 
@@ -151,6 +151,7 @@ export default class ngbBlatSearchController extends baseController {
         const blatRegion = {
             start: entity.startIndex,
             end: entity.endIndex,
+            chromosomeName,
         };
 
         if (chromosome !== chromosomeName) {

--- a/client/client/app/components/ngbBlatSearchPanel/ngbBlatSearch/ngbBlatSearch.controller.js
+++ b/client/client/app/components/ngbBlatSearchPanel/ngbBlatSearch/ngbBlatSearch.controller.js
@@ -143,26 +143,27 @@ export default class ngbBlatSearchController extends baseController {
         const chromosome = this.projectContext.currentChromosome ?
             this.projectContext.currentChromosome.name : null;
 
-        let addition = (entity.endIndex - entity.startIndex) * 0.1;
+        const addition = (entity.endIndex - entity.startIndex) * 0.1;
+        const viewport = {
+            start: entity.startIndex - addition,
+            end: entity.endIndex + addition,
+        };
+        const blatRegion = {
+            start: entity.startIndex,
+            end: entity.endIndex,
+        };
 
         if (chromosome !== chromosomeName) {
             this.projectContext.changeState({
                 chromosome: {
                     name: chromosomeName
                 },
-                viewport: {
-                    start: entity.startIndex - addition,
-                    end: entity.endIndex + addition,
-                }
+                viewport,
+                blatRegion,
             });
         }
         else {
-            this.projectContext.changeState({
-                viewport: {
-                    start: entity.startIndex - addition,
-                    end: entity.endIndex + addition,
-                }
-            });
+            this.projectContext.changeState({ viewport, blatRegion });
         }
     }
 

--- a/client/client/app/components/ngbBlatSearchPanel/ngbBlatSearch/ngbBlatSearch.controller.js
+++ b/client/client/app/components/ngbBlatSearchPanel/ngbBlatSearch/ngbBlatSearch.controller.js
@@ -143,10 +143,10 @@ export default class ngbBlatSearchController extends baseController {
             this.projectContext.currentChromosome.name : null;
 
         let chromosomeName;
-        if (chromosome.toLowerCase().includes('chr')) {
-            chromosomeName = entity.chr;
-        } else {
+        if (chromosome && !chromosome.toLowerCase().includes('chr')) {
             chromosomeName = `${entity.chr.slice(3)}`.toLowerCase();
+        } else {
+            chromosomeName = entity.chr;
         }
 
         const addition = (entity.endIndex - entity.startIndex) * 0.1;

--- a/client/client/app/components/ngbTracksView/ngbTracksView.controller.js
+++ b/client/client/app/components/ngbTracksView/ngbTracksView.controller.js
@@ -66,7 +66,8 @@ export default class ngbTracksViewController extends baseController {
                             .then(this.refreshTracksScope);
                     },
                     'position:select': ::this.selectPosition,
-                    'viewport:position': ::this.setViewport
+                    'viewport:position': ::this.setViewport,
+                    'blatRegion:change': ::this.setBlatRegion
                 });
             }
 
@@ -150,10 +151,16 @@ export default class ngbTracksViewController extends baseController {
                 start: this.projectContext.position
             };
         }
+        let blatRegion = undefined;
+        if (this.projectContext.blatRegion) {
+            blatRegion = this.projectContext.blatRegion;
+        } else {
+            blatRegion = null;
+        }
 
         const viewportPxMargin = 6;
         this.viewport = new Viewport(scrollPanel,
-            {brush, chromosomeSize: this.chromosome.size},
+            {brush, chromosomeSize: this.chromosome.size, blatRegion},
             this.dispatcher,
             this.projectContext,
             viewportPxMargin,
@@ -257,6 +264,12 @@ export default class ngbTracksViewController extends baseController {
     setViewport() {
         if (this.renderable) {
             this.viewport.selectInterval(this.projectContext.viewport);
+        }
+    }
+
+    setBlatRegion() {
+        if (this.renderable) {
+            this.viewport.blatRegion = this.projectContext.blatRegion;
         }
     }
 

--- a/client/client/app/shared/components/ngbGoldenLayout/ngbGoldenLayout.controller.js
+++ b/client/client/app/shared/components/ngbGoldenLayout/ngbGoldenLayout.controller.js
@@ -300,21 +300,45 @@ export default class ngbGoldenLayoutController extends baseController {
     }
 
     panelRemoveBlatSearchPanel(event) {
-        let savedBlatRequest = JSON.parse(localStorage.getItem('blatSearchRequest')) || null;
+        const [blatSearchItem] = this.goldenLayout.root
+            .getItemsByFilter((obj) => obj.config && obj.config.componentState
+                && obj.config.componentState.panel === this.panels.ngbBlatSearchPanel);
 
-        if(!savedBlatRequest) return;
+        if (!blatSearchItem) {
+            return;
+        }
 
-        let [currentBlatSearchBamTrack] = this.projectContext.tracks.filter( t => t.format === 'BAM' && t.id === savedBlatRequest.id);
+        const savedBlatRequest = JSON.parse(localStorage.getItem('blatSearchRequest')) || null;
+
+        if(!savedBlatRequest) {
+            return;
+        }
+
+        const [currentBlatSearchBamTrack] = this.projectContext.tracks.filter(t => t.format === 'BAM' && t.id === savedBlatRequest.id);
 
         if(!currentBlatSearchBamTrack) {
-            localStorage.removeItem('blatSearchRequest');
-            localStorage.removeItem('blatColumns');
             this.panelRemove(this.appLayout.Panels.blat);
         }
     }
 
+    blatSearchPanelDestroyedHandler(item) {
+        if (item.type === 'component') {
+            if (item.config.componentState.panel === this.panels.ngbBlatSearchPanel) {
+                this.goldenLayout.off('itemDestroyed', this.blatSearchPanelDestroyedHandler, this);
+                this.blatSearchPanelRemoved();
+            }
+        }
+    }
+
+    blatSearchPanelRemoved() {
+        localStorage.removeItem('blatSearchRequest');
+        localStorage.removeItem('blatColumns');
+
+        this.projectContext.changeState({ blatRegion: { forceReset: true } });
+    }
+
     panelAddBlatSearchPanel(event) {
-        let layoutChange = this.appLayout.Panels.blat;
+        const layoutChange = this.appLayout.Panels.blat;
         layoutChange.displayed = true;
 
         const [blatSearchItem] = this.goldenLayout.root
@@ -333,6 +357,7 @@ export default class ngbGoldenLayoutController extends baseController {
         };
         localStorage.setItem('blatSearchRequest', JSON.stringify(payload || {}));
 
+        this.goldenLayout.on('itemDestroyed', this.blatSearchPanelDestroyedHandler, this);
 
         if (!blatSearchItem) {
             this.panelAdd(layoutChange);

--- a/client/client/app/shared/components/ngbGoldenLayout/ngbGoldenLayout.controller.js
+++ b/client/client/app/shared/components/ngbGoldenLayout/ngbGoldenLayout.controller.js
@@ -299,7 +299,7 @@ export default class ngbGoldenLayoutController extends baseController {
         }
     }
 
-    panelRemoveBlatSearchPanel(event) {
+    panelRemoveBlatSearchPanel() {
         const [blatSearchItem] = this.goldenLayout.root
             .getItemsByFilter((obj) => obj.config && obj.config.componentState
                 && obj.config.componentState.panel === this.panels.ngbBlatSearchPanel);
@@ -324,8 +324,8 @@ export default class ngbGoldenLayoutController extends baseController {
     blatSearchPanelDestroyedHandler(item) {
         if (item.type === 'component') {
             if (item.config.componentState.panel === this.panels.ngbBlatSearchPanel) {
-                this.goldenLayout.off('itemDestroyed', this.blatSearchPanelDestroyedHandler, this);
                 this.blatSearchPanelRemoved();
+                this.goldenLayout.off('itemDestroyed', this.blatSearchPanelDestroyedHandler, this);
             }
         }
     }

--- a/client/client/app/shared/projectContext/index.js
+++ b/client/client/app/shared/projectContext/index.js
@@ -1601,10 +1601,7 @@ export default class projectContext {
         if (blatRegion.forceReset === true) {
             this._blatRegion = null;
         } else if (this._currentChromosome) {
-            this._blatRegion = {
-                start: Math.max(blatRegion.start, 1),
-                end: Math.min(blatRegion.end, this._currentChromosome.size)
-            };
+            this._blatRegion = blatRegion;
         }
 
         return (oldBlatRegion === null && this.blatRegion !== null) ||

--- a/client/client/app/shared/projectContext/index.js
+++ b/client/client/app/shared/projectContext/index.js
@@ -70,6 +70,7 @@ export default class projectContext {
     _currentChromosome = null;
     _position = null;
     _viewport = null;
+    _blatRegion = null;
 
     _vcfFilter = {};
     _vcfFilterIsDefault = true;
@@ -220,6 +221,10 @@ export default class projectContext {
 
     get viewport() {
         return this._viewport;
+    }
+
+    get blatRegion() {
+        return this._blatRegion;
     }
 
     get tracks() {
@@ -881,7 +886,8 @@ export default class projectContext {
                 positionDidChange,
                 referenceDidChange,
                 tracksStateDidChange,
-                viewportDidChange
+                viewportDidChange,
+                blatRegionDidChange
             } = result;
             let stateChanged = false;
             if (referenceDidChange) {
@@ -894,6 +900,10 @@ export default class projectContext {
             }
             if (positionDidChange) {
                 emitEventFn('position:select', this.getCurrentStateObject());
+                stateChanged = true;
+            }
+            if (blatRegionDidChange) {
+                emitEventFn('blatRegion:change', this.getCurrentStateObject());
                 stateChanged = true;
             }
             if (viewportDidChange) {
@@ -1070,7 +1080,9 @@ export default class projectContext {
             forceVariantsFilter,
             tracksReordering,
             filterDatasets,
-            shouldAddAnnotationTracks} = state;
+            shouldAddAnnotationTracks,
+            blatRegion
+        } = state;
         if (reference && !this._reference) {
             this._referenceIsPromised = true;
             this.dispatcher.emitGlobalEvent('reference:pre:change');
@@ -1093,6 +1105,12 @@ export default class projectContext {
         const chromosomeDidChange = this._changeChromosome(chromosome);
         let positionDidChange = false;
         let viewportDidChange = false;
+        let blatRegionDidChange = false;
+
+        if (blatRegion) {
+            blatRegionDidChange = this._changeBlatRegion(blatRegion);
+        }
+
         if (viewport) {
             viewportDidChange = this._changeViewport(viewport);
             if (viewportDidChange) {
@@ -1124,7 +1142,8 @@ export default class projectContext {
             positionDidChange,
             referenceDidChange,
             tracksStateDidChange,
-            viewportDidChange
+            viewportDidChange,
+            blatRegionDidChange
         };
     }
 
@@ -1133,11 +1152,13 @@ export default class projectContext {
         const chromosome = this.currentChromosome ? `${this.currentChromosome.name}` : null;
         const position = this._position;
         const viewport = this._viewport;
+        const blatRegion = this.blatRegion;
         return {
             chromosome,
             position,
             referenceId,
-            viewport
+            viewport,
+            blatRegion
         };
     }
 
@@ -1571,6 +1592,26 @@ export default class projectContext {
             (oldViewport !== null && this._viewport !== null && (
                 (oldViewport.start !== this._viewport.start) ||
                 (oldViewport.end !== this._viewport.end)
+            ));
+    }
+
+    _changeBlatRegion(blatRegion) {
+        const oldBlatRegion = this.blatRegion;
+
+        if (blatRegion.forceReset === true) {
+            this._blatRegion = null;
+        } else if (this._currentChromosome) {
+            this._blatRegion = {
+                start: Math.max(blatRegion.start, 1),
+                end: Math.min(blatRegion.end, this._currentChromosome.size)
+            };
+        }
+
+        return (oldBlatRegion === null && this.blatRegion !== null) ||
+            (oldBlatRegion !== null && this.blatRegion === null) ||
+            (oldBlatRegion !== null && this.blatRegion !== null && (
+                (oldBlatRegion.start !== this.blatRegion.start) ||
+                (oldBlatRegion.end !== this.blatRegion.end)
             ));
     }
 

--- a/client/client/modules/render/core/track/track.js
+++ b/client/client/modules/render/core/track/track.js
@@ -53,6 +53,10 @@ export class Track extends BaseTrack {
             this._flags.renderReset = true;
             this.invalidateCache();
         }),
+        this.viewport.blatRegionChangeSubject.subscribe(() => {
+            this._flags.blatRegionChanged = true;
+            requestAnimationFrame(::this.tick);
+        }),
         this.viewport.brushChangeSubject.subscribe(() =>
             this._flags.brushChanged = true),
         this.viewport.brushChangeSubject.subscribe((opts) => {

--- a/client/client/modules/render/core/viewport/viewport.js
+++ b/client/client/modules/render/core/viewport/viewport.js
@@ -11,6 +11,7 @@ const MAX_PIXEL_PER_BRUSH_BP = 20;
 export class Viewport extends BaseViewport {
     element: HTMLElement;
     brushChangeSubject = new Subject();
+    blatRegionChangeSubject = new Subject();
     shortenedIntronsChangeSubject = new Subject();
 
     margin = 0;
@@ -144,6 +145,7 @@ export class Viewport extends BaseViewport {
 
     set blatRegion(blatRegion) {
         this._blatRegion = blatRegion;
+        this.blatRegionChangeSubject.onNext(this);
     }
 
     _shortenedConvert = {

--- a/client/client/modules/render/core/viewport/viewport.js
+++ b/client/client/modules/render/core/viewport/viewport.js
@@ -25,12 +25,15 @@ export class Viewport extends BaseViewport {
 
     browserId = null;
 
+    _blatRegion = null;
+
     constructor(element: HTMLElement, {
         chromosomeSize,
         brush = {
             end: chromosomeSize,
             start: 1
-        }
+        },
+        blatRegion
     }, dispatcher, projectContext, margin = 0, browserInitialSetting, vcfDataService) {
         super({
             brush: brush,
@@ -48,6 +51,7 @@ export class Viewport extends BaseViewport {
         this.dispatcher = dispatcher;
         this.projectContext = projectContext;
         this.vcfDataService = vcfDataService;
+        this.blatRegion = blatRegion;
 
         if (browserInitialSetting && browserInitialSetting.browserId) {
             this.browserId = browserInitialSetting.browserId;
@@ -132,6 +136,14 @@ export class Viewport extends BaseViewport {
             return this._shortenedProject;
         }
         return super.project;
+    }
+
+    get blatRegion() {
+        return this._blatRegion;
+    }
+
+    set blatRegion(blatRegion) {
+        this._blatRegion = blatRegion;
     }
 
     _shortenedConvert = {

--- a/client/client/modules/render/tracks/ruler/index.js
+++ b/client/client/modules/render/tracks/ruler/index.js
@@ -46,7 +46,7 @@ export class RulerTrack extends Track {
                 RulerTransformer.transform(this.viewport, this.trackConfig.global, true),
                 RulerTransformer.transform(this.viewport, this.trackConfig.local));
         }
-        if (flags.brushChanged || flags.widthChanged || flags.renderReset) {
+        if (flags.brushChanged || flags.widthChanged || flags.renderReset || flags.blatRegionChanged) {
             this.brush.render();
             this.renderer.render(this.viewport, RulerTransformer.transform(this.viewport, this.trackConfig.local));
         }

--- a/client/client/modules/render/tracks/ruler/rulerRenderer.js
+++ b/client/client/modules/render/tracks/ruler/rulerRenderer.js
@@ -27,7 +27,8 @@ export default class RulerRenderer {
 
     get blatRegionConfig() {
         return {
-            fillColor: 0xE6E6E6,
+            fillColor: 0x92AEE7,
+            fillAlpha: 0.7,
             lineColor: 0x000000,
             thinLineThickness: 0.5,
             boldLineThickness: 1.5,
@@ -260,7 +261,7 @@ export default class RulerRenderer {
     }
 
     renderBlatRegion(blatRegionGraphics, region) {
-        const { fillColor, lineColor, thinLineThickness, boldLineThickness, coordinatesAdd, regionHeight } = this.blatRegionConfig;
+        const { fillColor, fillAlpha, lineColor, thinLineThickness, boldLineThickness, coordinatesAdd, regionHeight } = this.blatRegionConfig;
         const BP2Pixel = this.viewport.project.brushBP2pixel;
 
         const renderHatchFn = (start, boundaries) => {
@@ -295,7 +296,7 @@ export default class RulerRenderer {
 
         blatRegionGraphics
             .lineStyle(0, lineColor, 1)
-            .beginFill(fillColor, 1)
+            .beginFill(fillColor, fillAlpha)
             .drawRect(
                 BP2Pixel(region.start - coordinatesAdd),
                 0,

--- a/client/client/modules/render/tracks/ruler/rulerRenderer.js
+++ b/client/client/modules/render/tracks/ruler/rulerRenderer.js
@@ -16,12 +16,24 @@ export default class RulerRenderer {
 
     _globalRulerTicks = null;
     _localRulerTicks = null;
+    _localRulerBlatRegion = null;
 
     tickConfigs = new Map();
 
     constructor(viewport, config) {
         this.viewport = viewport;
         this._config = config;
+    }
+
+    get blatRegionConfig() {
+        return {
+            fillColor: 0xE6E6E6,
+            lineColor: 0x000000,
+            thinLineThickness: 0.5,
+            boldLineThickness: 1.5,
+            coordinatesAdd: 0.5,
+            regionHeight: this._config.local.body.height - 1,
+        };
     }
 
     init(ticks) {
@@ -36,10 +48,11 @@ export default class RulerRenderer {
         this._globalRulerBody = globalRulerContainers.body;
         this._globalRulerTicks = globalRulerContainers.ticksArea;
 
-        const localRulerContainers = this.createRuler(this._config.local, _localRulerOffsetY);
+        const localRulerContainers = this.createRuler(this._config.local, _localRulerOffsetY, true);
         this._localRuler = localRulerContainers.ruler;
         this._localRulerBody = localRulerContainers.body;
         this._localRulerTicks = localRulerContainers.ticksArea;
+        this._localRulerBlatRegion = localRulerContainers.blatRegion;
 
         container.addChild(this._globalRuler);
         container.addChild(this._localRuler);
@@ -49,7 +62,7 @@ export default class RulerRenderer {
         return container;
     }
 
-    createRuler(_config, rulerYOffset) {
+    createRuler(_config, rulerYOffset, isLocal = false) {
         const ruler = new PIXI.Container();
         ruler.y = rulerYOffset;
 
@@ -60,18 +73,31 @@ export default class RulerRenderer {
         ticksArea.y = _config.tickArea.margin;
         ruler.addChild(ticksArea);
 
+        let blatRegion = null;
+        if (isLocal) {
+            blatRegion = new PIXI.Container();
+            ruler.addChild(blatRegion);
+        }
+
         this.tickConfigs.set(ticksArea, _config);
 
-        return {
+        const res =  {
             body: body,
             ruler: ruler,
             ticksArea: ticksArea
         };
+
+        if (blatRegion) {
+            res.blatRegion = blatRegion;
+        }
+
+        return res;
     }
 
     render(viewport, localTicks) {
         this.viewport = viewport;
         this.changeDividers(this._localRulerTicks, localTicks || [], viewport);
+        this.changeBlatRegion(this._localRulerBlatRegion, viewport);
     }
 
     rebuild(viewport, globalTicks, localTicks) {
@@ -79,6 +105,7 @@ export default class RulerRenderer {
         this.changeRulerBody(this._localRulerBody, this._config.local);
         this.changeDividers(this._globalRulerTicks, globalTicks || [], viewport, true);
         this.changeDividers(this._localRulerTicks, localTicks || [], viewport);
+        this.changeBlatRegion(this._localRulerBlatRegion, viewport);
     }
 
     createRulerBody(_config) {
@@ -220,6 +247,69 @@ export default class RulerRenderer {
             }
             tickLabels = null;
         }
+    }
+
+    changeBlatRegion(container, viewport) {
+        container.removeChildren();
+        if (viewport.blatRegion && viewport.blatRegion.chromosomeName === viewport.projectContext.currentChromosome.name) {
+            const blatRegionGraphics = new PIXI.Graphics();
+            container.addChild(blatRegionGraphics);
+
+            this.renderBlatRegion(blatRegionGraphics, viewport.blatRegion);
+        }
+    }
+
+    renderBlatRegion(blatRegionGraphics, region) {
+        const { fillColor, lineColor, thinLineThickness, boldLineThickness, coordinatesAdd, regionHeight } = this.blatRegionConfig;
+        const BP2Pixel = this.viewport.project.brushBP2pixel;
+
+        const renderHatchFn = (start, boundaries) => {
+            const { x1, x2 } = boundaries;
+            const pointA = { x: start, y: regionHeight };
+            const pointB = { x: start + regionHeight, y: 0 };
+            if (pointA.x < x1) {
+                pointA.x = x1;
+                pointA.y = pointB.x - x1;
+            }
+            if (pointB.x > x2) {
+                pointB.y = pointB.x - x2;
+                pointB.x = x2;
+            }
+            blatRegionGraphics
+                .moveTo(pointA.x, pointA.y)
+                .lineTo(pointB.x, pointB.y);
+        };
+        const renderHatchingFn = (item) => {
+            const hatchAlpha = 0.5;
+            const hatchStep = 8;
+
+            const startPx = Math.max(- this.viewport.canvasSize, BP2Pixel(item.start - coordinatesAdd));
+            const endPx = Math.min(2 * this.viewport.canvasSize, BP2Pixel(item.end + coordinatesAdd));
+
+            blatRegionGraphics.lineStyle(thinLineThickness, lineColor, hatchAlpha);
+
+            for (let i = startPx - regionHeight; i < endPx; i += hatchStep) {
+                renderHatchFn(i, { x1: startPx, x2: endPx });
+            }
+        };
+
+        blatRegionGraphics
+            .lineStyle(0, lineColor, 1)
+            .beginFill(fillColor, 1)
+            .drawRect(
+                BP2Pixel(region.start - coordinatesAdd),
+                0,
+                BP2Pixel(region.end + coordinatesAdd) - BP2Pixel(region.start - coordinatesAdd),
+                regionHeight
+            )
+            .endFill()
+            .lineStyle(boldLineThickness, lineColor, 1)
+            .moveTo(BP2Pixel(region.start - coordinatesAdd), 0)
+            .lineTo(BP2Pixel(region.start - coordinatesAdd), regionHeight)
+            .moveTo(BP2Pixel(region.end + coordinatesAdd), 0)
+            .lineTo(BP2Pixel(region.end + coordinatesAdd), regionHeight);
+
+        renderHatchingFn(region);
     }
 
     static appendTickGraphics(graphics, x, _config, viewport) {


### PR DESCRIPTION
# Description

## Background

Fix for #129 

## Changes

Currently when user navigates to a region from the BLAT search results it is hard to find exact location of the found range.
This PR solves this. Found region is now highlighting within a local ruler space.

## Acceptance criteria

* Open BLAT search results
* Click on the row to navigate to a region
* Exact location of the found range should be highlighted within a local ruler.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
