### PR TITLE
Display full variation location in variation info

### DIFF
--- a/client/client/app/components/ngbVariantPanel/ngbVariantPanel.tpl.html
+++ b/client/client/app/components/ngbVariantPanel/ngbVariantPanel.tpl.html
@@ -10,16 +10,16 @@
     </div>
     <md-divider></md-divider>
     <md-tabs md-dynamic-height>
-        <md-tab id="visualizer">
-            <md-tab-label>Visualizer</md-tab-label>
-            <md-tab-body>
-                <ngb-variant-visualizer flex variant="$ctrl.variant" variant-request="$ctrl.variantRequest"></ngb-variant-visualizer>
-            </md-tab-body>
-        </md-tab>
         <md-tab id="info">
             <md-tab-label>Info</md-tab-label>
             <md-tab-body>
                 <ngb-variant-info flex variant="$ctrl.variant" variant-request="$ctrl.variantRequest"></ngb-variant-info>
+            </md-tab-body>
+        </md-tab>
+        <md-tab id="visualizer">
+            <md-tab-label>Visualizer</md-tab-label>
+            <md-tab-body>
+                <ngb-variant-visualizer flex variant="$ctrl.variant" variant-request="$ctrl.variantRequest"></ngb-variant-visualizer>
             </md-tab-body>
         </md-tab>
         <md-tab ng-if="$ctrl.rsId" id="dbsnp">

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantDetails.constant.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantDetails.constant.js
@@ -1,6 +1,7 @@
 export default{
     displayModes: {common: 'common', wide: 'wide'},
     errorMessages: {
+        chromosomeNotFound: 'Chromosome not found.',
         variantAnnotationsNotFound: 'Variant annotations not found.',
         errorLoadingVariantInfo: 'Error loading variant information.',
         errorLoadingVariantSnpInfo: 'Error loading variant information from SNP database.'

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.service.js
@@ -2,18 +2,21 @@ import {utilities} from '../utilities';
 
 export default class ngbVariantInfoService{
 
-    static instance(dispatcher, constants, vcfDataService) {
-        return new ngbVariantInfoService(dispatcher, constants, vcfDataService);
+    static instance(dispatcher, constants, vcfDataService, genomeDataService) {
+        return new ngbVariantInfoService(dispatcher, constants, vcfDataService, genomeDataService);
     }
 
     _constants;
     _dataService;
     _dispatcher;
+    _genomeDataService;
+    _chromosomeName;
 
-    constructor(dispatcher, constants, dataService){
+    constructor(dispatcher, constants, dataService, genomeDataService){
         this._dataService = dataService;
         this._constants = constants;
         this._dispatcher = dispatcher;
+        this._genomeDataService = genomeDataService;
     }
 
     loadVariantInfo(variantRequest, callback, errorCallback){
@@ -26,14 +29,30 @@ export default class ngbVariantInfoService{
             position: variantRequest.position
         };
 
-        this._dataService.getVariantInfo(request)
+        this._genomeDataService.loadChromosome(variantRequest.chromosomeId)
             .then(
-                (data) => {
-                    callback(this._mapVariantPropertiesData(data));
-                },
-                () => {
-                    errorCallback(this._constants.errorMessages.errorLoadingVariantInfo);
-                });
+                (chr) => {
+                    this.chromosomeName = chr.name;
+                    this._dataService.getVariantInfo(request)
+                        .then(
+                            (data) => {
+                                callback(this._mapVariantPropertiesData(data));
+                            }, () => {
+                                errorCallback(this._constants.errorMessages.errorLoadingVariantInfo);
+                            }
+                        );
+                }, () => {
+                    errorCallback(this._constants.errorMessages.chromosomeNotFound);
+                }
+            );
+    }
+
+    get chromosomeName() {
+        return this._chromosomeName;
+    }
+
+    set chromosomeName(value) {
+        this._chromosomeName = value ? value : null;
     }
 
     _mapVariantPropertiesData(variantData){
@@ -42,6 +61,18 @@ export default class ngbVariantInfoService{
         const commonFlex = 50;
         const trimGenesMaxItems = 5;
         const trimGenesMaxLength = 30;
+
+        variantProperties.push({
+            displayMode: this._constants.displayModes.wide,
+            flex: wideFlex,
+            title: 'Description',
+            values: [
+                `${this.chromosomeName
+                    ? `${this.chromosomeName}: `
+                    : ''
+                }${variantData.startIndex} ${variantData.referenceAllele} > ${variantData.alternativeAlleles[0]}`
+            ]
+        });
         if (variantData.hasOwnProperty('geneNames')) {
             if (variantData.geneNames.length === 1) {
                 variantProperties.push({

--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantInfo/ngbVariantInfo.service.js
@@ -70,7 +70,7 @@ export default class ngbVariantInfoService{
                 `${this.chromosomeName
                     ? `${this.chromosomeName}: `
                     : ''
-                }${variantData.startIndex} ${variantData.referenceAllele} > ${variantData.alternativeAlleles[0]}`
+                }${variantData.startIndex} ${utilities.trimString(variantData.referenceAllele)} > ${utilities.trimString(variantData.alternativeAlleles[0])}`
             ]
         });
         if (variantData.hasOwnProperty('geneNames')) {


### PR DESCRIPTION
# Description

## Background

Fix for issue #136 

## Changes

* Order of 'VISUALIZER' and 'INFO' tabs was changed
* Description field with full variation location info was added to 'INFO' tab

![image](https://user-images.githubusercontent.com/31693137/35440416-5a039ebc-02b0-11e8-9041-98344f474d89.png)

## Acceptance criteria

* choose dataset
* open variants panel
* push info icon to open variation info popup
* 'INFO' tab should be first in order and there should be Description field in it

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
