### PR TITLE
Demo data downloading for dev-docker tag

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -83,3 +83,7 @@ There are two version of NGB in this repository:
 * **ngb:latest-demo** - a "demo" version - contains demo data set, which does not require any data registration, you need only to run an image
 
 Details on usage of these images are available in [DockerHub Readme](https://hub.docker.com/r/lifescience/ngb/)
+
+# Develop versions of docker images
+
+Docker images from develop branch are automatically builded and pushed to DockerHub with -dev tag 

--- a/docker/README.md
+++ b/docker/README.md
@@ -86,4 +86,19 @@ Details on usage of these images are available in [DockerHub Readme](https://hub
 
 # Develop versions of docker images
 
-Docker images from develop branch are automatically builded and pushed to DockerHub with -dev tag 
+Docker images from develop branch are automatically builded by and pushed to DockerHub. 
+Due to the large size of demo data and Travis disk space limitations the demo data could not be included in the image.  
+* **ngb:-dev** - contains image of NGB without any data in it, only binaries
+
+To download the demo data just pull the -dev docker image
+
+```
+$ docker pull lifescience/ngb:-dev 
+```
+
+Launch the NGB from a created image
+
+Replace <script_folder> placeholder with a real path to a folder with NGS data
+```
+$ docker run -p 8080:8080 -d --name ngbcore -v <script_folder>:/ngs ngb:-dev
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -86,34 +86,31 @@ Details on usage of these images are available in [DockerHub Readme](https://hub
 
 # Develop versions of docker images
 
-Docker images from develop branch are automatically builded by and pushed to DockerHub. 
-Due to the large size of demo data and Travis disk space limitations the demo data could not be included in the image.  
-* **ngb:-dev** - contains image of NGB without any data in it, only binaries
+Docker images from develop branch are automatically builded by Travis-CI and pushed to DockerHub. 
+Unfourunately, the demo data could not be included in the image due to the large size of demo data and Travis disk space limitations.  
 
-To download the demo data just pull the -dev docker image
+At first, put the demo_data_script.sh file to the folder on the host machine you want to be used for the data download. 
+Just for the example let it be /home/user/ngb_files
+
+Next, download the pull the -dev docker image and launch it (replace 2.6.0.34.1.34.1 with the version number you want)
 
 ```
-$ docker pull lifescience/ngb:-dev 
+$ docker run -d -p 8080:8080 --name ngbcore -v /home/user/ngb_files/:/ngs epam/lifesciences/ngb:2.6.0.34.1.34.1-dev
 ```
-
-Launch the NGB from a pulled image
-
-Replace <script_folder> placeholder with a real path to the folder demo_data_download.sh script and run
-```
-$ docker run -p 8080:8080 -d --name ngbcore -v <script_folder>:/demo_data ngb:-dev
-```
-This command will start docker with name ngbcore, mount the folder containing demo_data_download script to the /demo_data mount point and expose the 8080 port for the ngb graphical interface
+This command will start docker with the ngbcore name, mount the folder /home/user/ngb_files on the host machine to the /ngs mount point of the container and expose the 8080 port for the ngb graphical interface
 
 Now run the script to download demo data 
 ```
-docker exec -d ngb_core ./demo_data/demo_data_download.sh
+$ docker exec -it ngbcore /ngs/demo_data_download.sh
 ```
-The demo_data_download.sh script will download genome references to ~/ngb_data/references and demo data to ~/ngb_data/data_files
-But you can change the paths for references and data files by passing -r and -f arguments, respectively
+demo_data_download.sh script will download genome references to ~/ngb_data/references and demo data to /home /ngb_data/data_files by default
+But you can change the paths for references and data files by passing -r and -f arguments to the demo_data_download.sh script, respectively if you want to
 
 For example:
 ```
 ./demo_data_download.sh -r ~/references -f ~/some/other/folder  
 ```
-The script will download all the necessary files and will register them by itself. But be  patient, please, as the reference donwload may take much time. 
+
+The script will download all the necessary files and will register them by itself. But please be patient, as the reference donwload may take much time. 
+
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -96,9 +96,24 @@ To download the demo data just pull the -dev docker image
 $ docker pull lifescience/ngb:-dev 
 ```
 
-Launch the NGB from a created image
+Launch the NGB from a pulled image
 
-Replace <script_folder> placeholder with a real path to a folder with NGS data
+Replace <script_folder> placeholder with a real path to the folder demo_data_download.sh script and run
 ```
-$ docker run -p 8080:8080 -d --name ngbcore -v <script_folder>:/ngs ngb:-dev
+$ docker run -p 8080:8080 -d --name ngbcore -v <script_folder>:/demo_data ngb:-dev
 ```
+This command will start docker with name ngbcore, mount the folder containing demo_data_download script to the /demo_data mount point and expose the 8080 port for the ngb graphical interface
+
+Now run the script to download demo data 
+```
+docker exec -d ngb_core ./demo_data/demo_data_download.sh
+```
+The demo_data_download.sh script will download genome references to ~/ngb_data/references and demo data to ~/ngb_data/data_files
+But you can change the paths for references and data files by passing -r and -f arguments, respectively
+
+For example:
+```
+./demo_data_download.sh -r ~/references -f ~/some/other/folder  
+```
+The script will download all the necessary files and will register them by itself. But be  patient, please, as the reference donwload may take much time. 
+

--- a/docker/demo/demo_data_download.sh
+++ b/docker/demo/demo_data_download.sh
@@ -1,0 +1,154 @@
+#!/bin/bash -e
+
+#This script just downloads demo data from ngb.opensource.epam.com and register it
+
+REFERENCES=~/ngb_files/references
+DATA_FOLDER=~/ngb_files/data_files
+
+while getopts "r:f:h" opt
+do
+  case $opt in
+        r) REFERENCES=$OPTARG;;
+        f) DATA_FOLDER=$OPTARG;;
+        h) echo "-f - the folder with test files (default is ~/ngb_files/data_files)"
+           echo "-r  - the folder to save references (default is  ~/ngb_files/references)" 
+	   echo "-h - this help"
+           exit 0 ;;
+        *) echo "-h will help you, please look it up"
+           exit 1;;
+  esac
+done
+
+if [ ! -d $REFERENCES ]; then
+  echo "The directory does not exist, so $REFERENCES folder will be created"
+  mkdir -p $REFERENCES
+fi
+
+if [ ! -d $DATA_FOLDER ]; then
+  echo "The directory does not exist, so $DATA_FOLDER folder will be created"
+  mkdir -p $DATA_FOLDER
+fi
+
+echo "References will be downloaded to folder $REFERENCES"
+echo "Demo data will be downloaded to folder $DATA_FOLDER"
+
+#Downloading data
+cd $REFERENCES
+
+# Download grch38
+wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.gtf.gz  && \
+wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.fa.gz && \
+wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.domains.bed && \
+gzip -d Homo_sapiens.GRCh38.fa.gz
+gzip -d Homo_sapiens.GRCh38.gtf.gz
+
+# Download grch37
+wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch37/Homo_sapiens.GRCh37.gtf.gz  && \
+wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch37/Homo_sapiens.GRCh37.fa.gz && \
+gzip -d Homo_sapiens.GRCh37.fa.gz
+gzip -d Homo_sapiens.GRCh38.gtf.gz
+
+# Download dm6
+wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/dm6/dmel-all-r6.06.sorted.gtf.gz && \
+wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/dm6/dmel-all-chromosome-r6.06.fasta.gz && \
+gzip -d dmel-all-chromosome-r6.06.fasta.gz
+gzip -d dmel-all-r6.06.sorted.gtf.gz
+
+# Download grcm38
+wget --quiet  --no-clobber http://ngb.opensource.epam.com/distr/data/genome/mm/Mus_musculus.GRCm38.sorted.gtf.gz && \
+wget --quiet  --no-clobber http://ngb.opensource.epam.com/distr/data/genome/mm/Mus_musculus.GRCm38.fa.gz && \
+gzip -d Mus_musculus.GRCm38.fa.gz
+gzip -d Mus_musculus.GRCm38.sorted.gtf.gz
+
+# Download demo data
+cd $DATA_FOLDER
+wget --quiet  --no-clobber http://ngb.opensource.epam.com/distr/data/demo/ngb_demo_data.tar.gz && \
+tar -zxvf ngb_demo_data.tar.gz
+
+echo "Registering GRCh38 reference"
+ngb reg_ref $REFERENCES/Homo_sapiens.GRCh38.fasta --name GRCh38 && \
+ngb reg_file GRCh38 $REFERENCES/Homo_sapiens.GRCh38.gtf --name GRCh38_Genes && \
+ngb ag GRCh38 GRCh38_Genes && \
+ngb reg_file GRCh38 $REFERENCES/Homo_sapiens.GRCh38.domains.bed --name GRCh38_Domains && \
+ngb an GRCh38 GRCh38_Domains && \
+ngb rs Human GRCh38 && ngb add_spec "GRCh38" "GRCh38" && \
+echo "GRCh38 reference and annotation were successfully registered" ||
+echo "Something with GRCh38 reference has gone wrong, please check paths and filenames"
+
+#Registering D.melanogaster reference
+ngb reg_ref $REFERENCES/dmel-all-chromosome-r6.06.fasta --species DM6 --name DM6 && \
+ngb reg_file DM6 $REFERENCES/dmel-all-r6.06.sorted.gtf --name DM6_Genes && \
+ngb ag DM6 DM6_Genes && \
+ngb rs Drosophila DM6 && ngb add_spec "DM6" "DM6" && \
+echo "GRCh38 reference and annotation were successfully registered" ||
+echo "Something with DM6 reference has gone wrong, please check paths and filenames"
+
+#Registering GRC37, GRCm38 references
+ngb reg_ref $REFERENCES/Homo_sapiens.GRCh37.fasta --species GRCh37 --name GRCh38 && \
+ngb reg_file GRCh37 $REFERENCES/Homo_sapiens.GRCh37.gtf --name GRCh37_Genes && \
+ngb ag GRCh37 GRCh37_Genes && \
+ngb rs Human GRCh37 && ngb add_spec "GRCh37" "GRCh37" && \
+echo "Success with GRCh37" || echo "GRCh37 fail"
+
+ngb reg_ref $REFERENCES/Mus_musculus.GRCm38.fa --name GRCm38 --species GRCm38 && \
+ngb reg_file GRCm38 $REFERENCES/Mus_musculus.GRCm38.sorted.gtf --name GRCm38_Genes && \
+ngb ag GRCm38 GRCm38_Genes && \
+ngb rs Human GRCm38 && ngb add_spec "GRCm38" "GRCm38" && \
+echo "Success with GRCm38" || echo "GRCm38 fail"
+
+#Now let's register datasets and separate files
+cd $DATA_FOLDER/ngb_demo_data
+ngb rd GRCh38 SV_Sample1
+ngb add SV_Sample1 sample_1-lumpy.vcf
+ngb add SV_Sample1 sv_sample_1.bw
+ngb add SV_Sample1 sv_sample_1.bam
+ngb reg_file GRCh38 sample_2-lumpy.vcf
+ngb reg_file GRCh38 sv_sample_2.bw
+ngb reg_file GRCh38 sv_sample_2.bam
+
+ngb rd GRCh38 SV_Sample2
+ngb add SV_Sample2 sample_2-lumpy.vcf
+ngb add SV_Sample2 sv_sample_2.bw
+ngb add SV_Sample2 sv_sample_2.bam
+
+ngb reg_file GRCh38 PIK3CA-E545K.vcf
+ngb reg_file GRCh38 PIK3CA-E545K.bam
+ngb reg_file GRCh38 PIK3CA-E545K.cram?PIK3CA-E545K.cram.crai
+
+ngb rd GRCh38 PIK3CA-E545K-Sample
+ngb add PIK3CA-E545K-Sample PIK3CA-E545K.vcf
+ngb add PIK3CA-E545K-Sample PIK3CA-E545K.bam
+ngb add PIK3CA-E545K-Sample PIK3CA-E545K.cram
+ngb reg_file GRCh38 brain_th.bam?brain_th.bam.bai
+
+ngb rd GRCh38 RNASeq-chr22-SpliceJunctions
+ngb add RNASeq-chr22-SpliceJunctions brain_th.bam
+
+ngb reg_file GRCh38 FGFR3-TACC-Fusion.vcf
+ngb reg_file GRCh38 FGFR3-TACC-Fusion.bam
+ngb rd GRCh38 FGFR3-TACC-Fusion-Sample
+ngb add FGFR3-TACC-Fusion-Sample FGFR3-TACC-Fusion.vcf
+ngb add FGFR3-TACC-Fusion-Sample FGFR3-TACC-Fusion.bam
+
+ngb reg_file DM6 agnX1.09-28.trim.dm606.realign.vcf
+ngb reg_file DM6 agnX1.09-28.trim.dm606.realign.bam?agnX1.09-28.trim.dm606.realign.bai
+ngb reg_file DM6 CantonS.09-28.trim.dm606.realign.vcf
+ngb reg_file DM6 CantonS.09-28.trim.dm606.realign.bam?CantonS.09-28.trim.dm606.realign.bai
+ngb reg_file DM6 agnts3.09-28.trim.dm606.realign.vcf
+ngb reg_file DM6 agnts3.09-28.trim.dm606.realign.bam?agnts3.09-28.trim.dm606.realign.bai
+
+ngb rd DM6 Fruitfly
+ngb add Fruitfly agnX1.09-28.trim.dm606.realign.vcf
+ngb add Fruitfly agnX1.09-28.trim.dm606.realign.bam
+ngb add Fruitfly CantonS.09-28.trim.dm606.realign.vcf
+ngb add Fruitfly CantonS.09-28.trim.dm606.realign.bam
+
+#Remove downloaded raw archives with genomes
+rm Homo_sapiens.GRCh38.fa.gz Homo_sapiens.GRCh37.fa.gz
+rm dmel-all-chromosome-r6.06.fasta.gz dmel-all-r6.06.sorted.gtf.gz
+rm Mus_musculus.GRCm38.fa.gz  Mus_musculus.GRCm38.sorted.gtf.gz
+
+#Remove demo data archive
+rm ngb_demo_data.tar.gz
+
+exit 0

--- a/docker/demo/demo_data_download.sh
+++ b/docker/demo/demo_data_download.sh
@@ -11,7 +11,7 @@ do
         r) REFERENCES=$OPTARG;;
         f) DATA_FOLDER=$OPTARG;;
         h) echo "-f - the folder with test files (default is ~/ngb_files/data_files)"
-           echo "-r  - the folder to save references (default is  ~/ngb_files/references)" 
+           echo "-r  - the folder to save references (default is  ~/ngb_files/references)"
 	   echo "-h - this help"
            exit 0 ;;
         *) echo "-h will help you, please look it up"
@@ -21,12 +21,12 @@ done
 
 if [ ! -d $REFERENCES ]; then
   echo "The directory does not exist, so $REFERENCES folder will be created"
-  mkdir -p $REFERENCES
+  mkdir -p $REFERENCES && echo "$REFERENCES folder created successfully"
 fi
 
 if [ ! -d $DATA_FOLDER ]; then
   echo "The directory does not exist, so $DATA_FOLDER folder will be created"
-  mkdir -p $DATA_FOLDER
+  mkdir -p $DATA_FOLDER && echo "$DATA_FOLDER folder created successfully"
 fi
 
 echo "References will be downloaded to folder $REFERENCES"
@@ -35,76 +35,160 @@ echo "Demo data will be downloaded to folder $DATA_FOLDER"
 #Downloading data
 cd $REFERENCES
 
-# Download grch38
-wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.gtf.gz  && \
-wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.fa.gz && \
-wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.domains.bed && \
-gzip -d Homo_sapiens.GRCh38.fa.gz
-gzip -d Homo_sapiens.GRCh38.gtf.gz
+# Download grch38 fasta and annotation
 
-# Download grch37
-wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch37/Homo_sapiens.GRCh37.gtf.gz  && \
-wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch37/Homo_sapiens.GRCh37.fa.gz && \
-gzip -d Homo_sapiens.GRCh37.fa.gz
-gzip -d Homo_sapiens.GRCh38.gtf.gz
+if [ ! -e Homo_sapiens.GRCh38.fa ]; then
+  echo "Downloading GRCh38 reference"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.fa.gz
+  gunzip Homo_sapiens.GRCh38.fa.gz && echo "Successfully downloaded and gunzipped"
+else
+  echo "GRCh38 fasta has already been downloaded"
+fi
+echo
 
-# Download dm6
-wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/dm6/dmel-all-r6.06.sorted.gtf.gz && \
-wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/dm6/dmel-all-chromosome-r6.06.fasta.gz && \
-gzip -d dmel-all-chromosome-r6.06.fasta.gz
-gzip -d dmel-all-r6.06.sorted.gtf.gz
+if [ ! -e Homo_sapiens.GRCh38.gtf ] && [ ! -e Homo_sapiens.GRCh38.domains.bed ]; then
+  echo "Downloadiing annotation files for GRCh38"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.gtf.gz
+  gunzip Homo_sapiens.GRCh38.gtf.gz && echo "Successfully downloaded and gunzipped"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch38/Homo_sapiens.GRCh38.domains.bed
+else
+  echo "Annotation files have been already downloaded"
+fi
+echo
+
+# Download grch37 fasta and annotation
+if [ ! -e Homo_sapiens.GRCh37.fa ]; then
+  echo "Downloading GRCh37 reference"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch37/Homo_sapiens.GRCh37.fa.gz
+  gunzip Homo_sapiens.GRCh37.fa.gz && echo "Successfully downloaded and gunzipped"
+else
+  echo "GRCh37 fasta has already been downloaded"
+fi
+echo
+
+if [ ! -e Homo_sapiens.GRCh37.gtf.gz ]; then
+  echo "Downloading GRCh37 annotation files"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/grch37/Homo_sapiens.GRCh37.gtf.gz
+  gunzip Homo_sapiens.GRCh37.gtf.gz && echo "Successfully downloaded and gunzipped"
+else
+  echo "GRCh37 annotation file has already been downloaded"
+fi
+echo
 
 # Download grcm38
-wget --quiet  --no-clobber http://ngb.opensource.epam.com/distr/data/genome/mm/Mus_musculus.GRCm38.sorted.gtf.gz && \
-wget --quiet  --no-clobber http://ngb.opensource.epam.com/distr/data/genome/mm/Mus_musculus.GRCm38.fa.gz && \
-gzip -d Mus_musculus.GRCm38.fa.gz
-gzip -d Mus_musculus.GRCm38.sorted.gtf.gz
+if [ ! -e Mus_musculus.GRCm38.fa ]; then
+  echo "Downloading GRCm38 reference file"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/mm/Mus_musculus.GRCm38.fa.gz
+  gunzip Mus_musculus.GRCm38.fa.gz && echo "Successfully downloaded and gunzipped"
+else
+ echo "GRCm38 fasta has already been downloaded"
+fi
+echo
 
-# Download demo data
+if [ ! -e Mus_musculus.GRCm38.sorted.gtf ]; then
+  echo "Downloading GRCm38 annotation file"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/mm/Mus_musculus.GRCm38.sorted.gtf.gz
+  gunzip Mus_musculus.GRCm38.sorted.gtf.gz && echo "Successfully downloaded and gunzipped"
+else
+ echo "GRCm38 annotation has already been downloaded"
+fi
+echo
+
+# Download dm6
+if [ ! -e dmel-all-chromosome-r6.06.fasta ]; then
+  echo "Downloading reference fasta for Drosophila"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/dm6/dmel-all-chromosome-r6.06.fasta.gz
+  gunzip dmel-all-chromosome-r6.06.fasta.gz && echo "Successfully downloaded and gunzipped"
+else
+ echo "Drosophila reference has already been downloaded"
+fi
+echo
+
+if [ ! -e dmel-all-r6.06.sorted.gtf ]; then
+  echo "Downloading annotation file for Drosophila"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/genome/dm6/dmel-all-r6.06.sorted.gtf.gz
+  gunzip dmel-all-r6.06.sorted.gtf.gz && echo "Successfully downloaded and gunzipped"
+else
+ echo "Drosophila annotation has already been downloaded"
+fi
+echo
+
+#Download demo data
 cd $DATA_FOLDER
-wget --quiet  --no-clobber http://ngb.opensource.epam.com/distr/data/demo/ngb_demo_data.tar.gz && \
-tar -zxvf ngb_demo_data.tar.gz
+if  [ ! -d ngb_demo_files ]; then
+  echo "Downloading demo files"
+  wget --quiet --no-clobber http://ngb.opensource.epam.com/distr/data/demo/ngb_demo_data.tar.gz && \
+  tar -zxvf ngb_demo_data.tar.gz && echo "Successfully downloaded and gunzipped"
+else
+  echo "Demo files seem to be already downloaded"
+fi
+echo
 
+
+#Now let's register references one by one
+
+#Registering the GRCh38 reference
+cd $REFERENCES
 echo "Registering GRCh38 reference"
-ngb reg_ref $REFERENCES/Homo_sapiens.GRCh38.fasta --name GRCh38 && \
-ngb reg_file GRCh38 $REFERENCES/Homo_sapiens.GRCh38.gtf --name GRCh38_Genes && \
-ngb ag GRCh38 GRCh38_Genes && \
-ngb reg_file GRCh38 $REFERENCES/Homo_sapiens.GRCh38.domains.bed --name GRCh38_Domains && \
-ngb an GRCh38 GRCh38_Domains && \
-ngb rs Human GRCh38 && ngb add_spec "GRCh38" "GRCh38" && \
-echo "GRCh38 reference and annotation were successfully registered" ||
+ngb reg_spec "GRCh38" "GRCh38"
+ngb reg_ref Homo_sapiens.GRCh38.fa --name "GRCh38" --genes Homo_sapiens.GRCh38.gtf --species "GRCh38" && \
+echo "GRCh38 reference and genes file were successfully registered" || \
 echo "Something with GRCh38 reference has gone wrong, please check paths and filenames"
+echo
+
+#Registering the GRCh38.domains.bed file as the annotation file
+ngb add_ann "GRCh38" Homo_sapiens.GRCh38.domains.bed && \
+echo "Annotation was successfully added to GRCh38 reference"
+
+#Registering the GRCh37 reference
+echo "Registering Human GRCh37 reference"
+ngb reg_spec "GRCh37" "GRCh37"
+ngb reg_ref Homo_sapiens.GRCh37.fa --name "GRCh37" --genes Homo_sapiens.GRCh37.gtf --species "GRCh37" && \
+echo "Human GRCh37 reference and annotation were successfully registered" || \
+echo "Something with GRCh37 reference has gone wrong, please check paths and filenames"
+echo
+
+#Registering the GRCm38 reference
+echo "Registering Mouse GRCm38 reference"
+ngb reg_spec "Mouse" "GRCm38"
+ngb reg_ref Mus_musculus.GRCm38.fa --name "Mouse" --genes Mus_musculus.GRCm38.sorted.gtf --species "GRCm38" && \
+echo "Mouse reference and annotation were successfully registered" || \
+echo "Something with Mouse reference has gone wrong, please check paths and filenames"
+echo
 
 #Registering D.melanogaster reference
-ngb reg_ref $REFERENCES/dmel-all-chromosome-r6.06.fasta --species DM6 --name DM6 && \
-ngb reg_file DM6 $REFERENCES/dmel-all-r6.06.sorted.gtf --name DM6_Genes && \
-ngb ag DM6 DM6_Genes && \
-ngb rs Drosophila DM6 && ngb add_spec "DM6" "DM6" && \
-echo "GRCh38 reference and annotation were successfully registered" ||
+echo "Registering D.melanogaster reference"
+ngb reg_spec "Drosophila" "DM6"
+ngb reg_ref dmel-all-chromosome-r6.06.fasta --name "Drosophila" --genes dmel-all-r6.06.sorted.gtf --species "DM6" && \
+echo "DM6 reference and annotation were successfully registered" || \
 echo "Something with DM6 reference has gone wrong, please check paths and filenames"
-
-#Registering GRC37, GRCm38 references
-ngb reg_ref $REFERENCES/Homo_sapiens.GRCh37.fasta --species GRCh37 --name GRCh38 && \
-ngb reg_file GRCh37 $REFERENCES/Homo_sapiens.GRCh37.gtf --name GRCh37_Genes && \
-ngb ag GRCh37 GRCh37_Genes && \
-ngb rs Human GRCh37 && ngb add_spec "GRCh37" "GRCh37" && \
-echo "Success with GRCh37" || echo "GRCh37 fail"
-
-ngb reg_ref $REFERENCES/Mus_musculus.GRCm38.fa --name GRCm38 --species GRCm38 && \
-ngb reg_file GRCm38 $REFERENCES/Mus_musculus.GRCm38.sorted.gtf --name GRCm38_Genes && \
-ngb ag GRCm38 GRCm38_Genes && \
-ngb rs Human GRCm38 && ngb add_spec "GRCm38" "GRCm38" && \
-echo "Success with GRCm38" || echo "GRCm38 fail"
+echo
 
 #Now let's register datasets and separate files
 cd $DATA_FOLDER/ngb_demo_data
+echo "Registering files for Drosophila"
+ngb reg_file Drosophila agnX1.09-28.trim.dm606.realign.vcf
+ngb reg_file Drosophila agnX1.09-28.trim.dm606.realign.bam?agnX1.09-28.trim.dm606.realign.bai
+ngb reg_file Drosophila CantonS.09-28.trim.dm606.realign.vcf
+ngb reg_file Drosophila CantonS.09-28.trim.dm606.realign.bam?CantonS.09-28.trim.dm606.realign.bai
+ngb reg_file Drosophila agnts3.09-28.trim.dm606.realign.vcf
+ngb reg_file Drosophila agnts3.09-28.trim.dm606.realign.bam?agnts3.09-28.trim.dm606.realign.bai
+echo
+
+echo "Registering Fruitfly dataset"
+ngb rd Drosophila Fruitfly
+ngb add Fruitfly agnX1.09-28.trim.dm606.realign.vcf
+ngb add Fruitfly agnX1.09-28.trim.dm606.realign.bam
+ngb add Fruitfly CantonS.09-28.trim.dm606.realign.vcf
+ngb add Fruitfly CantonS.09-28.trim.dm606.realign.bam
+echo
+
+echo "Registering data for GRCh38 reference"
+
 ngb rd GRCh38 SV_Sample1
 ngb add SV_Sample1 sample_1-lumpy.vcf
 ngb add SV_Sample1 sv_sample_1.bw
 ngb add SV_Sample1 sv_sample_1.bam
-ngb reg_file GRCh38 sample_2-lumpy.vcf
-ngb reg_file GRCh38 sv_sample_2.bw
-ngb reg_file GRCh38 sv_sample_2.bam
 
 ngb rd GRCh38 SV_Sample2
 ngb add SV_Sample2 sample_2-lumpy.vcf
@@ -126,29 +210,11 @@ ngb add RNASeq-chr22-SpliceJunctions brain_th.bam
 
 ngb reg_file GRCh38 FGFR3-TACC-Fusion.vcf
 ngb reg_file GRCh38 FGFR3-TACC-Fusion.bam
+
 ngb rd GRCh38 FGFR3-TACC-Fusion-Sample
 ngb add FGFR3-TACC-Fusion-Sample FGFR3-TACC-Fusion.vcf
 ngb add FGFR3-TACC-Fusion-Sample FGFR3-TACC-Fusion.bam
 
-ngb reg_file DM6 agnX1.09-28.trim.dm606.realign.vcf
-ngb reg_file DM6 agnX1.09-28.trim.dm606.realign.bam?agnX1.09-28.trim.dm606.realign.bai
-ngb reg_file DM6 CantonS.09-28.trim.dm606.realign.vcf
-ngb reg_file DM6 CantonS.09-28.trim.dm606.realign.bam?CantonS.09-28.trim.dm606.realign.bai
-ngb reg_file DM6 agnts3.09-28.trim.dm606.realign.vcf
-ngb reg_file DM6 agnts3.09-28.trim.dm606.realign.bam?agnts3.09-28.trim.dm606.realign.bai
-
-ngb rd DM6 Fruitfly
-ngb add Fruitfly agnX1.09-28.trim.dm606.realign.vcf
-ngb add Fruitfly agnX1.09-28.trim.dm606.realign.bam
-ngb add Fruitfly CantonS.09-28.trim.dm606.realign.vcf
-ngb add Fruitfly CantonS.09-28.trim.dm606.realign.bam
-
-#Remove downloaded raw archives with genomes
-rm Homo_sapiens.GRCh38.fa.gz Homo_sapiens.GRCh37.fa.gz
-rm dmel-all-chromosome-r6.06.fasta.gz dmel-all-r6.06.sorted.gtf.gz
-rm Mus_musculus.GRCm38.fa.gz  Mus_musculus.GRCm38.sorted.gtf.gz
-
-#Remove demo data archive
-rm ngb_demo_data.tar.gz
+echo "All data have been registered successfully"
 
 exit 0

--- a/docs/md/installation/docker.md
+++ b/docs/md/installation/docker.md
@@ -141,3 +141,35 @@ Restarting a container using this command will not cause loss of data or NGB con
 * PIK3CA-E545K-Sample dataset: [E545K SNV](http://localhost:8080/catgenome/#/GRCh38/3/179218268/179218337?rewrite=Off&tracks=%5B%7B%22h%22%3A20%2C%22s%22%3A%7B%7D%2C%22b%22%3A%22GRCh38%22%2C%22p%22%3A%22PIK3CA-E545K-Sample%22%7D%2C%7B%22h%22%3A70%2C%22s%22%3A%7B%22v%22%3A%22Collapsed%22%7D%2C%22b%22%3A%22PIK3CA-E545K.vcf%22%2C%22p%22%3A%22PIK3CA-E545K-Sample%22%7D%2C%7B%22h%22%3A80%2C%22s%22%3A%7B%22g%22%3A%22expanded%22%7D%2C%22b%22%3A%22GRCh38_Genes%22%2C%22p%22%3A%22PIK3CA-E545K-Sample%22%7D%2C%7B%22h%22%3A365%2C%22s%22%3A%7B%22a%22%3Atrue%2C%22c%22%3A%22noColor%22%2C%22c1%22%3Atrue%2C%22d%22%3Atrue%2C%22g1%22%3A%22default%22%2C%22i%22%3Atrue%2C%22m%22%3Atrue%2C%22r%22%3A%221%22%2C%22s1%22%3Afalse%2C%22s2%22%3Atrue%2C%22s3%22%3Afalse%2C%22v1%22%3Afalse%7D%2C%22b%22%3A%22PIK3CA-E545K.bam%22%2C%22p%22%3A%22PIK3CA-E545K-Sample%22%7D%5D)
 
 * Fruitfly dataset: [LIMK 1 SNV-INDELS](http://localhost:8080/catgenome/#/DM6/X/12588906/12592411?rewrite=Off&tracks=%5B%7B%22h%22%3A20%2C%22s%22%3A%7B%7D%2C%22b%22%3A%22DM6%22%2C%22p%22%3A%22Fruitfly%22%7D%2C%7B%22h%22%3A69%2C%22s%22%3A%7B%22g%22%3A%22collapsed%22%7D%2C%22b%22%3A%22DM6_Genes%22%2C%22p%22%3A%22Fruitfly%22%7D%2C%7B%22h%22%3A189%2C%22s%22%3A%7B%22v%22%3A%22Expanded%22%7D%2C%22b%22%3A%22CantonS.09-28.trim.dm606.realign.vcf%22%2C%22p%22%3A%22Fruitfly%22%7D%2C%7B%22h%22%3A444%2C%22s%22%3A%7B%22a%22%3Atrue%2C%22c%22%3A%22noColor%22%2C%22c1%22%3Atrue%2C%22d%22%3Atrue%2C%22g1%22%3A%22default%22%2C%22i%22%3Atrue%2C%22m%22%3Atrue%2C%22r%22%3A%221%22%2C%22s1%22%3Afalse%2C%22s2%22%3Atrue%2C%22s3%22%3Afalse%2C%22v1%22%3Afalse%7D%2C%22b%22%3A%22CantonS.09-28.trim.dm606.realign.bam%22%2C%22p%22%3A%22Fruitfly%22%7D%5D)
+
+# Develop versions of docker images
+
+Docker images from develop branch are automatically builded by Travis-CI and pushed to DockerHub.
+Unfourunately, the demo data could not be included in the image due to the large size of demo data and Travis disk space limitations.
+So you have to download data by the demo_data_download.sh script located in the docker/demo/ folder
+
+To launch the docker image put the demo_data_script.sh file to the folder on the host machine you want to be used for the data download.
+Just for the example let it be /home/user/ngb_files
+
+Next, download the pull the -dev docker image and launch it (replace 2.6.0.34.1.34.1 with the version number you want)
+
+```
+$ docker run -d -p 8080:8080 --name ngbcore -v /home/user/ngb_files/:/ngs epam/lifesciences/ngb:2.6.0.34.1.34.1-dev
+```
+This command will start docker with the ngbcore name, mount the folder /home/user/ngb_files on the host machine to the /ngs mount point of the container and expose the 8080 port for the ngb graphical interface
+
+Now run the script to download demo data
+```
+$ docker exec -it ngbcore /ngs/demo_data_download.sh
+```
+demo_data_download.sh script will download genome references to ~/ngb_data/references and demo data to /home /ngb_data/data_files by default
+But you can change the paths for references and data files by passing -r and -f arguments to the demo_data_download.sh script, respectively if you want to
+
+For example:
+```
+./demo_data_download.sh -r ~/references -f ~/some/other/folder
+```
+
+The script will download all the necessary files and will register them by itself. But please be patient, as the reference donwload may take much time.
+
+


### PR DESCRIPTION
# Description


## Background
The develop branch is automatically deployed to Dockerhub, but with no data in it. The script added in this PR downloads data to the ngb after the docker container launch

## Changes
The demo_data_download.sh was added to the /docker/demo/ folder 

## Acceptance criteria

The script could be able to download reference fasta's, gene files, demo data from ngb.opensource.epam.com and register them. 

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [x] Documentation is updated
