### PR TITLE
Fix for s3 paths handling in default region

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/EnhancedUrlHelper.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/EnhancedUrlHelper.java
@@ -39,7 +39,7 @@ import htsjdk.tribble.util.URLHelper;
  */
 public class EnhancedUrlHelper implements URLHelper {
 
-    private static final Pattern S3_PATTERN = Pattern.compile(".*s3\\..*\\.amazonaws\\.com");
+    private static final Pattern S3_PATTERN = Pattern.compile(".*s3.*\\.amazonaws\\.com");
 
     private URLHelper wrappedHelper;
 


### PR DESCRIPTION
# Description
Fix for opening AWS S3 paths in default (us-east-1) region

## Background

Currently NGB fails to open VCF, BED and GFF files from S3 buckets in default region (us-east-1). This PR introduces fix for this issue.

## Changes
Regexp for matching s3 paths fixed

## Acceptance criteria

Upload VCF files to a bucket in us-east-1 region and upload VCF files. Check browsing VCF files from this bucket.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
