### PR TITLE
Changing allele frequency threshold setting behaviour

### DIFF
--- a/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.tpl.html
+++ b/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.tpl.html
@@ -182,12 +182,13 @@
                                     <input name="alleleFrequencyThresholdBam"
                                            type="number"
                                            required
-                                           placeholder="allele frequency threshold(%)"
+                                           placeholder="allele frequency threshold"
                                            ng-model="ctrl.settings.alleleFrequencyThresholdBam"
+                                           step="0.01"
                                            ng-min="0"
-                                           ng-max="100"/>
+                                           ng-max="1"/>
                                     <div ng-messages="settingsForm.alleleFrequencyThresholdBam.$error" role="alert">
-                                        <div ng-message="required,min,max">Enter allele frequency threshold (%).</div>
+                                        <div ng-message="required,min,max">Enter allele frequency threshold.</div>
                                     </div>
                                 </md-input-container>
                             </div>

--- a/client/client/dataServices/local/defaultData.js
+++ b/client/client/dataServices/local/defaultData.js
@@ -184,7 +184,7 @@ export default {
         isDownSampling: true,
         maxBAMBP: 100000,
         maxBAMCoverageBP: 500000,
-        alleleFrequencyThresholdBam: 10,
+        alleleFrequencyThresholdBam: 0.1,
         maxBpCount: 10000,
         maxFrameSize: 50,
         maxReadsCount: 300,

--- a/client/client/dataServices/local/defaultData.js
+++ b/client/client/dataServices/local/defaultData.js
@@ -184,7 +184,7 @@ export default {
         isDownSampling: true,
         maxBAMBP: 100000,
         maxBAMCoverageBP: 500000,
-        alleleFrequencyThresholdBam: 90,
+        alleleFrequencyThresholdBam: 10,
         maxBpCount: 10000,
         maxFrameSize: 50,
         maxReadsCount: 300,

--- a/client/client/modules/render/tracks/bam/internal/transformers/bamReadsCoverageTransformer.js
+++ b/client/client/modules/render/tracks/bam/internal/transformers/bamReadsCoverageTransformer.js
@@ -59,7 +59,7 @@ export default class BamReadsCoverageTransformer extends WIGTransformer {
         item.tCov = item.tCov || 0;
 
         item.totalMismatches = item.aCov + item.cCov + item.gCov + item.tCov + item.nCov;
-        item.isHighlightedLocus = (item.value - item.totalMismatches) / item.value >= highlightThreshold;
+        item.isHighlightedLocus = 1 - ((item.value - item.totalMismatches) / item.value) >= highlightThreshold;
         item.isTransformed = true;
         const locusLetter = this._bamCache.getReferenceValueAtLocus(item.startIndex);
         let locusInfo = {

--- a/client/client/modules/render/tracks/bam/internal/transformers/bamReadsCoverageTransformer.js
+++ b/client/client/modules/render/tracks/bam/internal/transformers/bamReadsCoverageTransformer.js
@@ -51,7 +51,7 @@ export default class BamReadsCoverageTransformer extends WIGTransformer {
         super.transformItem(item);
         if (item.isTransformed)
             return;
-        const highlightThreshold = this.alleleFrequencyThresholdBam / 100;
+        const highlightThreshold = this.alleleFrequencyThresholdBam;
         item.aCov = item.aCov || 0;
         item.cCov = item.cCov || 0;
         item.gCov = item.gCov || 0;

--- a/client/client/modules/render/tracks/bam/internal/transformers/bamReadsCoverageTransformer.js
+++ b/client/client/modules/render/tracks/bam/internal/transformers/bamReadsCoverageTransformer.js
@@ -59,7 +59,7 @@ export default class BamReadsCoverageTransformer extends WIGTransformer {
         item.tCov = item.tCov || 0;
 
         item.totalMismatches = item.aCov + item.cCov + item.gCov + item.tCov + item.nCov;
-        item.isHighlightedLocus = (item.value - item.totalMismatches) / item.value <= highlightThreshold;
+        item.isHighlightedLocus = (item.value - item.totalMismatches) / item.value >= highlightThreshold;
         item.isTransformed = true;
         const locusLetter = this._bamCache.getReferenceValueAtLocus(item.startIndex);
         let locusInfo = {


### PR DESCRIPTION
# Description

## Background

Fix for issue #193 

## Changes

* Changed Allele Frequency threshold units from percentage to floating number (from 0.00 to 1.00)
* Changed highlighting logic:
Before was: "% of mismatches" <= "allele frequency threshold",
now became: "% of mismatches" >= "allele frequency threshold"

## Acceptance criteria

Try changing the corresponding setting and see how BAM's locuses' highlighting changes

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
