### PR TITLE
Js api ready event

### DIFF
--- a/client/client/app/app.controller.js
+++ b/client/client/app/app.controller.js
@@ -47,7 +47,7 @@ export default class ngbAppController extends baseController {
         });
 
         if (window.addEventListener) {
-            window.addEventListener("message", (event) => {
+            window.addEventListener('message', (event) => {
                 if (!!event.data && typeof event.data === 'object' && !Array.isArray(event.data)) {
                     this._listener(event);
                 }
@@ -63,7 +63,7 @@ export default class ngbAppController extends baseController {
     _listener(event) {
         const callerId = event.data.callerId ? event.data.callerId : null;
         switch (event.data.method) {
-            case "loadDataSet":
+            case 'loadDataSet':
                 const id = parseInt(event.data.params && event.data.params.id ? event.data.params.id : null);
                 const forceSwitchRef = event.data.params && event.data.params.forceSwitchRef ? event.data.params.forceSwitchRef : false;
                 if (id) {
@@ -77,11 +77,11 @@ export default class ngbAppController extends baseController {
                     }, callerId);
                 }
                 break;
-            case "navigateToCoordinate":
+            case 'navigateToCoordinate':
                 const coordinates = event.data.params && event.data.params.coordinates ? event.data.params.coordinates : null;
                 this._apiResponse(this.apiService.navigateToCoordinate(coordinates), callerId);
                 break;
-            case "toggleSelectTrack":
+            case 'toggleSelectTrack':
                 if (event.data.params && event.data.params.track) {
                     this.apiService.toggleSelectTrack(event.data.params).then((response) => {
                         this._apiResponse(response, callerId);
@@ -93,7 +93,7 @@ export default class ngbAppController extends baseController {
                     }, callerId);
                 }
                 break;
-            case "loadTracks":
+            case 'loadTracks':
                 const tracks = event.data.params && event.data.params.tracks ? event.data.params.tracks : null,
                     mode = event.data.params && event.data.params.mode ? event.data.params.mode : null;
                 if (tracks && mode) {
@@ -107,7 +107,7 @@ export default class ngbAppController extends baseController {
                     }, callerId);
                 }
                 break;
-            case "setGlobalSettings":
+            case 'setGlobalSettings':
                 const globalSettingsParams = event.data.params;
                 if (globalSettingsParams) {
                     this._apiResponse(this.apiService.setGlobalSettings(globalSettingsParams), callerId);
@@ -118,7 +118,7 @@ export default class ngbAppController extends baseController {
                     }, callerId);
                 }
                 break;
-            case "setTrackSettings":
+            case 'setTrackSettings':
                 const trackSettingParams = event.data.params;
                 if (trackSettingParams) {
                     this._apiResponse(this.apiService.setTrackSettings(trackSettingParams), callerId);
@@ -129,7 +129,7 @@ export default class ngbAppController extends baseController {
                     }, callerId);
                 }
                 break;
-            case "setToken":
+            case 'setToken':
                 const token = event.data.params && event.data.params.token ? event.data.params.token : null;
                 if (token) {
                     this._apiResponse(this.apiService.setToken(token), callerId);

--- a/client/client/app/app.controller.js
+++ b/client/client/app/app.controller.js
@@ -53,6 +53,7 @@ export default class ngbAppController extends baseController {
                 }
             });
         }
+        this.emitReady();
     }
 
     events = {
@@ -147,7 +148,14 @@ export default class ngbAppController extends baseController {
         }
     }
 
-    _apiResponse(params, callerId) {
+    emitReady() {
+        this._apiResponse({
+            isSuccessful: true,
+            message: 'ready',
+        });
+    }
+
+    _apiResponse(params, callerId = null) {
         params.callerId = callerId;
         if (window.location !== window.parent.location) {
             window.parent.postMessage(params, '*');

--- a/client/client/app/shared/services/api.service.js
+++ b/client/client/app/shared/services/api.service.js
@@ -42,30 +42,25 @@ export default class ngbApiService {
     }
 
     /** returns a Promise */
-    loadDataSet(id, forceSwitchRef = false) {
+    async loadDataSet(id, forceSwitchRef = false) {
         let datasets = this.projectContext.datasets;
         if (!datasets || datasets.length === 0) {
-            this.projectContext.refreshDatasets().then(async () => {
-                datasets = await this.ngbDataSetsService.getDatasets();
-                const [item] = datasets.filter(m => m.id === id);
-                if (!item) {
-                    return new Promise((resolve) => {
-                        resolve({
-                            message: `No dataset with id = ${id}`,
-                            isSuccessful: false
-                        });
-                    });
-                }
-                return this._select(item, true, datasets, forceSwitchRef);
-            })
+            await this.projectContext.refreshDatasets();
+            datasets = await this.ngbDataSetsService.getDatasets();
+            const [item] = datasets.filter(m => m.id === id);
+            if (!item) {
+                return Promise.resolve({
+                    isSuccessful: false,
+                    message: `No dataset with id = ${id}`
+                });
+            }
+            return this._select(item, true, datasets, forceSwitchRef);
         } else {
             const [item] = datasets.filter(m => m.id === id);
             if (!item) {
-                return new Promise((resolve) => {
-                    resolve({
-                        message: `No dataset with id = ${id}`,
-                        isSuccessful: false
-                    });
+                return Promise.resolve({
+                    isSuccessful: false,
+                    message: `No dataset with id = ${id}`
                 });
             }
             return this._select(item, true, datasets, forceSwitchRef);

--- a/docs/md/user-guide/embedding-js.md
+++ b/docs/md/user-guide/embedding-js.md
@@ -4,7 +4,14 @@ NGB could be embedded into 3rd paty web application using an iFrame approach. De
 
 Communication with NGB window implemented with [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage "MDN web docks"), that is safely enables cross-origin communication.
 
-You can start using postMessage when NGB window loaded
+When loaded NGB will send postMessage to `window.parent`/`window.opener` with following response:
+```javascript
+{
+    isSuccessful: true,
+    message: 'ready'
+}
+```
+Once you receive that response, it is safe to start using postMessage with NGB
 
 Common request structure:
 ```javascript


### PR DESCRIPTION
# Description

## Background

Fix for issue #194 

## Changes

Additional API response was added, so now it's possible to determine the exact moment when NGB is ready to receive `postMessage`s.
Host app will receive following response:
```javascript
{
  isSuccessful: true,
  message: 'ready',
}
```

## Acceptance criteria

Follow the instructions for embedding NGB listed in [the documentation](https://github.com/epam/NGB/blob/js-api_ready-event/docs/md/user-guide/embedding-js.md), they was updated according to changes.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [x] Documentation is updated
