### PR TITLE
Fix Alignments typo in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ The following sections are currently covered in a documentation
     * [VCF track](md/user-guide/tracks-vcf.md)
     * [WIG track](md/user-guide/tracks-wig.md)
     * [BED track](md/user-guide/tracks-bed.md)
-    * [Aignments track](md/user-guide/tracks-bam.md)
+    * [Alignments track](md/user-guide/tracks-bam.md)
     * [Working with Annotations](md/user-guide/annotations.md)
 
 ## Building documentation

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,7 +22,7 @@ pages:
         - VCF track: user-guide/tracks-vcf.md
         - WIG track: user-guide/tracks-wig.md
         - BED track: user-guide/tracks-bed.md
-        - Aignments track: user-guide/tracks-bam.md
+        - Alignments track: user-guide/tracks-bam.md
         - Working with Annotations: user-guide/annotations.md
         - Embedding NGB with URL: user-guide/embedding-url.md
         - Embedding NGB with JS: user-guide/embedding-js.md


### PR DESCRIPTION
# Description

## Background

There is a typo in the documentation, "Aignments"

## Changes

Aignments → Alignments

## Acceptance criteria

See the documentation

# Check list

- [NA] Unit tests are provided
- [NA] Integration tests are provided (if CLI/API was changed)
- [X] Documentation is updated