### PR TITLE
Add support for WIG files located on S3 bucket

### DIFF
--- a/server/catgenome/build.gradle
+++ b/server/catgenome/build.gradle
@@ -166,7 +166,9 @@ dependencies {
     //hadoop
     compile group: "org.apache.hadoop", name:"hadoop-client", version: "2.2.0"
 
-    compile group: "org.jetbrains.bio", name: "big", version: "0.3.4"
+    compile (group: "org.jetbrains.bio", name: "big", version: "0.8.3") {
+        exclude group: "com.github.samtools", module: "htsjdk"
+    }
 
     // >>>>> dependencies used to compile tests; in fact no need to include them into artifact
     testCompile("org.springframework.boot:spring-boot-starter-test")

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/FacadeWigManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/FacadeWigManager.java
@@ -135,6 +135,7 @@ public class FacadeWigManager {
             }
             switch (request.getType()) {
                 case FILE:
+                case S3:
                     wigFile = fillWigFile(requestPath, request.getName(),
                             request.getPrettyName(), request.getReferenceId());
                     break;
@@ -146,7 +147,8 @@ public class FacadeWigManager {
                             request.getPrettyName(), request.getReferenceId());
                     break;
                 default:
-                    throw new IllegalArgumentException(getMessage(MessagesConstants.ERROR_INVALID_PARAM));
+                    throw new IllegalArgumentException(getMessage(MessagesConstants.ERROR_INVALID_PARAM,
+                            "type", request.getType()));
             }
             long id = wigFileManager.create();
             biologicalDataItemManager.createBiologicalDataItem(wigFile);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/WigProcessor.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/WigProcessor.java
@@ -23,7 +23,11 @@ import org.jetbrains.bio.big.WigSection;
 import org.springframework.util.Assert;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static com.epam.catgenome.component.MessageHelper.getMessage;
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/aws/SeekableS3Stream.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/aws/SeekableS3Stream.java
@@ -40,7 +40,7 @@ public class SeekableS3Stream extends SeekableStream {
 
         this.currentDataStream = new CountingWithSkipInputStream(
                 new S3ObjectChunkInputStream(s3Source, offset, length() - 1));
-        LOGGER.debug("A new data stream was launched on offset = ", offset);
+        LOGGER.debug("A new data stream was launched on offset = {}", offset);
     }
 
     @Override
@@ -60,7 +60,7 @@ public class SeekableS3Stream extends SeekableStream {
      */
     @Override
     public void seek(long targetPosition) throws IOException {
-        LOGGER.debug("Seeking from ", position(), " to ", targetPosition);
+        LOGGER.debug("Seeking from {} to {}", position(), targetPosition);
         this.offset = targetPosition;
         recreateInnerStream();
     }


### PR DESCRIPTION
# Description

Provides support for registering WIG files located on the S3 bucket according to the [issue comment](https://github.com/epam/NGB/issues/215#issuecomment-447840190).

The essential part that made this pull request possible is the fact that `NgbSeekableStreamFactory` performs self-registration in [htsjdk](https://github.com/samtools/htsjdk)'s `SeekableStreamFactory` singleton and provides support for S3 files seekable streams.

## Changes

- Small change in `FacadeWigManager` to support S3 paths as well as regular file system paths.
- Migrate to the newest [big library](https://github.com/JetBrains-Research/big) api in `WigProcessor`.
- Few fixes in logging templates.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
