### PR TITLE
RBAC: Support permissions viewing in CLI 

### DIFF
--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/app/Application.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/app/Application.java
@@ -185,6 +185,9 @@ public class Application {
     @Option(name = "-gr", usage = "Groups for permission update",  aliases = {"--groups"})
     private String groups;
 
+    @Option(name = "-perm", usage = "shows permissions", aliases = {"--permissions"})
+    private boolean showPermissions = false;
+
     @Argument
     private List<String> arguments;
 
@@ -281,6 +284,7 @@ public class Application {
             options.setDoIndex(false);
         }
         options.setMaxMemory(maxMemory);
+        options.setShowPermissions(showPermissions);
         return options;
     }
 

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/app/ApplicationOptions.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/app/ApplicationOptions.java
@@ -100,6 +100,8 @@ public class ApplicationOptions {
 
     private String groups;
 
+    private boolean showPermissions;
+
     /**
      * Creates object with default option's values
      */
@@ -249,5 +251,13 @@ public class ApplicationOptions {
 
     public void setDatasets(String datasets) {
         this.datasets = datasets;
+    }
+
+    public boolean isShowPermissions() {
+        return showPermissions;
+    }
+
+    public void setShowPermissions(boolean showPermissions) {
+        this.showPermissions = showPermissions;
     }
 }

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/constants/MessageConstants.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/constants/MessageConstants.java
@@ -58,6 +58,7 @@ public final class MessageConstants {
     public static final String ERROR_FILES_NOT_REGISTERED = "Failed to register files: %s.";
     public static final String ERROR_NEGATIVE_MEMORY = "Max memory value must be positive";
     public static final String ERROR_WRONG_PERMISSION = "Wrong permission pattern, use only w,r";
+    public static final String ERROR_PERMISSIONS_NOT_FOUND = "Failed to find permissions for %s with ID %d";
     public static final String INFO_SORT_SUCCESS = "File is successfully sorted and placed to [%s].";
 
     private MessageConstants(){

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/entity/AclSecuredEntry.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/entity/AclSecuredEntry.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.ngb.cli.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AclSecuredEntry {
+
+    private Entity entity;
+    private List<AclPermissionEntry> permissions = new ArrayList<>();
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Entity {
+        private Long id;
+        private String name;
+        private int mask;
+        private String owner;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class AclPermissionEntry {
+        private Sid sid;
+        private int mask;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Sid {
+        private String name;
+        private boolean principal;
+    }
+}

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/entity/PermissionsContainer.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/entity/PermissionsContainer.java
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.ngb.cli.entity;
+
+import com.epam.ngb.cli.manager.printer.Printable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Represents an container that contains permissions info for NGB entity to print.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PermissionsContainer implements Printable<PermissionsContainer> {
+
+    private boolean isPrincipal;
+    private String userName;
+    private String prettyMask;
+
+    @Override
+    public String getFormatString(final List<PermissionsContainer> table) {
+        Map<FieldFormat, Integer> formatMap = new EnumMap<>(FieldFormat.class);
+        for (FieldFormat field : FieldFormat.values()) {
+            formatMap.put(field, field.name().length());
+        }
+
+        table.forEach(line -> {
+            calculateFieldWidth(formatMap, FieldFormat.SID_NAME, line.getUserName());
+            calculateFieldWidth(formatMap, FieldFormat.PERMISSIONS, line.getPrettyMask());
+        });
+
+        return formatMap.values().stream().map(v -> "%" + (v + 1) + "s").collect(Collectors.joining());
+    }
+
+    @Override
+    public String formatItem(final String format) {
+        return String.format(format, userName, prettyMask);
+    }
+
+    @Override
+    public String formatHeader(String format) {
+        String[] names = Arrays.stream(FieldFormat.values()).map(Enum::name).toArray(String[]::new);
+        return String.format(format, (Object[]) names);
+    }
+
+    private enum FieldFormat {
+        SID_NAME,
+        PERMISSIONS
+    }
+
+    private static void calculateFieldWidth(Map<FieldFormat, Integer> formatMap, FieldFormat field, String value) {
+        if (value == null) {
+            return;
+        }
+        if (formatMap.get(field) < value.length()) {
+            formatMap.put(field, value.length());
+        }
+    }
+}

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/manager/command/handler/http/DatasetListHandler.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/manager/command/handler/http/DatasetListHandler.java
@@ -31,6 +31,7 @@ import java.net.URISyntaxException;
 import java.util.Comparator;
 import java.util.List;
 
+import com.epam.ngb.cli.entity.PermissionGrantRequest;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
@@ -67,6 +68,8 @@ public class DatasetListHandler extends AbstractHTTPCommandHandler {
      */
     private Long parentId;
 
+    private boolean permissionsRequired;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DatasetListHandler.class);
 
     /**
@@ -84,6 +87,7 @@ public class DatasetListHandler extends AbstractHTTPCommandHandler {
         if (options.getParent() != null) {
             this.parentId = parseProjectId(options.getParent());
         }
+        permissionsRequired = options.isShowPermissions();
     }
 
     /**
@@ -114,6 +118,10 @@ public class DatasetListHandler extends AbstractHTTPCommandHandler {
             items.sort(Comparator.comparing(Project::getId));
             AbstractResultPrinter printer = AbstractResultPrinter
                     .getPrinter(printTable, items.get(0).getFormatString(items));
+            if (permissionsRequired) {
+                printWithPermissions(items, printer);
+                return 0;
+            }
             printer.printHeader(items.get(0));
             items.forEach(printer::printItem);
         }
@@ -133,5 +141,15 @@ public class DatasetListHandler extends AbstractHTTPCommandHandler {
 
     private HttpRequestBase createListingRequest() {
         return getRequest(getRequestUrl());
+    }
+
+    private void printWithPermissions(final List<Project> items, final AbstractResultPrinter printer) {
+        items.forEach(item -> {
+            printer.printHeader(item);
+            printer.printItem(item);
+
+            PrintPermissionsHelper permissionsHelper = new PrintPermissionsHelper(this, printTable);
+            permissionsHelper.print(item.getId(), PermissionGrantRequest.AclClass.PROJECT.name());
+        });
     }
 }

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/manager/command/handler/http/GrantPermissionHandler.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/manager/command/handler/http/GrantPermissionHandler.java
@@ -57,7 +57,7 @@ public class GrantPermissionHandler extends AbstractHTTPCommandHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GrantPermissionHandler.class);
 
-    private static final Map<String, Integer> PERMISSION_MAP = new HashMap<>();
+    public static final Map<String, Integer> PERMISSION_MAP = new HashMap<>();
     private static final String DELETE_PERMISSION_URL = "/restapi/grant?id=%d&aclClass=%s&user=%s&isPrincipal=%b";
     private static final String DELETE_TYPE = "DELETE";
     private static final String DELETE_PERMISSION_ACTION = "!";

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/manager/command/handler/http/PrintPermissionsHelper.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/manager/command/handler/http/PrintPermissionsHelper.java
@@ -1,0 +1,113 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.ngb.cli.manager.command.handler.http;
+
+import com.epam.ngb.cli.entity.AclSecuredEntry;
+import com.epam.ngb.cli.entity.PermissionsContainer;
+import com.epam.ngb.cli.exception.ApplicationException;
+import com.epam.ngb.cli.manager.printer.AbstractResultPrinter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.epam.ngb.cli.manager.command.handler.http.GrantPermissionHandler.PERMISSION_MAP;
+
+/**
+ * Prepares entity permissions and prints them.
+ */
+@Setter
+@Getter
+@RequiredArgsConstructor
+public class PrintPermissionsHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PrintPermissionsHelper.class);
+
+    private final AbstractHTTPCommandHandler handler;
+    private final boolean printTable;
+
+    /**
+     * Loads entity permissions and prints them.
+     * @param entityId entity ID
+     * @param entityClass entity acl class
+     */
+    public void print(final Long entityId, final String entityClass) {
+        try {
+            AclSecuredEntry permissions = handler.loadPermissions(entityId, entityClass);
+            List<AclSecuredEntry.AclPermissionEntry> rawPermissions = permissions.getPermissions();
+
+            List<PermissionsContainer> permissionsContainer = preparePermissions(rawPermissions);
+            if (CollectionUtils.isEmpty(permissionsContainer)) {
+                return;
+            }
+
+            AbstractResultPrinter printer = AbstractResultPrinter
+                    .getPrinter(printTable, permissionsContainer.get(0).getFormatString(permissionsContainer));
+            printer.printHeader(permissionsContainer.get(0));
+            permissionsContainer
+                    .stream()
+                    .sorted(getSidComparator())
+                    .forEach(printer::printItem);
+        } catch (IOException | ApplicationException e) {
+            LOGGER.error("An error occurred during building permissions", e);
+        }
+    }
+
+    private static List<PermissionsContainer> preparePermissions(List<AclSecuredEntry.AclPermissionEntry> permissions) {
+        if (CollectionUtils.isEmpty(permissions)) {
+            return Collections.emptyList();
+        }
+        return permissions.stream()
+                .map(entry -> PermissionsContainer
+                        .builder()
+                        .isPrincipal(entry.getSid().isPrincipal())
+                        .userName(entry.getSid().getName())
+                        .prettyMask(convertToPrettyMask(entry.getMask()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private static Comparator<PermissionsContainer> getSidComparator() {
+        return (table1, table2) -> table1.isPrincipal() ? -1 : 1;
+    }
+
+    private static String convertToPrettyMask(final int mask) {
+        StringBuilder permissions = new StringBuilder();
+        PERMISSION_MAP.forEach((permissionName, permissionMask) -> {
+            if ((mask & permissionMask) == permissionMask) {
+                permissions.append(permissionName);
+            }
+        });
+        return permissions.toString();
+    }
+}

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/manager/command/handler/http/SearchHandler.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/manager/command/handler/http/SearchHandler.java
@@ -52,6 +52,7 @@ public class SearchHandler extends AbstractHTTPCommandHandler {
     private String query;
     private boolean strict;
     private boolean printTable;
+    private boolean permissionsRequired;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchHandler.class);
 
@@ -64,9 +65,11 @@ public class SearchHandler extends AbstractHTTPCommandHandler {
         query = arguments.get(0);
         strict = options.isStrictSearch();
         printTable = options.isPrintTable();
+        permissionsRequired = options.isShowPermissions();
     }
 
-    @Override public int runCommand() {
+    @Override
+    public int runCommand() {
         List<BiologicalDataItem> items = loadItemsByName(query, strict);
         if (items == null || items.isEmpty()) {
             LOGGER.info("No files found matching a request \"" + query + "\".");
@@ -74,8 +77,22 @@ public class SearchHandler extends AbstractHTTPCommandHandler {
         }
         AbstractResultPrinter printer = AbstractResultPrinter.getPrinter(printTable,
                 items.get(0).getFormatString(items));
+        if (permissionsRequired) {
+            printWithPermissions(items, printer);
+            return 0;
+        }
         printer.printHeader(items.get(0));
         items.forEach(printer::printItem);
         return 0;
+    }
+
+    private void printWithPermissions(final List<BiologicalDataItem> items, final AbstractResultPrinter printer) {
+        items.forEach(item -> {
+            printer.printHeader(item);
+            printer.printItem(item);
+
+            PrintPermissionsHelper permissionsHelper = new PrintPermissionsHelper(this, printTable);
+            permissionsHelper.print(item.getId(), item.getFormat().name());
+        });
     }
 }

--- a/server/ngb-cli/src/test/java/com/epam/ngb/cli/AbstractCliTest.java
+++ b/server/ngb-cli/src/test/java/com/epam/ngb/cli/AbstractCliTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractCliTest {
     public static final String SPEC_DELETION_URL = "/catgenome/restapi/secure/reference/register/species";
     public static final String SPEC_ADDING_URL = "/catgenome/restapi/secure/reference/%d/species";
     public static final String SPEC_REMOVING_URL = "/catgenome/restapi/secure/reference/%d/species";
-    public static final String TOKEN = "123456";
+    public static final String GET_PERMISSIONS_URL = "/catgenome/restapi/grant";
 
     //server properties
     public static final String TEST_SERVER_PROPERTIES = "external/server.properties";
@@ -90,6 +90,10 @@ public abstract class AbstractCliTest {
     public static final String GET_EXISTING_INDEX_URL_PROPERTY = "get_existing_index_url";
 
     public static final String SERVER_URL = "http://localhost:%d/catgenome";
+
+    public static final String TOKEN = "123456";
+    public static final String TEST_OWNER = "OWNER";
+    public static final String TEST_GROUP = "ROLE";
 
     private static ConfigurationLoader configLoader = new ConfigurationLoader();
 

--- a/server/ngb-cli/src/test/java/com/epam/ngb/cli/TestDataProvider.java
+++ b/server/ngb-cli/src/test/java/com/epam/ngb/cli/TestDataProvider.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -216,6 +217,29 @@ public final class TestDataProvider {
 
     public static Project getProject(Long id, String name, List<BiologicalDataItem> items) {
         return getProject(id, name, items, null);
+    }
+
+    public static AclSecuredEntry buildAclSecuredEntry(AclSecuredEntry.Entity entity, String user, String group) {
+        AclSecuredEntry.Sid userSid = new AclSecuredEntry.Sid();
+        userSid.setPrincipal(true);
+        userSid.setName(user);
+
+        AclSecuredEntry.Sid groupSid = new AclSecuredEntry.Sid();
+        groupSid.setPrincipal(false);
+        groupSid.setName(group);
+
+        AclSecuredEntry.AclPermissionEntry permission1 = new AclSecuredEntry.AclPermissionEntry();
+        permission1.setMask(1);
+        permission1.setSid(userSid);
+
+        AclSecuredEntry.AclPermissionEntry permission2 = new AclSecuredEntry.AclPermissionEntry();
+        permission2.setMask(2);
+        permission2.setSid(groupSid);
+
+        AclSecuredEntry entry = new AclSecuredEntry();
+        entry.setEntity(entity);
+        entry.setPermissions(Arrays.asList(permission1, permission2));
+        return entry;
     }
 
     public static Project getProject(Long id, String name, List<BiologicalDataItem> items,

--- a/server/ngb-cli/src/test/java/com/epam/ngb/cli/TestHttpServer.java
+++ b/server/ngb-cli/src/test/java/com/epam/ngb/cli/TestHttpServer.java
@@ -536,4 +536,15 @@ public class TestHttpServer extends AbstractCliTest{
                 .withBody(TestDataProvider.getPayloadJson(indexPath))
                 .withStatus(HTTP_STATUS_OK);
     }
+
+    public void addPermissions(AclSecuredEntry entry, String entityClass) {
+        onRequest()
+                .havingMethodEqualTo(HTTP_GET)
+                .havingPathEqualTo(GET_PERMISSIONS_URL)
+                .havingParameterEqualTo("id", String.valueOf(entry.getEntity().getId()))
+                .havingParameterEqualTo("aclClass", entityClass)
+                .respond()
+                .withBody(TestDataProvider.getPayloadJson(entry))
+                .withStatus(HTTP_STATUS_OK);
+    }
 }

--- a/server/ngb-cli/src/test/java/com/epam/ngb/cli/manager/command/handler/http/SearchHandlerTest.java
+++ b/server/ngb-cli/src/test/java/com/epam/ngb/cli/manager/command/handler/http/SearchHandlerTest.java
@@ -28,6 +28,7 @@ import com.epam.ngb.cli.AbstractCliTest;
 import com.epam.ngb.cli.TestDataProvider;
 import com.epam.ngb.cli.TestHttpServer;
 import com.epam.ngb.cli.app.ApplicationOptions;
+import com.epam.ngb.cli.entity.AclSecuredEntry;
 import com.epam.ngb.cli.entity.BiologicalDataItem;
 import com.epam.ngb.cli.entity.BiologicalDataItemFormat;
 import com.epam.ngb.cli.manager.command.ServerParameters;
@@ -36,6 +37,8 @@ import org.junit.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static com.epam.ngb.cli.TestDataProvider.buildAclSecuredEntry;
 
 public class SearchHandlerTest extends AbstractCliTest {
 
@@ -125,6 +128,28 @@ public class SearchHandlerTest extends AbstractCliTest {
         ApplicationOptions applicationOptions = new ApplicationOptions();
         applicationOptions.setPrintTable(true);
         handler.parseAndVerifyArguments(Collections.emptyList(), applicationOptions);
+    }
+
+    @Test
+    public void shouldPrintPermissions() {
+        AclSecuredEntry entry = buildAclSecuredEntry(
+                AclSecuredEntry.Entity
+                .builder()
+                .id(REF_ID)
+                .mask(1)
+                .name(REFERENCE_NAME)
+                .owner(TEST_OWNER)
+                .build(), TEST_OWNER, TEST_GROUP);
+
+        server.addReference(REF_BIO_ID, REF_ID, REFERENCE_NAME, PATH_TO_REFERENCE);
+        server.addPermissions(entry, BiologicalDataItemFormat.REFERENCE.name());
+
+        SearchHandler handler = getSearchHandler();
+        ApplicationOptions applicationOptions = new ApplicationOptions();
+        applicationOptions.setPrintTable(true);
+        applicationOptions.setShowPermissions(true);
+        handler.parseAndVerifyArguments(Collections.singletonList(REFERENCE_NAME), applicationOptions);
+        Assert.assertEquals(RUN_STATUS_OK, handler.runCommand());
     }
 
     private SearchHandler getSearchHandler() {


### PR DESCRIPTION
# Description
This PR provides permissions viewing in CLI described in issue https://github.com/epam/NGB/issues/218

## Background

Support ability for users to view what permissions are set for a specific object (`seach` and `list_dataset` commands)

## Changes

- a new flag option `--permissions (-perm)` created. If that option is specified permissions for each object (dataset/file) will be printed. 

## Acceptance criteria

- create several users/roles
-  grant permissions for files/datasets
- run `ngb ld --permissions` 
- run `ngb s file_name --permissions`

# Check list

- [X] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
