### PR TITLE
Cache for indexes and headers enable/disable feature 

### DIFF
--- a/docs/md/installation/binaries.md
+++ b/docs/md/installation/binaries.md
@@ -92,10 +92,10 @@ echo "files.vcf.max.entries.in.memory=1000000" >> $CATGENOME_CONF_DIR/catgenome.
 
 If you want to disable cache for headers and indexes of VCF, GTF, BED files, change the following property. By default it is true:
 
-* **server.cache.enabled=false** - disables caching for headers and indexes
+* **server.index.cache.enabled=false** - disables caching for headers and indexes
 
 ```
-echo "server.cache.enabled=false" >> $CATGENOME_CONF_DIR/catgenome.properties
+echo "server.index.cache.enabled=false" >> $CATGENOME_CONF_DIR/catgenome.properties
 ```
 
 Set Tomcat configuration in the file **$CATALINA_HOME/conf/server.xml** by adding the 

--- a/docs/md/installation/binaries.md
+++ b/docs/md/installation/binaries.md
@@ -90,6 +90,14 @@ If you want to specify max number of VcfIndexEntries keeping in memory during vc
 echo "files.vcf.max.entries.in.memory=1000000" >> $CATGENOME_CONF_DIR/catgenome.properties
 ```
 
+If you want to disable cache for headers and indexes of VCF, GTF, BED files, change the following property. By default it is true:
+
+* **server.cache.enabled=false** - disables caching for headers and indexes
+
+```
+echo "server.cache.enabled=false" >> $CATGENOME_CONF_DIR/catgenome.properties
+```
+
 Set Tomcat configuration in the file **$CATALINA_HOME/conf/server.xml** by adding the 
  following values to the **"Connector"** XML node
  

--- a/docs/md/installation/standalone.md
+++ b/docs/md/installation/standalone.md
@@ -84,6 +84,9 @@ If you want to configure default options for tracks visualization on a client si
 If you want to specify max number of VcfIndexEntries keeping in memory during vcf loading, add the following property. For files, which produce more entries then the number, extra entries will be spilled to disk (temp directory).
 * **files.vcf.max.entries.in.memory=1000000** - 1000000 entries take about 3Gb in the heap
 
+If you want to disable cache for headers and indexes of VCF, GTF, BED files, change the following property. By default it is true:
+* **server.cache.enabled=false** - disables caching for headers and indexes
+
 If you want to secure NGB we provide an optional authorization using JWT tokens. To enable authorization you should set the following properties:
  * **jwt.security.enable=true** enables the JWT Authorization
  * **jwt.key.public=PUBLIC_KEY_VALUE** public key to perform JWT token validation

--- a/docs/md/installation/standalone.md
+++ b/docs/md/installation/standalone.md
@@ -85,7 +85,7 @@ If you want to specify max number of VcfIndexEntries keeping in memory during vc
 * **files.vcf.max.entries.in.memory=1000000** - 1000000 entries take about 3Gb in the heap
 
 If you want to disable cache for headers and indexes of VCF, GTF, BED files, change the following property. By default it is true:
-* **server.cache.enabled=false** - disables caching for headers and indexes
+* **server.index.cache.enabled=false** - disables caching for headers and indexes
 
 If you want to secure NGB we provide an optional authorization using JWT tokens. To enable authorization you should set the following properties:
  * **jwt.security.enable=true** enables the JWT Authorization

--- a/server/catgenome/profiles/desktop/catgenome.properties
+++ b/server/catgenome/profiles/desktop/catgenome.properties
@@ -43,5 +43,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
-#cache settings
-server.cache.enabled=true
+#index cache settings
+server.index.cache.enabled=true

--- a/server/catgenome/profiles/desktop/catgenome.properties
+++ b/server/catgenome/profiles/desktop/catgenome.properties
@@ -43,4 +43,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
+#cache settings
 server.cache.enabled=true

--- a/server/catgenome/profiles/desktop/catgenome.properties
+++ b/server/catgenome/profiles/desktop/catgenome.properties
@@ -42,3 +42,5 @@ blat.search.url=http://genome.cse.ucsc.edu/cgi-bin/hgBlat
 blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
+
+server.cache.enabled=true

--- a/server/catgenome/profiles/dev/catgenome.properties
+++ b/server/catgenome/profiles/dev/catgenome.properties
@@ -64,3 +64,5 @@ blat.search.url=http://genome.cse.ucsc.edu/cgi-bin/hgBlat
 blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
+
+server.cache.enabled=true

--- a/server/catgenome/profiles/dev/catgenome.properties
+++ b/server/catgenome/profiles/dev/catgenome.properties
@@ -65,5 +65,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
-#cache settings
-server.cache.enabled=true
+#index cache settings
+server.index.cache.enabled=true

--- a/server/catgenome/profiles/dev/catgenome.properties
+++ b/server/catgenome/profiles/dev/catgenome.properties
@@ -65,4 +65,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
+#cache settings
 server.cache.enabled=true

--- a/server/catgenome/profiles/h2/test-catgenome-cache-disable.properties
+++ b/server/catgenome/profiles/h2/test-catgenome-cache-disable.properties
@@ -1,0 +1,1 @@
+server.index.cache.enabled=false

--- a/server/catgenome/profiles/h2/test-catgenome.properties
+++ b/server/catgenome/profiles/h2/test-catgenome.properties
@@ -75,5 +75,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
-#cache settings
-server.cache.enabled=true
+#index cache settings
+server.index.cache.enabled=true

--- a/server/catgenome/profiles/h2/test-catgenome.properties
+++ b/server/catgenome/profiles/h2/test-catgenome.properties
@@ -74,3 +74,5 @@ blat.search.url=http://genome.cse.ucsc.edu/cgi-bin/hgBlat
 blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
+
+server.cache.enabled=true

--- a/server/catgenome/profiles/h2/test-catgenome.properties
+++ b/server/catgenome/profiles/h2/test-catgenome.properties
@@ -75,4 +75,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
+#cache settings
 server.cache.enabled=true

--- a/server/catgenome/profiles/jar/catgenome.properties
+++ b/server/catgenome/profiles/jar/catgenome.properties
@@ -47,3 +47,5 @@ blat.search.url=http://genome.cse.ucsc.edu/cgi-bin/hgBlat
 blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
+
+server.cache.enabled=true

--- a/server/catgenome/profiles/jar/catgenome.properties
+++ b/server/catgenome/profiles/jar/catgenome.properties
@@ -48,4 +48,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
+#cache settings
 server.cache.enabled=true

--- a/server/catgenome/profiles/jar/catgenome.properties
+++ b/server/catgenome/profiles/jar/catgenome.properties
@@ -48,5 +48,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
-#cache settings
-server.cache.enabled=true
+#index cache settings
+server.index.cache.enabled=true

--- a/server/catgenome/profiles/postgres/test-catgenome.properties
+++ b/server/catgenome/profiles/postgres/test-catgenome.properties
@@ -73,5 +73,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
-#cache settings
-server.cache.enabled=true
+#index cache settings
+server.index.cache.enabled=true

--- a/server/catgenome/profiles/postgres/test-catgenome.properties
+++ b/server/catgenome/profiles/postgres/test-catgenome.properties
@@ -73,4 +73,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
+#cache settings
 server.cache.enabled=true

--- a/server/catgenome/profiles/postgres/test-catgenome.properties
+++ b/server/catgenome/profiles/postgres/test-catgenome.properties
@@ -72,3 +72,5 @@ blat.search.url=http://genome.cse.ucsc.edu/cgi-bin/hgBlat
 blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
+
+server.cache.enabled=true

--- a/server/catgenome/profiles/release/catgenome.properties
+++ b/server/catgenome/profiles/release/catgenome.properties
@@ -56,3 +56,5 @@ blat.search.url=http://genome.cse.ucsc.edu/cgi-bin/hgBlat
 blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
+
+server.cache.enabled=true

--- a/server/catgenome/profiles/release/catgenome.properties
+++ b/server/catgenome/profiles/release/catgenome.properties
@@ -57,4 +57,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
+#cache settings
 server.cache.enabled=true

--- a/server/catgenome/profiles/release/catgenome.properties
+++ b/server/catgenome/profiles/release/catgenome.properties
@@ -57,5 +57,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
-#cache settings
-server.cache.enabled=true
+#index cache settings
+server.index.cache.enabled=true

--- a/server/catgenome/profiles/staging/catgenome.properties
+++ b/server/catgenome/profiles/staging/catgenome.properties
@@ -57,3 +57,5 @@ blat.search.url=http://genome.cse.ucsc.edu/cgi-bin/hgBlat
 blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
+
+server.cache.enabled=true

--- a/server/catgenome/profiles/staging/catgenome.properties
+++ b/server/catgenome/profiles/staging/catgenome.properties
@@ -58,5 +58,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
-#cache settings
-server.cache.enabled=true
+#index cache settings
+server.index.cache.enabled=true

--- a/server/catgenome/profiles/staging/catgenome.properties
+++ b/server/catgenome/profiles/staging/catgenome.properties
@@ -58,4 +58,5 @@ blat.search.type=DNA
 blat.search.sort.order=query,score
 blat.search.output.type=psl
 
+#cache settings
 server.cache.enabled=true

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
@@ -166,7 +166,7 @@ public class FileManager {
     private static final String EMPTY = "";
     public static final String BED_GRAPH_FEATURE_TEMPLATE = "%s\t%d\t%d\t%f%n";
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
     /**
      * Provides paths' patterns that have to be used to construct real relative paths

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
@@ -111,7 +111,7 @@ public class BedManager {
     @Autowired
     private FeatureIndexManager featureIndexManager;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     private static final Logger LOG = LoggerFactory.getLogger(BedManager.class);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -166,7 +166,7 @@ public class GffManager {
     @Autowired
     private TaskExecutorService taskExecutorService;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     private static final String EXON_FEATURE_NAME = "exon";

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/maf/MafManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/maf/MafManager.java
@@ -93,7 +93,7 @@ public class MafManager {
     @Autowired
     private DownloadFileManager downloadFileManager;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MafManager.class);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -155,7 +155,7 @@ public class VcfManager {
     @Autowired
     private FeatureIndexDao featureIndexDao;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     public static final double HTSJDK_WRONG_QUALITY = -10.0;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/FacadeWigManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/FacadeWigManager.java
@@ -96,7 +96,7 @@ public class FacadeWigManager {
     @Autowired
     protected DownloadFileManager downloadFileManager;
 
-    @Autowired
+    @Autowired(required = false)
     protected EhCacheBasedIndexCache indexCache;
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(FacadeWigManager.class);

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/AbstractFeatureReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/AbstractFeatureReader.java
@@ -105,11 +105,11 @@ public abstract class AbstractFeatureReader<T extends Feature, S> implements Fea
                     throw new TribbleException(
                             "Tabix indexed files only work with ASCII codecs, but received non-Ascii codec "
                                     + codec.getClass().getSimpleName());
-                } return new TabixFeatureReader<F, S>(featureResource, indexResource,
+                }
+                return new TabixFeatureReader<F, S>(featureResource, indexResource,
                         (AsciiFeatureCodec) codec, indexCache);
-            }
-            // Not tabix => tribble index file (might be gzipped, but not block gzipped)
-            else {
+            } else {
+                // Not tabix => tribble index file (might be gzipped, but not block gzipped)
                 return new TribbleIndexedFeatureReader<F, S>(featureResource, indexResource, codec,
                         requireIndex, indexCache);
             }

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/EhCacheBasedIndexCache.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/EhCacheBasedIndexCache.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 @Service
-@ConditionalOnProperty(value = "server.cache.enabled", havingValue = "true")
+@ConditionalOnProperty(value = "server.index.cache.enabled", havingValue = "true")
 public class EhCacheBasedIndexCache {
     private static final String INDEX_CACHE = "indexCache";
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/EhCacheBasedIndexCache.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/EhCacheBasedIndexCache.java
@@ -30,11 +30,13 @@ import net.sf.ehcache.CacheException;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.ehcache.EhCacheCacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 @Service
+@ConditionalOnProperty(value = "server.cache.enabled", havingValue = "true")
 public class EhCacheBasedIndexCache {
     private static final String INDEX_CACHE = "indexCache";
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/TabixFeatureReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/TabixFeatureReader.java
@@ -102,7 +102,8 @@ public class TabixFeatureReader<T extends Feature, S> extends AbstractFeatureRea
                 indexFilePath = IndexUtils.getFirstPartForIndexPath(indexFile);
             }
             if (indexCache != null && indexCache.contains(indexFilePath)) {
-                TabixReader.TabixIndexCache tabixIndexCache = (TabixReader.TabixIndexCache) indexCache.getFromCache(indexFilePath);
+                TabixReader.TabixIndexCache tabixIndexCache =
+                        (TabixReader.TabixIndexCache) indexCache.getFromCache(indexFilePath);
                 header = tabixIndexCache.getHeader();
 
                 if (header == null) {
@@ -194,10 +195,13 @@ public class TabixFeatureReader<T extends Feature, S> extends AbstractFeatureRea
         protected void readNextRecord() throws IOException {
             currentRecord = null;
             String nextLine;
-            while (currentRecord == null && (nextLine = lineReader.readLine()) != null) {
-                final Feature f;
+            while (currentRecord == null) {
+                nextLine = lineReader.readLine();
+                if (nextLine == null) {
+                    return;
+                }
                 try {
-                    f = ((AsciiFeatureCodec)codec).decode(nextLine);
+                    final Feature f = ((AsciiFeatureCodec)codec).decode(nextLine);
                     if (f == null) {
                         continue;   // Skip
                     }
@@ -208,7 +212,6 @@ public class TabixFeatureReader<T extends Feature, S> extends AbstractFeatureRea
                         continue;   // Skip
                     }
                     currentRecord = (T) f;
-
                 } catch (TribbleException e) {
                     e.setSource(path);
                     throw e;

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/TabixReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/TabixReader.java
@@ -67,16 +67,16 @@ public class TabixReader {
 
     private Map<String, Integer> mChr2tid;
 
-    private static int maxBin = 37450;
+    private static final int MAX_BIN = 37450;
     //private static int TAD_MIN_CHUNK_GAP = 32768; (not used)
-    private static int tadLidxShift = 14;
+    private static final int TAD_LIDX_SHIFT = 14;
 
     protected static class TPair64 implements Comparable<TPair64> {
         long u, v;
 
-        public TPair64(final long _u, final long _v) {
-            u = _u;
-            v = _v;
+        public TPair64(final long longU, final long longV) {
+            u = longU;
+            v = longV;
         }
 
         public TPair64(final TPair64 p) {
@@ -179,34 +179,43 @@ public class TabixReader {
     }
 
     /** return the source (filename/URL) of that reader */
-    public String getSource()
-    {
+    public String getSource() {
         return this.mFn;
     }
 
-    private static int reg2bins(final int beg, final int _end, final int[] list) {
-        int i = 0, k, end = _end;
+    private static int reg2bins(final int beg, final int intEnd, final int[] list) {
+        int i = 0, k, end = intEnd;
         if (beg >= end) {
             return 0;
         }
-        if (end >= 1 << 29) {
-            end = 1 << 29;
+        final int shift0 = 29;
+        if (end >= 1 << shift0) {
+            end = 1 << shift0;
         }
         --end;
         list[i++] = 0;
-        for (k = 1 + (beg >> 26); k <= 1 + (end >> 26); ++k) {
+        final int shift1 = 26;
+        for (k = 1 + (beg >> shift1); k <= 1 + (end >> shift1); ++k) {
             list[i++] = k;
         }
-        for (k = 9 + (beg >> 23); k <= 9 + (end >> 23); ++k) {
+        final int shift2 = 23;
+        final int startShift2 = 9;
+        for (k = startShift2 + (beg >> shift2); k <= startShift2 + (end >> shift2); ++k) {
             list[i++] = k;
         }
-        for (k = 73 + (beg >> 20); k <= 73 + (end >> 20); ++k) {
+        final int shift3 = 20;
+        final int startShift3 = 73;
+        for (k = startShift3 + (beg >> shift3); k <= startShift3 + (end >> shift3); ++k) {
             list[i++] = k;
         }
-        for (k = 585 + (beg >> 17); k <= 585 + (end >> 17); ++k) {
+        final int shift4 = 17;
+        final int startShift4 = 585;
+        for (k = startShift4 + (beg >> shift4); k <= startShift4 + (end >> shift4); ++k) {
             list[i++] = k;
         }
-        for (k = 4681 + (beg >> 14); k <= 4681 + (end >> 14); ++k) {
+        final int shift5 = 14;
+        final int startShift5 = 4681;
+        for (k = startShift5 + (beg >> shift5); k <= startShift5 + (end >> shift5); ++k) {
             list[i++] = k;
         }
         return i;
@@ -226,9 +235,10 @@ public class TabixReader {
 
     public static String readLine(final InputStream is) throws IOException {
         StringBuffer buf = new StringBuffer();
-        int c;
-        while ((c = is.read()) >= 0 && c != '\n') {
+        int c = is.read();
+        while (c >= 0 && c != '\n') {
             buf.append((char) c);
+            c = is.read();
         }
         if (c < 0) {
             return null;
@@ -271,13 +281,16 @@ public class TabixReader {
             mBc = readInt(is);
             mEc = readInt(is);
             mMeta = readInt(is);
-            readInt(is);//unused
+            readInt(is); //unused
             // read sequence dictionary
-            int i, j, k, l = readInt(is);
+            int l = readInt(is);
+            int i;
+            int j;
+            int k;
             buf = new byte[l];
             is.read(buf);
 
-            for (i = j = k = 0; i < buf.length; ++i) {
+            for (i = 0, j = 0, k = 0; i < buf.length; ++i) {
                 if (buf[i] == 0) {
                     byte[] b = new byte[i - j];
                     System.arraycopy(buf, j, b, 0, b.length);
@@ -292,10 +305,10 @@ public class TabixReader {
 
             for (i = 0; i < mSeq.length; ++i) {
                 // the binning index
-                int n_bin = readInt(is);
+                int nBin = readInt(is);
                 mIndex[i] = new TIndex();
-                mIndex[i].b = new HashMap<Integer, TPair64[]>(n_bin);
-                for (j = 0; j < n_bin; ++j) {
+                mIndex[i].b = new HashMap<Integer, TPair64[]>(nBin);
+                for (j = 0; j < nBin; ++j) {
                     int bin = readInt(is);
                     TPair64[] chunks = new TPair64[readInt(is)];
                     for (k = 0; k < chunks.length; ++k) {
@@ -334,7 +347,8 @@ public class TabixReader {
      */
     private void readIndex() throws IOException {
         ISeekableStreamFactory ssf = SeekableStreamFactory.getInstance();
-        SeekableStream bufferedStream = ssf.getBufferedStream(ssf.getStreamFor(mIdxFn), 128000);
+        final int bufferSize = 128000;
+        SeekableStream bufferedStream = ssf.getBufferedStream(ssf.getStreamFor(mIdxFn), bufferSize);
         readIndex(bufferedStream);
     }
 
@@ -352,8 +366,7 @@ public class TabixReader {
     }
 
     /** return the chromosomes in that tabix file */
-    public Set<String> getChromosomes()
-    {
+    public Set<String> getChromosomes() {
         return Collections.unmodifiableSet(this.mChr2tid.keySet());
     }
 
@@ -372,21 +385,26 @@ public class TabixReader {
         hyphen = reg.indexOf('-');
         chr = colon >= 0 ? reg.substring(0, colon) : reg;
         ret[1] = colon >= 0 ? Integer.parseInt(reg.substring(colon + 1, hyphen >= 0 ? hyphen : reg.length())) - 1 : 0;
-        ret[2] = hyphen >= 0 ? Integer.parseInt(reg.substring(hyphen + 1)) : 0x7fffffff;
+        final int maxIntInHex = 0x7fffffff;
+        ret[2] = hyphen >= 0 ? Integer.parseInt(reg.substring(hyphen + 1)) : maxIntInHex;
         ret[0] = this.chr2tid(chr);
         return ret;
     }
 
     private TIntv getIntv(final String s) {
         TIntv intv = new TIntv();
-        int col = 0, end = 0, beg = 0;
-        while ((end = s.indexOf('\t', beg)) >= 0 || end == -1) {
+        int col = 0;
+        int beg = 0;
+        int end = s.indexOf('\t', beg);
+        while (end >= 0 || end == -1) {
             ++col;
             if (col == mSc) {
                 intv.tid = chr2tid(end != -1 ? s.substring(beg, end) : s.substring(beg));
             } else if (col == mBc) {
-                intv.beg = intv.end = Integer.parseInt(end != -1 ? s.substring(beg, end) : s.substring(beg));
-                if ((mPreset & 0x10000) != 0) {
+                intv.end = Integer.parseInt(end != -1 ? s.substring(beg, end) : s.substring(beg));
+                intv.beg = intv.end;
+                final int magicNumber = 0x10000;
+                if ((mPreset & magicNumber) != 0) {
                     ++intv.end;
                 } else {
                     --intv.beg;
@@ -398,15 +416,16 @@ public class TabixReader {
                     intv.end = 1;
                 }
             } else { // FIXME: SAM supports are not tested yet
-                if ((mPreset & 0xffff) == 0) { // generic
+                final int bitFlag = 0xffff;
+                if ((mPreset & bitFlag) == 0) { // generic
                     if (col == mEc) {
                         intv.end = Integer.parseInt(end != -1 ? s.substring(beg, end) : s.substring(beg));
                     }
-                } else if ((mPreset & 0xffff) == 1) { // SAM
+                } else if ((mPreset & bitFlag) == 1) { // SAM
                     if (col == 6) { // CIGAR
                         int l = 0, i, j;
                         String cigar = s.substring(beg, end);
-                        for (i = j = 0; i < cigar.length(); ++i) {
+                        for (i = 0, j = 0; i < cigar.length(); ++i) {
                             if (cigar.charAt(i) > '9') {
                                 int op = cigar.charAt(i);
                                 if (op == 'M' || op == 'D' || op == 'N') {
@@ -417,7 +436,7 @@ public class TabixReader {
                         }
                         intv.end = intv.beg + l;
                     }
-                } else if ((mPreset & 0xffff) == 2) { // VCF
+                } else if ((mPreset & bitFlag) == 2) { // VCF
                     String alt;
                     alt = end >= 0 ? s.substring(beg, end) : s.substring(beg);
                     if (col == 4) { // REF
@@ -425,18 +444,18 @@ public class TabixReader {
                             intv.end = intv.beg + alt.length();
                         }
                     } else if (col == 8) { // INFO
-                        int e_off = -1, i = alt.indexOf("END=");
+                        int eOff = -1, i = alt.indexOf("END=");
                         if (i == 0) {
-                            e_off = 4;
+                            eOff = 4;
                         } else if (i > 0) {
                             i = alt.indexOf(";END=");
                             if (i >= 0) {
-                                e_off = i + 5;
+                                eOff = i + 5;
                             }
                         }
-                        if (e_off > 0) {
-                            i = alt.indexOf(';', e_off);
-                            intv.end = Integer.parseInt(i > e_off ? alt.substring(e_off, i) : alt.substring(e_off));
+                        if (eOff > 0) {
+                            i = alt.indexOf(';', eOff);
+                            intv.end = Integer.parseInt(i > eOff ? alt.substring(eOff, i) : alt.substring(eOff));
                         }
                     }
                 }
@@ -445,18 +464,18 @@ public class TabixReader {
                 break;
             }
             beg = end + 1;
+            end = s.indexOf('\t', beg);
         }
         return intv;
     }
 
-    public interface Iterator
-    {
+    public interface Iterator {
         /** return null when there is no more data to read */
         String next() throws IOException;
     }
 
     /** iterator returned instead of null when there is no more data */
-    private static final Iterator EOF_ITERATOR=new Iterator()  {
+    private static final Iterator EOF_ITERATOR = new Iterator()  {
         @Override
         public String next() throws IOException {
             return null;
@@ -464,23 +483,23 @@ public class TabixReader {
     };
 
     /** default implementation of Iterator */
-    private class IteratorImpl implements Iterator {
+    private final class IteratorImpl implements Iterator {
         private int i;
         //private int n_seeks;
         private int tid, beg, end;
         private TPair64[] off;
-        private long curr_off;
+        private long currOff;
         private boolean iseof;
 
-        private IteratorImpl(final int _tid, final int _beg, final int _end, final TPair64[] _off) {
+        private IteratorImpl(final int intTid, final int intBeg, final int intEnd, final TPair64[] tPairOff) {
             i = -1;
             //n_seeks = 0;
-            curr_off = 0;
+            currOff = 0;
             iseof = false;
-            off = _off;
-            tid = _tid;
-            beg = _beg;
-            end = _end;
+            off = tPairOff;
+            tid = intTid;
+            beg = intBeg;
+            end = intEnd;
         }
 
         @Override
@@ -488,26 +507,26 @@ public class TabixReader {
             if (iseof) {
                 return null;
             }
-            for (; ;) {
-                if (curr_off == 0 || !less64(curr_off, off[i].v)) { // then jump to the next chunk
+            for (;;) {
+                if (currOff == 0 || !less64(currOff, off[i].v)) { // then jump to the next chunk
                     if (i == off.length - 1) {
                         break; // no more chunks
                     }
                     if (i >= 0) {
-                        assert (curr_off == off[i].v); // otherwise bug
+                        assert (currOff == off[i].v); // otherwise bug
                     }
                     if (i < 0 || off[i].v != off[i + 1].u) { // not adjacent chunks; then seek
                         mFp.seek(off[i + 1].u);
-                        curr_off = mFp.getFilePointer();
+                        currOff = mFp.getFilePointer();
                         //++n_seeks;
                     }
                     ++i;
                 }
-                String s;
-                if ((s = readLine(mFp)) != null) {
+                String s = readLine(mFp);
+                if (s != null) {
                     TIntv intv;
                     char[] str = s.toCharArray();
-                    curr_off = mFp.getFilePointer();
+                    currOff = mFp.getFilePointer();
                     if (str.length == 0 || str[0] == mMeta) {
                         continue;
                     }
@@ -535,68 +554,69 @@ public class TabixReader {
      */
     public Iterator query(final int tid, final int beg, final int end) {
         TPair64[] off, chunks;
-        long min_off;
-        if(tid< 0 || tid>=this.mIndex.length) {
+        long minOff;
+        if (tid < 0 || tid >= this.mIndex.length) {
             return EOF_ITERATOR;
         }
         TIndex idx = mIndex[tid];
-        int[] bins = new int[maxBin];
-        int i, l, n_off, n_bins = reg2bins(beg, end, bins);
+        int[] bins = new int[MAX_BIN];
+        int i, l, nOff, nBins = reg2bins(beg, end, bins);
 
         if (idx.l.length > 0) {
-            min_off = (beg >> tadLidxShift >= idx.l.length) ? idx.l[idx.l.length - 1] : idx.l[beg >> tadLidxShift];
+            minOff = (beg >> TAD_LIDX_SHIFT >= idx.l.length) ? idx.l[idx.l.length - 1] : idx.l[beg >> TAD_LIDX_SHIFT];
         } else {
-            min_off = 0;
+            minOff = 0;
         }
-        for (i = n_off = 0; i < n_bins; ++i) {
-            if ((chunks = idx.b.get(bins[i])) != null) {
-                n_off += chunks.length;
+        for (i = 0, nOff = 0; i < nBins; ++i) {
+            chunks = idx.b.get(bins[i]);
+            if (chunks != null) {
+                nOff += chunks.length;
             }
         }
-        if (n_off == 0) {
+        if (nOff == 0) {
             return EOF_ITERATOR;
         }
-        off = new TPair64[n_off];
-        for (i = n_off = 0; i < n_bins; ++i) {
-            if ((chunks = idx.b.get(bins[i])) != null) {
+        off = new TPair64[nOff];
+        for (i = 0, nOff = 0; i < nBins; ++i) {
+            chunks = idx.b.get(bins[i]);
+            if (chunks != null) {
                 for (int j = 0; j < chunks.length; ++j) {
-                    if (less64(min_off, chunks[j].v)) {
-                        off[n_off++] = new TPair64(chunks[j]);
+                    if (less64(minOff, chunks[j].v)) {
+                        off[nOff++] = new TPair64(chunks[j]);
                     }
                 }
             }
         }
-        Arrays.sort(off, 0, n_off);
+        Arrays.sort(off, 0, nOff);
         // resolve completely contained adjacent blocks
-        for (i = 1, l = 0; i < n_off; ++i) {
+        for (i = 1, l = 0; i < nOff; ++i) {
             if (less64(off[l].v, off[i].v)) {
                 ++l;
                 off[l].u = off[i].u;
                 off[l].v = off[i].v;
             }
         }
-        n_off = l + 1;
+        nOff = l + 1;
         // resolve overlaps between adjacent blocks; this may happen due to the merge in indexing
-        for (i = 1; i < n_off; ++i) {
+        for (i = 1; i < nOff; ++i) {
             if (!less64(off[i - 1].v, off[i].u)) {
                 off[i - 1].v = off[i].u;
             }
         }
         // merge adjacent blocks
-        for (i = 1, l = 0; i < n_off; ++i) {
+        for (i = 1, l = 0; i < nOff; ++i) {
             if (off[l].v >> 16 == off[i].u >> 16) {
                 off[l].v = off[i].v;
-            }
-            else {
+            } else {
                 ++l;
                 off[l].u = off[i].u;
                 off[l].v = off[i].v;
             }
         }
-        n_off = l + 1;
+        nOff = l + 1;
         // return
-        TPair64[] ret = new TPair64[n_off];
-        for (i = 0; i < n_off; ++i) {
+        TPair64[] ret = new TPair64[nOff];
+        for (i = 0; i < nOff; ++i) {
             if (off[i] != null) {
                 ret[i] = new TPair64(off[i].u, off[i].v); // in C, this is inefficient
             }
@@ -659,7 +679,7 @@ public class TabixReader {
 
     // ADDED BY JTR
     public void close() throws IOException {
-        if(mFp != null) {
+        if (mFp != null) {
             try {
                 mFp.close();
             } catch (IOException e) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/TribbleIndexedFeatureReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/feature/reader/TribbleIndexedFeatureReader.java
@@ -128,7 +128,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, S> extends AbstractF
     private Index retrieveIndex(final String indexFile) {
         Index index;
         String indexFilePath = IndexUtils.getFirstPartForIndexPath(Tribble.indexFile(this.path));
-        if (indexCache.contains(indexFilePath)) {
+        if (indexCache != null && indexCache.contains(indexFilePath)) {
             tribbleIndexCache = (TribbleIndexCache) indexCache.getFromCache(indexFilePath);
             if (tribbleIndexCache.index != null) {
                 return tribbleIndexCache.index;
@@ -140,9 +140,11 @@ public class TribbleIndexedFeatureReader<T extends Feature, S> extends AbstractF
             }
         } else {
             index = IndexFactory.loadIndex(indexFile);
-            tribbleIndexCache = new TribbleIndexCache();
-            tribbleIndexCache.index = index;
-            indexCache.putInCache(tribbleIndexCache, indexFilePath);
+            if (indexCache != null) {
+                tribbleIndexCache = new TribbleIndexCache();
+                tribbleIndexCache.index = index;
+                indexCache.putInCache(tribbleIndexCache, indexFilePath);
+            }
             return index;
         }
     }
@@ -261,7 +263,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, S> extends AbstractF
             final S source;
             String indexFilePath = IndexUtils.getFirstPartForIndexPath(Tribble.indexFile(this.path));
 
-            if (indexCache.contains(indexFilePath)) {
+            if (indexCache != null && indexCache.contains(indexFilePath)) {
                 tribbleIndexCache = (TribbleIndexCache) indexCache.getFromCache(indexFilePath);
                 header = tribbleIndexCache.header;
                 if (header == null) {
@@ -275,11 +277,12 @@ public class TribbleIndexedFeatureReader<T extends Feature, S> extends AbstractF
             }  else {
                 source = codec.makeSourceFromStream(pbs);
                 header = codec.readHeader(source);
-
-                tribbleIndexCache = new TribbleIndexCache();
-                tribbleIndexCache.header = header;
-                tribbleIndexCache.codec = codec;
-                indexCache.putInCache(tribbleIndexCache, indexFilePath);
+                if (indexCache != null) {
+                    tribbleIndexCache = new TribbleIndexCache();
+                    tribbleIndexCache.header = header;
+                    tribbleIndexCache.codec = codec;
+                    indexCache.putInCache(tribbleIndexCache, indexFilePath);
+                }
             }
         } catch (IOException e) {
             throw new TribbleException.MalformedFeatureFile(

--- a/server/catgenome/src/main/resources/application.properties
+++ b/server/catgenome/src/main/resources/application.properties
@@ -11,3 +11,4 @@ security.headers.cache=false
 spring.resources.chain.enabled=true
 spring.resources.chain.strategy.content.enabled=true
 spring.resources.chain.strategy.content.paths=/**
+server.cache.enabled=true

--- a/server/catgenome/src/test/java/com/epam/catgenome/controller/BamControllerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/controller/BamControllerTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -107,6 +108,10 @@ public class BamControllerTest extends AbstractControllerTest {
         super.setup();
 
         taskExecutorService.setForceSequential(true);
+
+        System.out.println("Property from  file: " + context.getEnvironment().getProperty("database.username"));
+        ConfigurableEnvironment env = (ConfigurableEnvironment) context.getEnvironment();
+        System.out.println("Property sources: "+ env.getPropertySources());
 
         resource = context.getResource("classpath:templates");
         File fastaFile = new File(resource.getFile().getAbsolutePath() + "//dm606.X.fa");

--- a/server/catgenome/src/test/java/com/epam/catgenome/controller/BamControllerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/controller/BamControllerTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -108,10 +107,6 @@ public class BamControllerTest extends AbstractControllerTest {
         super.setup();
 
         taskExecutorService.setForceSequential(true);
-
-        System.out.println("Property from  file: " + context.getEnvironment().getProperty("database.username"));
-        ConfigurableEnvironment env = (ConfigurableEnvironment) context.getEnvironment();
-        System.out.println("Property sources: "+ env.getPropertySources());
 
         resource = context.getResource("classpath:templates");
         File fastaFile = new File(resource.getFile().getAbsolutePath() + "//dm606.X.fa");

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/gene/GffManagerUnitTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/gene/GffManagerUnitTest.java
@@ -70,7 +70,7 @@ public class GffManagerUnitTest {
     @Autowired
     private ApplicationContext context;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     private List<GeneFeature> featureList;

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/tools/SortTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/tools/SortTest.java
@@ -64,7 +64,7 @@ public class SortTest extends AbstractJUnitTest {
     @Autowired
     private ToolsManager toolsManager;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     @Test

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
@@ -115,7 +115,7 @@ import com.epam.catgenome.util.Utils;
  * @author Mikhail Miroliubov
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@TestPropertySource("classpath:application.properties")
+@TestPropertySource("classpath:test-catgenome.properties")
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class VcfManagerTest extends AbstractManagerTest {
 

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
@@ -58,6 +58,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -114,6 +115,7 @@ import com.epam.catgenome.util.Utils;
  * @author Mikhail Miroliubov
  */
 @RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource("classpath:application.properties")
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class VcfManagerTest extends AbstractManagerTest {
 
@@ -172,7 +174,7 @@ public class VcfManagerTest extends AbstractManagerTest {
     private ApplicationContext context;
 
     @Spy
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     private static final int TEST_END_INDEX = 187708306;

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/DiskBasedListTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/DiskBasedListTest.java
@@ -62,7 +62,7 @@ public class DiskBasedListTest {
     @Autowired
     private ApplicationContext context;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     @Test

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheDisabledIndexCacheTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheDisabledIndexCacheTest.java
@@ -1,0 +1,37 @@
+package com.epam.catgenome.util;
+
+import com.epam.catgenome.util.feature.reader.EhCacheBasedIndexCache;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test features of EhCacheBasedIndexCache: if index cache is disabled in properties, it must be null.
+ */
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource("classpath:test-catgenome-cache-disable.properties")
+@ContextConfiguration({"classpath:applicationContext-test.xml"})
+public class EhCacheDisabledIndexCacheTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Autowired(required = false)
+    private EhCacheBasedIndexCache indexCache;
+
+    @Test
+    public void testCacheProperty() {
+        assertNotNull(context);
+        Boolean indexCachePropertyStatus =
+                Boolean.valueOf(context.getEnvironment().getProperty("server.index.cache.enabled"));
+        assertFalse("Index cache property must be false", indexCachePropertyStatus);
+        assertNull("Index cache must be null", indexCache);
+    }
+}

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
@@ -50,7 +50,7 @@ public class EhCacheTest {
 
     @Test
     public void testCacheProperty() {
-        Boolean indexCacheStatus = Boolean.valueOf(context.getEnvironment().getProperty("server.cache.enabled"));
+        Boolean indexCacheStatus = Boolean.valueOf(context.getEnvironment().getProperty("server.index.cache.enabled"));
         assertTrue(indexCacheStatus);
         assertNotNull(indexCache);
     }

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.ehcache.EhCacheCacheManager;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -19,13 +20,14 @@ import static org.junit.Assert.*;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource("classpath:application.properties")
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class EhCacheTest {
 
     @Autowired
     private ApplicationContext context;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     @Autowired

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
@@ -8,17 +8,11 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.ehcache.EhCacheCacheManager;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.MutablePropertySources;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 import static org.junit.Assert.*;
 
 /**
@@ -31,7 +25,7 @@ import static org.junit.Assert.*;
 public class EhCacheTest {
 
     @Autowired
-    private ConfigurableApplicationContext context;
+    private ApplicationContext context;
 
     @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
@@ -48,13 +42,8 @@ public class EhCacheTest {
         assertNotNull(context);
         assertNotNull(cacheManager);
 
-        System.out.println("Property from file: " + context.getEnvironment().getProperty("database.username"));
-        ConfigurableEnvironment env = context.getEnvironment();
-        System.out.println("Property sources: "+ env.getPropertySources());
-
         index1 = new TestIndexCache("indexName1");
         index2 = new TestIndexCache("indexName2");
-
         indexCache.putInCache(index1, "1");
         indexCache.putInCache(index2, "2");
     }
@@ -64,16 +53,6 @@ public class EhCacheTest {
         Boolean indexCacheStatus = Boolean.valueOf(context.getEnvironment().getProperty("server.cache.enabled"));
         assertTrue(indexCacheStatus);
         assertNotNull(indexCache);
-
-        ConfigurableEnvironment env = context.getEnvironment();
-        MutablePropertySources propertySources = env.getPropertySources();
-        Map<String, Object> map = new HashMap<>();
-        map.put("server.cache.enabled","false");
-        propertySources
-                .addFirst(new MapPropertySource("newmap", map));
-
-        indexCacheStatus = Boolean.valueOf(context.getEnvironment().getProperty("server.cache.enabled"));
-        assertFalse(indexCacheStatus);
     }
 
     @Test

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 import static org.junit.Assert.*;
@@ -38,9 +39,6 @@ public class EhCacheTest {
     @Autowired
     private EhCacheCacheManager cacheManager;
 
-    @Autowired
-    private ConfigurableEnvironment environment;
-
     private IndexCache index1;
     private IndexCache index2;
     private static final String INDEX_CACHE_NAME = "indexCache";
@@ -49,6 +47,10 @@ public class EhCacheTest {
     public void setup() {
         assertNotNull(context);
         assertNotNull(cacheManager);
+
+        System.out.println("Property from file: " + context.getEnvironment().getProperty("database.username"));
+        ConfigurableEnvironment env = context.getEnvironment();
+        System.out.println("Property sources: "+ env.getPropertySources());
 
         index1 = new TestIndexCache("indexName1");
         index2 = new TestIndexCache("indexName2");

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/EhCacheTest.java
@@ -99,7 +99,8 @@ public class EhCacheTest {
 
         cacheConfiguration.setMaxBytesLocalHeap(1L);
         cacheConfiguration.setName("TestCache");
-        cacheConfiguration.setTimeToIdleSeconds(100);
+        final int testingTimeToIdleSeconds = 100;
+        cacheConfiguration.setTimeToIdleSeconds(testingTimeToIdleSeconds);
 
         assertEquals("Cache Name: TestCache, cacheManager: " + cache.getCacheManager() +
                 " cacheSize: 0 maxBytesLocalHeap: 1 timeToIdle: 100", indexCache.toString());

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/IndexHeaderCacheTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/IndexHeaderCacheTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@TestPropertySource("classpath:application.properties")
+@TestPropertySource("classpath:test-catgenome.properties")
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class IndexHeaderCacheTest<T extends Feature, S> extends AbstractManagerTest {
 

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/IndexHeaderCacheTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/IndexHeaderCacheTest.java
@@ -12,6 +12,7 @@ import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.junit.Test;
 
@@ -25,6 +26,7 @@ import java.io.IOException;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource("classpath:application.properties")
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class IndexHeaderCacheTest<T extends Feature, S> extends AbstractManagerTest {
 
@@ -32,7 +34,7 @@ public class IndexHeaderCacheTest<T extends Feature, S> extends AbstractManagerT
     private ApplicationContext context;
 
     @Spy
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     private static final String FELIS_CATUS_VCF = "classpath:templates/Felis_catus.vcf";

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/TabixReaderTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/TabixReaderTest.java
@@ -37,12 +37,15 @@ public class TabixReaderTest {
 
     @Test
     public void testSequenceNames() {
-        String[] expectedSeqNames = new String[24];
-        for (int i = 1; i < 24; i++) {
+        final int expectedSeqNamesLength = 24;
+        String[] expectedSeqNames = new String[expectedSeqNamesLength];
+        for (int i = 1; i < expectedSeqNamesLength; i++) {
             expectedSeqNames[i - 1] = String.valueOf(i);
         }
-        expectedSeqNames[22] = "X";
-        expectedSeqNames[23] = "Y";
+        final int numberChrX = 22;
+        final int numberChrY = 23;
+        expectedSeqNames[numberChrX] = "X";
+        expectedSeqNames[numberChrY] = "Y";
         assertEquals(expectedSeqNames.length, sequenceNames.size());
 
         for (String s : expectedSeqNames) {
@@ -60,12 +63,14 @@ public class TabixReaderTest {
 
     @Test
     public void testIterators() throws IOException {
-        TabixReader.Iterator iter = tabixReader.query("1", 1, 400);
+        final int sequenceIntervalEnd = 400;
+        TabixReader.Iterator iter = tabixReader.query("1", 1, sequenceIntervalEnd);
         assertNotNull(iter);
         assertNotNull(iter.next());
         assertNull(iter.next());
 
-        iter = tabixReader.query("UN", 1, 100);
+        final int sequenceShortIntervalEnd = 100;
+        iter = tabixReader.query("UN", 1, sequenceShortIntervalEnd);
         assertNotNull(iter);
         assertNull(iter.next());
 
@@ -77,7 +82,8 @@ public class TabixReaderTest {
         assertNotNull(iter);
         assertNull(iter.next());
 
-        iter = tabixReader.query(999999, 9, 9);
+        final int sequenceId = 999999;
+        iter = tabixReader.query(sequenceId, 9, 9);
         assertNotNull(iter);
         assertNull(iter.next());
 
@@ -85,18 +91,18 @@ public class TabixReaderTest {
         assertNotNull(iter);
         assertNull(iter.next());
 
-        final int pos_snp_in_vcf_chr1 = 327;
+        final int posSnpInVcfChr1 = 327;
 
-        iter = tabixReader.query("1", pos_snp_in_vcf_chr1, pos_snp_in_vcf_chr1);
+        iter = tabixReader.query("1", posSnpInVcfChr1, posSnpInVcfChr1);
         assertNotNull(iter);
         assertNotNull(iter);
         assertNull(iter.next());
 
-        iter = tabixReader.query("1", pos_snp_in_vcf_chr1 - 1, pos_snp_in_vcf_chr1 - 1);
+        iter = tabixReader.query("1", posSnpInVcfChr1 - 1, posSnpInVcfChr1 - 1);
         assertNotNull(iter);
         assertNull(iter.next());
 
-        iter = tabixReader.query("1", pos_snp_in_vcf_chr1 + 1, pos_snp_in_vcf_chr1 + 1);
+        iter = tabixReader.query("1", posSnpInVcfChr1 + 1, posSnpInVcfChr1 + 1);
         assertNotNull(iter);
         assertNull(iter.next());
     }
@@ -108,8 +114,11 @@ public class TabixReaderTest {
      */
     @Test
     public void testLocalQuery() throws IOException {
+        final int intervalBegin = 320;
+        final int intervalEnd = 330;
+
         TabixIteratorLineReader lineReader = new TabixIteratorLineReader(
-                tabixReader.query(tabixReader.chr2tid("4"), 320, 330));
+                tabixReader.query(tabixReader.chr2tid("4"), intervalBegin, intervalEnd));
 
         int nRecords = 0;
         String nextLine;
@@ -128,10 +137,12 @@ public class TabixReaderTest {
     @Test
     public void testRemoteQuery() throws IOException {
         String tabixFile = "https://personal.broadinstitute.org/picard/testdata/igvdata/tabix/trioDup.vcf.gz";
+        final int intervalBegin = 320;
+        final int intervalEnd = 330;
 
         TabixReader tabixReader = new TabixReader(tabixFile);
         TabixIteratorLineReader lineReader = new TabixIteratorLineReader(
-                tabixReader.query(tabixReader.chr2tid("4"), 320, 330));
+                tabixReader.query(tabixReader.chr2tid("4"), intervalBegin, intervalEnd));
 
         int nRecords = 0;
         String nextLine;

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/TestAbstractFeatureReader.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/TestAbstractFeatureReader.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.File;
@@ -39,13 +40,14 @@ import static org.junit.Assert.*;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource("classpath:application.properties")
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class TestAbstractFeatureReader  {
 
     @Autowired
     private ApplicationContext context;
 
-    @Autowired
+    @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
     private static final String LOCAL_MIRROR_HTTP_INDEXED_VCF_PATH = "classpath:templates/ex2.vcf";

--- a/server/catgenome/src/test/java/com/epam/catgenome/util/TestAbstractFeatureReader.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/util/TestAbstractFeatureReader.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.*;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@TestPropertySource("classpath:application.properties")
+@TestPropertySource("classpath:test-catgenome.properties")
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class TestAbstractFeatureReader  {
 


### PR DESCRIPTION
# Description
The PR adds the feature to enable/disable cache for headers and indexes in Tabix/Tribble Readers.
## Background
Additions to task #143 
## Changes
Added property for bean.
# Check list
- [x] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [x] Documentation is updated
