### PR TITLE
Fix for issue #137 (browsing gene files via s3 paths)

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/BiologicalDataItemResourceType.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/BiologicalDataItemResourceType.java
@@ -27,6 +27,8 @@ package com.epam.catgenome.entity;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.epam.catgenome.util.NgbFileUtils;
+
 /**
  * Source:      BiologicalItemType
  * Created:     17.12.15, 12:45
@@ -116,7 +118,7 @@ public enum BiologicalDataItemResourceType {
     public static BiologicalDataItemResourceType getTypeFromPath(final String path) {
         if (path.startsWith("s3")) {
             return S3;
-        } else if (path.startsWith("http") || path.startsWith("https") || path.startsWith("ftsp")) {
+        } else if (NgbFileUtils.isRemotePath(path)) {
             return URL;
         } else {
             return FILE;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
@@ -39,6 +39,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.file.AccessDeniedException;
@@ -1188,7 +1190,7 @@ public class FileManager {
     public AbstractFeatureReader<GeneFeature, LineIterator> makeGeneReader(final GeneFile geneFile,
                                                                            final GeneFileType type) {
         String realFileName = geneFile.getPath() != null ? geneFile.getPath() : geneFile.getName();
-        String extension = Utils.getFileExtension(realFileName);
+        String extension = getGeneFileExtension(realFileName);
         extension = GffCodec.GffType.forExt(extension).getExtensions()[0];
 
         final Map<String, Object> params = new HashMap<>();
@@ -2102,8 +2104,16 @@ public class FileManager {
      * @return gene extension
      */
     public static String getGeneFileExtension(final String fileName) {
+        String name = fileName;
+        if (NgbFileUtils.isRemotePath(fileName)) {
+            try {
+                name = new URL(fileName).getPath();
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("Unsupported remote path: " + fileName);
+            }
+        }
         for (String e : GENE_FILE_EXTENSIONS) {
-            if (fileName.endsWith(e)) {
+            if (name.endsWith(e)) {
                 return e;
             }
         }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceManager.java
@@ -42,7 +42,7 @@ import com.epam.catgenome.entity.track.ReferenceTrackMode;
 import com.epam.catgenome.manager.BiologicalDataItemManager;
 import com.epam.catgenome.manager.reference.io.FastaSequenceFile;
 import com.epam.catgenome.manager.reference.io.FastaUtils;
-import com.epam.catgenome.util.AuthUtils;
+import com.epam.catgenome.util.*;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -79,9 +79,6 @@ import com.epam.catgenome.manager.gene.GeneFileManager;
 import com.epam.catgenome.manager.gene.GffManager;
 import com.epam.catgenome.manager.reference.io.NibDataReader;
 import com.epam.catgenome.manager.reference.io.NibDataWriter;
-import com.epam.catgenome.util.BlockCompressedDataInputStream;
-import com.epam.catgenome.util.BlockCompressedDataOutputStream;
-import com.epam.catgenome.util.Utils;
 
 /**
  * Source:      ReferenceManager.java
@@ -557,7 +554,7 @@ import com.epam.catgenome.util.Utils;
             reference.getChromosomes().add(chromosome);
 
             //work with GC
-            if (!FastaUtils.isRemote(path) && createGC) {
+            if (!NgbFileUtils.isRemotePath(path) && createGC) {
                 byte[] sequence = referenceReader.getChromosome(chr);
                 try (BlockCompressedDataOutputStream gcStream = fileManager
                         .makeGCOutputStream(referenceId, chromosome)) {
@@ -572,7 +569,7 @@ import com.epam.catgenome.util.Utils;
     private void setIndex(Reference reference) {
         String path = reference.getPath();
         String indexPath;
-        if (!FastaUtils.isRemote(path) && !FastaUtils.hasIndex(path)) {
+        if (!NgbFileUtils.isRemotePath(path) && !FastaUtils.hasIndex(path)) {
             indexPath = fileManager.createReferenceIndex(reference);
         } else {
             indexPath = path + FastaUtils.FASTA_INDEX;
@@ -615,7 +612,7 @@ import com.epam.catgenome.util.Utils;
     }
 
     private boolean isNibReference(String path) {
-        return !FastaUtils.isRemote(path) && !FastaUtils.isFasta(path);
+        return !NgbFileUtils.isRemotePath(path) && !FastaUtils.isFasta(path);
     }
 
     //method to support intermediate references not nib but without registered index item

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/io/FastaUtils.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/io/FastaUtils.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.epam.catgenome.util.NgbFileUtils;
 import htsjdk.tribble.readers.AsciiLineReader;
 import org.apache.log4j.Logger;
 
@@ -33,7 +34,7 @@ public final class FastaUtils {
 
     public static BufferedReader openBufferedReader(String pathOrUrl) throws IOException {
         InputStream inputStream;
-        if (isRemote(pathOrUrl)) {
+        if (NgbFileUtils.isRemotePath(pathOrUrl)) {
             URL url = new URL(pathOrUrl);
             inputStream = openConnection(url).getInputStream();
         } else {
@@ -62,7 +63,7 @@ public final class FastaUtils {
     public static long getContentLength(String path) {
         try {
             long contentLength;
-            if (isRemote(path)) {
+            if (NgbFileUtils.isRemotePath(path)) {
                 URL url = new URL(path);
                 contentLength = getContentLength(url);
             } else {
@@ -83,11 +84,6 @@ public final class FastaUtils {
             return Long.parseLong(contentLengthString);
         }
     }
-
-    public static boolean isRemote(final String path) {
-        return path.startsWith("http:") || path.startsWith("https:");
-    }
-
 
     /**
      * Creates fasta index near original reference

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/NgbFileUtils.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/NgbFileUtils.java
@@ -147,4 +147,8 @@ public final class NgbFileUtils {
     public static boolean isGzCompressed(String fileName) {
         return fileName.endsWith(GZ_EXTENSION);
     }
+
+    public static boolean isRemotePath(String path) {
+        return path.startsWith("http:") || path.startsWith("https:") || path.startsWith("ftsp:");
+    }
 }


### PR DESCRIPTION
# Description

## Background

This PR fixes issue #137 with opening Gene files (gtf, gff) using S3 paths

## Changes

Currently gene files cannot be opened by S3 link, this PR fixes this problem.

## Acceptance criteria

- Upload gtf/gff file and corresponding index to S3 bucket.
- Check viewing uploaded files in NGB using S3 path, e.g. s3://bucket/genes.gtf.gz

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
