### PR TITLE
Fix for opening non registered local/s3/url BAM files

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/BiologicalDataItemResourceType.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/BiologicalDataItemResourceType.java
@@ -117,7 +117,9 @@ public enum BiologicalDataItemResourceType {
      */
     public static BiologicalDataItemResourceType getTypeFromPath(final String path) {
         if (path.startsWith("s3")) {
-            return S3;
+            // since we replace s3 paths with signed urls, for all processing
+            // s3 paths should act as URLs
+            return URL;
         } else if (NgbFileUtils.isRemotePath(path)) {
             return URL;
         } else {

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/bam/BamManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/bam/BamManagerTest.java
@@ -404,6 +404,30 @@ public class BamManagerTest extends AbstractManagerTest {
 
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void testLoadLocalNonRegisteredBam() throws Exception {
+        final String bamPath = resource.getFile().getAbsolutePath() + TEST_BAM_NAME;
+        final String indexPath = bamPath + BAI_EXTENSION;
+        Track<Read> fullTrackQ = new Track<>();
+        fullTrackQ.setStartIndex(TEST_START_INDEX_SMALL_RANGE);
+        fullTrackQ.setEndIndex(TEST_END_INDEX_SMALL_RANGE);
+        fullTrackQ.setScaleFactor(SCALE_FACTOR_SMALL);
+        fullTrackQ.setChromosome(new Chromosome(testChromosome.getId()));
+
+        BamQueryOption option = new BamQueryOption();
+        option.setTrackDirection(TrackDirectionType.MIDDLE);
+        option.setShowSpliceJunction(true);
+        option.setShowClipping(true);
+        option.setFrame(TEST_FRAME_SIZE);
+        option.setCount(TEST_COUNT);
+
+        ResponseEmitterMock emitterMock = new ResponseEmitterMock();
+        bamManager.sendBamTrackToEmitterFromUrl(fullTrackQ, option, bamPath, indexPath, emitterMock);
+        BamTrack<Read> fullTrack = emitterMock.getBamTrack();
+        testBamTrack(fullTrack);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void testLoadUrl() throws Exception {
         final String path = "/agnX1.09-28.trim.dm606.realign.bam";
         String bamUrl = UrlTestingUtils.TEST_FILE_SERVER_URL + path;


### PR DESCRIPTION
# Fix opening non-registered BAM files

Currently there is minor bug, that causes an error on opening BAM files via S3 paths

## Changes

This PR fixes related bug and enables fully functional work of non registered BAM files from local server path, remote URL, S3 path.

## Acceptance criteria

- open non registered BAM file from server file system
- open non registered BAM file from remote URl (http, https, ftp)
- open non registered BAM file from S3 path

# Check list

- [x] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
