### PR TITLE
load histo when file is from S3

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -681,7 +681,8 @@ public class GffManager {
         TrackHelper.validateHistogramTrack(track);
 
         final GeneFile geneFile = geneFileManager.load(track.getId());
-        if (BiologicalDataItemResourceType.FILE != geneFile.getType()) {
+        if (BiologicalDataItemResourceType.FILE != geneFile.getType() &&
+                BiologicalDataItemResourceType.S3 != geneFile.getType()) {
             track.setBlocks(Collections.emptyList());
             return track;
         }


### PR DESCRIPTION
# Description

## Background

Small changes that allow to show histogram for a gene file that is located on S3 cloud
