### PR TITLE
Add read group

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/bam/Read.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/bam/Read.java
@@ -54,6 +54,7 @@ public class Read extends Block implements Serializable {
     private Integer tLen;
     private String rNext;
     private Integer pNext;
+    private String readGroup;
     /**
      * {@code List<CigarElement>} A list of CigarElements, which describes how a read aligns with the reference.
      * E.g. the Cigar string 10M1D25M means
@@ -216,6 +217,14 @@ public class Read extends Block implements Serializable {
 
     public void setSequence(String sequence) {
         this.sequence = sequence;
+    }
+
+    public String getReadGroup() {
+        return readGroup;
+    }
+
+    public void setReadGroup(String readGroup) {
+        this.readGroup = readGroup;
     }
 }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/BamUtil.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/BamUtil.java
@@ -91,7 +91,6 @@ public final class BamUtil {
         read.setName(samRecord.getReadName());
         read.setCigarString(samRecord.getCigarString());
         read.setStand(!samRecord.getReadNegativeStrandFlag());
-        read.setReadGroup(samRecord.getReadGroup().getReadGroupId());
         read.setMappingQuality(samRecord.getMappingQuality());
         read.setFlagMask(samRecord.getFlags());
         read.setTLen(samRecord.getInferredInsertSize());
@@ -102,6 +101,13 @@ public final class BamUtil {
         read.setDifferentBase(differentBase);
         read.setHeadSequence(head);
         read.setTailSequence(tail);
+
+        if (samRecord.getReadGroup() != null) {
+            read.setReadGroup(samRecord.getReadGroup().getReadGroupId());
+        } else {
+            read.setReadGroup("");
+        }
+
         return read;
     }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/BamUtil.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/BamUtil.java
@@ -91,6 +91,7 @@ public final class BamUtil {
         read.setName(samRecord.getReadName());
         read.setCigarString(samRecord.getCigarString());
         read.setStand(!samRecord.getReadNegativeStrandFlag());
+        read.setReadGroup(samRecord.getReadGroup().getReadGroupId());
         read.setMappingQuality(samRecord.getMappingQuality());
         read.setFlagMask(samRecord.getFlags());
         read.setTLen(samRecord.getInferredInsertSize());

--- a/server/catgenome/src/test/java/com/epam/catgenome/controller/BamControllerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/controller/BamControllerTest.java
@@ -319,6 +319,7 @@ public class BamControllerTest extends AbstractControllerTest {
         Assert.assertNotNull(read.getStartIndex());
         Assert.assertNotNull(read.getEndIndex());
         Assert.assertNotNull(read.getCigarString());
+        Assert.assertNotNull(read.getReadGroup());
         Assert.assertFalse(read.getCigarString().isEmpty());
     }
 

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/bam/BamManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/bam/BamManagerTest.java
@@ -693,6 +693,7 @@ public class BamManagerTest extends AbstractManagerTest {
         Assert.assertTrue(!read.getCigarString().isEmpty());
         Assert.assertNotNull(read.getFlagMask());
         Assert.assertNotNull(read.getMappingQuality());
+        Assert.assertNotNull(read.getReadGroup());
         Assert.assertNotNull(read.getTLen());
         Assert.assertNotNull(read.getPNext());
         Assert.assertNotNull(read.getRNext());


### PR DESCRIPTION
# Description
## Background

This PR adds the server side feature for issue #155. 

## Changes

Read Group ID (RG ID) was added to the Read creation for the BAM. If read group is null, empty string returns.

# Check list
- [x] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
