### PR TITLE
'Error loading variant info' error fixed (for variations that out of gene)

### DIFF
--- a/client/client/app/shared/components/ngbVariantDetails/ngbVariantVisualizer/ngbVariantVisualizer.service.js
+++ b/client/client/app/shared/components/ngbVariantDetails/ngbVariantVisualizer/ngbVariantVisualizer.service.js
@@ -403,7 +403,10 @@ export default class ngbVariantVisualizerService {
     }
 
     getEmptyAffectedGenes(index) {
-        return [{empty: true, name: `empty_${  index}`}];
+        return [{empty: true, name: `empty_${  index}`,
+            selectedTranscript: {empty: true, name: 'empty_transcript', canonicalCds: []},
+            transcripts: [{empty: true, name: 'empty_transcript', canonicalCds: []}]
+        }];
     }
 
     getAffectedGeneInfo(breakpoint, gene) {

--- a/client/client/modules/render/variant-render/renderers/structural-variant-renderer.js
+++ b/client/client/modules/render/variant-render/renderers/structural-variant-renderer.js
@@ -1170,6 +1170,9 @@ export default class StructuralVariantRenderer extends VariantBaseRenderer {
     }
 
     _renderTranscriptsBlock(config, gene) {
+        if (gene.selectedTranscript.empty) {
+            return;
+        }
         const localContainer = new PIXI.Container();
         const graphics = new PIXI.Graphics();
         localContainer.addChild(graphics);


### PR DESCRIPTION
# Description

Fix for issue #154 

## Changes

'getEmptyAffectedGenes' method updated - now it returns 'empty' transcript as well.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
