### PR TITLE
Singularity image build support for NGB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
+jdk:
+  - openjdk8
 sudo: required
 os:
   - linux
-dist: trusty
+dist: xenial
 install: 
     - sudo add-apt-repository -y ppa:jonathonf/python-2.7
     - sudo apt-get update
@@ -12,8 +14,10 @@ install:
     - sudo pip install mkdocs
     - sudo pip install mkdocs-material
 script:
-    - ./gradlew buildJar buildWar buildCli buildDoc buildDocker -PbuildNumber=${TRAVIS_JOB_NUMBER} ${CLIENT_PATH} && ./e2e/integration_tests.sh
+    - ./gradlew buildJar buildWar buildCli buildDoc buildDocker -PbuildNumber=${TRAVIS_JOB_NUMBER} ${CLIENT_PATH}
     - ./gradlew jacocoTestReport
+    - ./singularity/setup_environment.sh
+    - sudo ./singularity/build_image.sh $(pwd)/singularity/ngb.singularity $(pwd)/dist/ngb.singularity.img
 after_success:
     - bash <(curl -s https://codecov.io/bash)
 deploy:

--- a/singularity/README.md
+++ b/singularity/README.md
@@ -1,0 +1,38 @@
+# NGB Singularity management commands reference
+
+Once image is built - use the following commands to start/manage/stop:
+
+Start singularity instance from NGB image
+```
+mkdir -p logs contents H2
+singularity instance start  -B ./logs/:/opt/ngb/logs/ \
+                            -B ./contents/:/opt/ngb/contents/ \
+                            -B ./H2/:/opt/ngb/H2/ \
+                            ./ngb.sinularity.img \
+                            ngb
+```
+
+List singularity instances
+```
+singularity instance list
+```
+
+Check that NGB is started
+```
+curl http://localhost:8080/catgenome/ -v
+```
+
+Connect to the running service's shell
+```
+singularity shell instance://ngb
+```
+
+Execute NGB CLI command
+```
+singularity exec instance://ngb ngb lr
+```
+
+Kill NGB instance
+```
+singularity instance stop ngb
+```

--- a/singularity/build_image.sh
+++ b/singularity/build_image.sh
@@ -1,0 +1,32 @@
+SINGULARITY_FILE=$1
+SINGULARITY_IMAGE=$2
+
+if [ -z "$SINGULARITY_FILE" ]; then
+  echo "Path to singularity file is not specified, exiting..."
+  exit 1
+fi
+
+if [ -z "$SINGULARITY_IMAGE" ]; then
+  SINGULARITY_IMAGE=$(pwd)/ngb.singularity.img
+  echo "Resulting image path is not set, using current directory: $SINGULARITY_IMAGE"
+fi
+
+NGB_DOCKER_IMAGE="ngb:latest"
+# Check whether ngb:latest is built
+docker inspect --type=image $NGB_DOCKER_IMAGE > /dev/null
+NGB_DOCKER_BUILT=$?
+
+if [ $NGB_DOCKER_BUILT != 0 ]; then
+  echo "$NGB_DOCKER_IMAGE is not found, cannot build singularity image from it, exiting..."
+  exit 1
+fi
+
+# Setup local docker registry as working with docker locals is not supported by singularity
+# And push prebuilt NGB docker image to it
+docker run -d -p 5000:5000 --restart=always --name registry registry:2
+docker tag $NGB_DOCKER_IMAGE localhost:5000/$NGB_DOCKER_IMAGE
+docker push localhost:5000/$NGB_DOCKER_IMAGE
+
+export SINGULARITY_NOHTTPS=1
+
+singularity build "$SINGULARITY_IMAGE" "$SINGULARITY_FILE"

--- a/singularity/ngb.singularity
+++ b/singularity/ngb.singularity
@@ -1,0 +1,8 @@
+Bootstrap: docker
+Registry: localhost:5000
+From: ngb:latest
+Includecmd: no
+
+%startscript
+	cd /opt/ngb
+	nohup java -Xmx2G -jar catgenome.jar > /dev/null 2>&1 < /dev/null &

--- a/singularity/setup_environment.sh
+++ b/singularity/setup_environment.sh
@@ -1,0 +1,37 @@
+set -e
+
+# 1. Install singlularity
+
+## 1.1 Install deps
+sudo apt-get update && \
+sudo apt-get install -y build-essential \
+                        libssl-dev \
+                        uuid-dev \
+                        libgpgme11-dev \
+                        squashfs-tools \
+                        libseccomp-dev \
+                        pkg-config
+
+## 1.2 Install GO
+export VERSION=1.11 OS=linux ARCH=amd64
+cd /tmp
+wget -q https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz
+sudo tar -C /usr/local -xzf go$VERSION.$OS-$ARCH.tar.gz
+echo 'export GOPATH=${HOME}/go' >> ~/.bashrc
+echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc
+source ~/.bashrc
+mkdir -p ${GOPATH}/bin
+curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+## 1.3 Clone singularity
+mkdir -p $GOPATH/src/github.com/sylabs
+cd $GOPATH/src/github.com/sylabs
+git clone https://github.com/sylabs/singularity.git
+cd singularity
+
+## 1.4 Build singularity
+cd $GOPATH/src/github.com/sylabs/singularity
+./mconfig
+cd ./builddir
+make
+sudo make install


### PR DESCRIPTION
# Description

Implementation of #224 

Some of the users do not run docker infrastructure at all. Instead, singularity containers are encouraged to be used.

To support such use cases, NGB distribution now includes singularity image, built from the docker image.

# Further TODO

Currently, this is implemented using standalone sh scripts and a docker is used to bootstrap singularity. We shall probably change this to:
- Use `gradle` to build image (in the same manner as docker, i.e. `buildSingularity` command)
- Create a separate singularity file, that will not rely on the docker daemon/image or  to be present
