### PR TITLE
Rename the file in current session #166

### DIFF
--- a/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFile.controller.js
+++ b/client/client/app/shared/components/ngbMainToolbar/ngbOpenFile/ngbOpenFile.controller.js
@@ -61,6 +61,15 @@ export default class ngbOpenFileController {
         });
     }
 
+    fileName(path) {
+        if (!path || !path.length) {
+            return null;
+        }
+        let list = path.split('/');
+        list = list[list.length - 1].split('\\');
+        return list[list.length - 1];
+    }
+
     loadTracks(selectedFiles) {
         const mapFn = (selectedFile) => {
             return {
@@ -71,7 +80,7 @@ export default class ngbOpenFileController {
                 bioDataItemId: selectedFile.path,
                 referenceId: selectedFile.reference.id,
                 reference: selectedFile.reference,
-                name: selectedFile.path,
+                name: this.fileName(selectedFile.path),
                 indexPath: selectedFile.index,
                 projectId: selectedFile.reference.name
             };


### PR DESCRIPTION
# Description

## Background

Fixes for issue Rename the file in current session #166

## Changes

Display only "filename" by default, not  the full URL

## Acceptance criteria

1. Open a file from the NGB server or via the URL
2. Check that the file name is displayed in a short form
![image](https://user-images.githubusercontent.com/31283705/37531691-efdab2e0-294d-11e8-9112-c61f4313d72a.png)

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
