### PR TITLE
Fix exons count for collapsed genes

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/reader/GffReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/reader/GffReader.java
@@ -115,9 +115,8 @@ public class GffReader extends AbstractGeneReader {
             canonicalTranscript.setItems(new ArrayList<>(stuffIntervalMap.values()));
             gene.setItems(Collections.singletonList(canonicalTranscript));
 
-            if (gene.getExonsCount() == null) {
-                calculateExonsCountAndLength(gene, canonicalTranscript.getItems());
-            }
+            // exon count is null for collapsed mode
+            gene.setExonsCount(null);
         }
 
         if (passesScaleFactor(gene, scaleFactor)) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/reader/GtfReader.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/reader/GtfReader.java
@@ -107,9 +107,8 @@ public class GtfReader extends AbstractGeneReader {
             canonicalTranscript.setItems(new ArrayList<>(stuffIntervalMap.values()));
             gene.setItems(Collections.singletonList(canonicalTranscript));
 
-            if (gene.getExonsCount() == null) {
-                calculateExonsCountAndLength(gene, canonicalTranscript.getItems());
-            }
+            // exon count is null for collapsed mode
+            gene.setExonsCount(null);
         }
 
         if (passesScaleFactor(gene, scaleFactor)) {

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/GffManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/GffManagerTest.java
@@ -628,7 +628,11 @@ public class GffManagerTest extends AbstractManagerTest {
         track.setScaleFactor(FULL_QUERY_SCALE_FACTOR);
 
         Track<Gene> featureList = gffManager.loadGenes(track, false);
+
         Assert.assertTrue(featureList.getBlocks().stream().anyMatch(g -> g.getItems().size() > 1));
+        Assert.assertTrue(featureList.getBlocks()
+                .stream().filter(g -> g.getItems() != null).flatMap(g -> g.getItems()
+                        .stream()).filter(GeneUtils::isTranscript).allMatch(t -> t.getExonsCount() > 0));
 
         track = new Track<>();
         track.setId(geneFile.getId());
@@ -648,6 +652,8 @@ public class GffManagerTest extends AbstractManagerTest {
         Assert.assertFalse(featureListCollapsed.getBlocks().stream().filter(GeneUtils::isGene)
                 .allMatch(g -> g.getItems().get(0).getItems().isEmpty()));
 
+        Assert.assertTrue(featureListCollapsed.getBlocks()
+                .stream().filter(GeneUtils::isGene).allMatch(g -> g.getExonsCount() == null));
         return true;
     }
 
@@ -771,6 +777,5 @@ public class GffManagerTest extends AbstractManagerTest {
         String pathStr = resource.getFile().getPath();
         return new String(Files.readAllBytes(Paths.get(pathStr)), Charset.defaultCharset());
     }
-
 
 }


### PR DESCRIPTION
# Description
This PR changes the calculation of exons count for collapse mode.
## Background
Based on task #139 . Exon count for collapsed genes was calculate wrong.
## Changes
Calculation of exons count for gene in collapsed mode was removed (now will return null). Added test for collapse and non-collapse case.

# Check list

- [x] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
