### PR TITLE
RBAC: Support users auto-registration based on SAML groups

### DIFF
--- a/server/catgenome/profiles/dev/catgenome.properties
+++ b/server/catgenome/profiles/dev/catgenome.properties
@@ -85,8 +85,8 @@ saml.security.enable=false
 #saml.authorities.attribute.names=http://schemas.xmlsoap.org/ws/2005/05/identity/claims/tokenGroups
 #saml.user.attributes=Email=http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress,Name=http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name
 
-# Create a NGB user if it is not present in the database
-saml.user.auto.create=false
+# Create a NGB user if it is not present in the database. Available strategies: AUTO, EXPLICIT, EXPLICIT_GROUP
+saml.user.auto.create=EXPLICIT
 
 # Required for JWT token generation
 jwt.key.private=

--- a/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
@@ -253,6 +253,7 @@ public final class MessagesConstants {
     public static final String ERROR_USER_LIST_EMPTY = "error.user.list.empty";
     public static final String ERROR_ROLE_NAME_REQUIRED = "error.role.name.required";
     public static final String ERROR_ROLE_ALREADY_EXIST = "error.role.already.exists";
+    public static final String ERROR_NO_GROUP_WAS_FOUND = "error.no.group.was.found";
 
     private MessagesConstants() {
         // No-op

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/person/UserController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/person/UserController.java
@@ -175,4 +175,17 @@ public class UserController extends AbstractRESTController {
     public Result loadUserByName(@RequestParam String name) {
         return Result.success(userSecurityService.loadUserByName(name));
     }
+
+    @GetMapping(value = "/group/find")
+    @ResponseBody
+    @ApiOperation(
+            value = "Finds user group by a prefix (case insensitive).",
+            notes = "Finds user group by a prefix (case insensitive).",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<Collection<String>> findGroups(@RequestParam(required = false) String prefix) {
+        return Result.success(userSecurityService.findGroups(prefix));
+    }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/BiologicalDataItemDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/BiologicalDataItemDao.java
@@ -31,7 +31,6 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.epam.catgenome.component.MessageHelper;
 import com.epam.catgenome.constant.MessagesConstants;
@@ -194,8 +193,7 @@ public class BiologicalDataItemDao extends NamedParameterJdbcDaoSupport {
             return Collections.emptyList();
         }
 
-        List<String> quotedNames = names.stream().map(n -> "'" + n + "'").collect(Collectors.toList());
-        String query = DaoHelper.getQueryFilledWithIdArray(loadBiologicalDataItemsByNamesStrictQuery, quotedNames);
+        String query = DaoHelper.getQueryFilledWithStringArray(loadBiologicalDataItemsByNamesStrictQuery, names);
 
         return getJdbcTemplate().query(query, getRowMapper());
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/DaoHelper.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/DaoHelper.java
@@ -54,6 +54,7 @@ public class DaoHelper extends NamedParameterJdbcDaoSupport {
     private static final String UNDERSCORE = "_";
     private static final String UNDERSCORE_ESCAPED = "\\\\_";
     private static final String IN_CLAUSE_PLACEHOLDER = "@in@";
+    public static final String QUOTE = "'";
 
     private String createIdQuery;
 
@@ -81,13 +82,19 @@ public class DaoHelper extends NamedParameterJdbcDaoSupport {
     }
 
     public static String getQueryFilledWithIdArray(String queryTemplate, Collection<?> ids) {
-        return queryTemplate.replace("@in@",
+        return queryTemplate.replaceAll(IN_CLAUSE_PLACEHOLDER,
                 "(" + ids.stream().filter(Objects::nonNull)
                         .map(Object::toString).collect(Collectors.joining(",")) + ")");
     }
 
+    public static String getQueryFilledWithStringArray(String queryTemplate, Collection<String> ids) {
+        return queryTemplate.replaceAll(IN_CLAUSE_PLACEHOLDER,
+                "(" + ids.stream().filter(Objects::nonNull)
+                        .map(s -> QUOTE + s + QUOTE).collect(Collectors.joining(",")) + ")");
+    }
+
     public static String getQueryFilledWithTempTable(String queryTemplate, Collection<?> ids) {
-        return queryTemplate.replace("@in@",
+        return queryTemplate.replaceAll(IN_CLAUSE_PLACEHOLDER,
                 ids.stream().filter(Objects::nonNull)
                         .map(Object::toString).collect(Collectors.joining(",")));
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/user/UserDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/user/UserDao.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.epam.catgenome.entity.security.NgbSecurityGroup;
@@ -87,7 +86,7 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
     private DaoHelper daoHelper;
 
     /**
-     * Loads user by name with roles. Groups should be explicitly loaded with loadGroupsByUsersIds method call
+     * Loads user by name with roles.
      *
      * @param userName
      * @return user with roles
@@ -123,11 +122,12 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
 
     private void insertUserGroups(Long id, List<String> groups) {
         List<NgbSecurityGroup> existingGroups = loadExistingGroupsFromList(groups);
-        Map<String, NgbSecurityGroup> existingGroupsByName = existingGroups.stream()
-                .collect(Collectors.toMap(NgbSecurityGroup::getGroupName, Function.identity()));
+        Set<String> existingGroupsNames = existingGroups.stream()
+                .map(NgbSecurityGroup::getGroupName)
+                .collect(Collectors.toSet());
 
         List<String> newGroups = groups.stream()
-                .filter(g -> !existingGroupsByName.containsKey(g))
+                .filter(g -> !existingGroupsNames.contains(g))
                 .collect(Collectors.toList());
         List<Long> ids = daoHelper.createIds(groupSequence, newGroups.size());
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/user/UserDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/user/UserDao.java
@@ -94,7 +94,7 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
      */
     public NgbUser loadUserByName(String userName) {
         List<NgbUser> items = getJdbcTemplate().query(loadUserByNameQuery,
-                                    UserParameters.getUserWithRolesAndGroupsExtractor(), userName.toLowerCase());
+                UserParameters.getUserWithRolesAndGroupsExtractor(), userName.toLowerCase(), userName.toLowerCase());
         if (CollectionUtils.isEmpty(items)) {
             return null;
         } else {
@@ -164,14 +164,14 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
             return Collections.emptyList();
         }
 
-        String query = DaoHelper.replaceInClause(loadUsersByNamesQuery, names.size());
-        return getJdbcTemplate().query(query, UserParameters.getUserWithRolesAndGroupsExtractor(),
-                                       names.stream().map(String::toLowerCase).toArray());
+        List<String> args = names.stream().map(String::toLowerCase).collect(Collectors.toList());
+        String query = DaoHelper.getQueryFilledWithStringArray(loadUsersByNamesQuery, args);
+        return getJdbcTemplate().query(query, UserParameters.getUserWithRolesAndGroupsExtractor());
     }
 
     public NgbUser loadUserById(Long id) {
         List<NgbUser> items =
-            getJdbcTemplate().query(loadUserByIdQuery, UserParameters.getUserWithRolesAndGroupsExtractor(), id);
+            getJdbcTemplate().query(loadUserByIdQuery, UserParameters.getUserWithRolesAndGroupsExtractor(), id, id);
         return items.stream().findFirst().orElse(null);
     }
 
@@ -238,7 +238,7 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
 
     public List<NgbUser> loadUsersByGroup(String group) {
         return getJdbcTemplate().query(loadUsersByGroupQuery, UserParameters.getUserWithRolesAndGroupsExtractor(),
-                                       group.toLowerCase());
+                                       group.toLowerCase(), group.toLowerCase());
     }
 
     public List<NgbSecurityGroup> loadExistingGroupsFromList(List<String> groups) {
@@ -248,7 +248,7 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
 
     public boolean isUserInGroup(String userName, String group) {
         List<NgbUser> user = getJdbcTemplate().query(loadUserByNameAndGroupQuery,
-                                                     UserParameters.getUserRowMapper(), userName, group);
+                UserParameters.getUserRowMapper(), userName, group,  userName, group);
         return !CollectionUtils.isEmpty(user);
     }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/security/NgbSecurityGroup.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/security/NgbSecurityGroup.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.entity.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents an object describes NGB security group
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NgbSecurityGroup {
+    private Long id;
+    private String groupName;
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/user/UserSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/user/UserSecurityService.java
@@ -122,4 +122,9 @@ public class UserSecurityService {
     public Collection<NgbUser> loadUsersByNames(IDList userList) {
         return userManager.loadUsersByNames(userList.getIds());
     }
+
+    @PreAuthorize(ROLE_ADMIN)
+    public Collection<String> findGroups(final String prefix) {
+        return userManager.findGroups(prefix);
+    }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/security/acl/JdbcMutableAclServiceImpl.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/security/acl/JdbcMutableAclServiceImpl.java
@@ -24,12 +24,14 @@
 
 package com.epam.catgenome.security.acl;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 
+import com.epam.catgenome.dao.DaoHelper;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.security.acls.domain.GrantedAuthoritySid;
 import org.springframework.security.acls.domain.ObjectIdentityImpl;
@@ -49,6 +51,7 @@ public class JdbcMutableAclServiceImpl extends JdbcMutableAclService {
 
     private String deleteSidByIdQuery;
     private String deleteEntriesBySidQuery;
+    private String loadEntriesBySidsCountQuery;
 
     public JdbcMutableAclServiceImpl(DataSource dataSource, LookupStrategy lookupStrategy,
                                      AclCache aclCache) {
@@ -166,6 +169,11 @@ public class JdbcMutableAclServiceImpl extends JdbcMutableAclService {
         updateAcl(acl);
     }
 
+    public Integer loadEntriesBySidsCount(final Collection<Long> sidIds) {
+        String query = DaoHelper.replaceInClause(loadEntriesBySidsCountQuery, sidIds.size());
+        return jdbcTemplate.queryForObject(query, sidIds.toArray(), Integer.class);
+    }
+
     @Required
     public void setDeleteSidByIdQuery(String deleteSidByIdQuery) {
         this.deleteSidByIdQuery = deleteSidByIdQuery;
@@ -174,5 +182,10 @@ public class JdbcMutableAclServiceImpl extends JdbcMutableAclService {
     @Required
     public void setDeleteEntriesBySidQuery(String deleteEntriesBySidQuery) {
         this.deleteEntriesBySidQuery = deleteEntriesBySidQuery;
+    }
+
+    @Required
+    public void setLoadEntriesBySidsCountQuery(String loadEntriesBySidsCountQuery) {
+        this.loadEntriesBySidsCountQuery = loadEntriesBySidsCountQuery;
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/security/saml/SAMLUserDetailsServiceImpl.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/security/saml/SAMLUserDetailsServiceImpl.java
@@ -87,8 +87,6 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
         Map<String, String> attributes = readAttributes(credential);
         NgbUser loadedUser = userManager.loadUserByName(userName);
 
-        groups.add("TEST_GROUP");
-
         if (loadedUser == null) {
             checkAbilityToCreate(userName, groups);
             LOGGER.debug(MessageHelper.getMessage(MessagesConstants.ERROR_USER_NAME_NOT_FOUND, userName));

--- a/server/catgenome/src/main/java/com/epam/catgenome/security/saml/SAMLUserDetailsServiceImpl.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/security/saml/SAMLUserDetailsServiceImpl.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.epam.catgenome.security.acl.GrantPermissionManager;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -67,14 +68,17 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
         "#{catgenome['saml.user.attributes'] != null ? catgenome['saml.user.attributes'].split(',') : new String[0]}")
     private Set<String> samlAttributes;
 
-    @Value("${saml.user.auto.create: false}")
-    private boolean autoCreateUsers;
+    @Value("${saml.user.auto.create: EXPLICIT}")
+    private SamlUserRegisterStrategy autoCreateUsers;
 
     @Autowired
     private UserManager userManager;
 
     @Autowired
     private RoleManager roleManager;
+
+    @Autowired
+    private GrantPermissionManager permissionManager;
 
     @Override
     public Object loadUserBySAML(SAMLCredential credential) throws UsernameNotFoundException {
@@ -83,13 +87,11 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
         Map<String, String> attributes = readAttributes(credential);
         NgbUser loadedUser = userManager.loadUserByName(userName);
 
-        if (loadedUser == null) {
-            if (!autoCreateUsers) {
-                throw new UsernameNotFoundException(
-                    MessageHelper.getMessage(MessagesConstants.ERROR_USER_NAME_NOT_FOUND, userName));
-            }
-            LOGGER.debug(MessageHelper.getMessage(MessagesConstants.ERROR_USER_NAME_NOT_FOUND, userName));
+        groups.add("TEST_GROUP");
 
+        if (loadedUser == null) {
+            checkAbilityToCreate(userName, groups);
+            LOGGER.debug(MessageHelper.getMessage(MessagesConstants.ERROR_USER_NAME_NOT_FOUND, userName));
 
             List<Long> roles = roleManager.getDefaultRolesIds();
             NgbUser createdUser = userManager.createUser(userName, roles, groups, attributes);
@@ -111,6 +113,22 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
             }
 
             return new UserContext(loadedUser);
+        }
+    }
+
+    private void checkAbilityToCreate(final String userName, final List<String> groups) {
+        switch (autoCreateUsers) {
+            case EXPLICIT:
+                throw new UsernameNotFoundException(
+                        MessageHelper.getMessage(MessagesConstants.ERROR_USER_NAME_NOT_FOUND, userName));
+            case EXPLICIT_GROUP:
+                if (!permissionManager.isGroupRegistered(groups)) {
+                    throw new UsernameNotFoundException(
+                            MessageHelper.getMessage(MessagesConstants.ERROR_NO_GROUP_WAS_FOUND, userName));
+                }
+                break;
+            default:
+                break;
         }
     }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/security/saml/SamlUserRegisterStrategy.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/security/saml/SamlUserRegisterStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.security.saml;
+
+/**
+ * Represents the SAML user registration strategies set into saml.user.auto.create property.
+ * AUTO - creates a new NGB user if not exists
+ * EXPLICIT - requires users pre-registration id database (performs by admin)
+ * EXPLICIT_GROUP - requires specific groups pre-registration. If users SAML groups have no intersections with
+ * registered NGB security groups the authentication will be failed.
+ */
+public enum SamlUserRegisterStrategy {
+    AUTO, EXPLICIT, EXPLICIT_GROUP
+}

--- a/server/catgenome/src/main/resources/catgenome-messages.properties
+++ b/server/catgenome/src/main/resources/catgenome-messages.properties
@@ -251,3 +251,4 @@ error.user.id.not.found=Failed to find user by id ''{0}''.
 error.user.list.empty=Given user list is empty!
 error.role.name.required=Role name is required!
 error.role.already.exists=Role ''{0}'' already exists!
+error.no.group.was.found=No groups were found for user ''{0}''

--- a/server/catgenome/src/main/resources/conf/catgenome/acl-dao.xml
+++ b/server/catgenome/src/main/resources/conf/catgenome/acl-dao.xml
@@ -154,5 +154,12 @@
                 ]]>
             </value>
         </property>
+        <property name="loadEntriesBySidsCountQuery">
+            <value>
+                <![CDATA[
+                    SELECT count(*) FROM catgenome.acl_entry where sid IN (@in@)
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/server/catgenome/src/main/resources/conf/catgenome/dao/user-dao.xml
+++ b/server/catgenome/src/main/resources/conf/catgenome/dao/user-dao.xml
@@ -41,15 +41,27 @@
                         r.name as role_name,
                         r.predefined as role_predefined,
                         r.user_default as role_user_default,
-                        g.id as group_id,
-                        g.name as group_name
+                        NULL as group_id,
+                        NULL as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                    WHERE LOWER(u.name) LIKE LOWER(:USER_NAME)
+                    UNION
+                    SELECT
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        NULL as role_id,
+                        NULL as role_name,
+                        NULL as role_predefined,
+                        NULL as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
+                    FROM catgenome.user u
                         LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
                         LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
-                    WHERE
-                        LOWER(u.name) LIKE :USER_NAME
+                    WHERE LOWER(u.name) LIKE LOWER(:USER_NAME)
                 ]]>
             </value>
         </property>
@@ -145,14 +157,28 @@
                         r.name as role_name,
                         r.predefined as role_predefined,
                         r.user_default as role_user_default,
-                        g.id as group_id,
-                        g.name as group_name
+                        NULL as group_id,
+                        NULL as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                    WHERE LOWER(u.name) = LOWER(?)
+                    UNION
+                    SELECT
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        NULL as role_id,
+                        NULL as role_name,
+                        NULL as role_predefined,
+                        NULL as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
+                    FROM catgenome.user u
                         LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
                         LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                     WHERE LOWER(u.name) = LOWER(?)
+
                 ]]>
             </value>
         </property>
@@ -161,20 +187,32 @@
             <value>
                 <![CDATA[
                     SELECT
-                       u.id as user_id,
-                       u.name as user_name,
-                       u.attributes as attributes,
-                       r.id as role_id,
-                       r.name as role_name,
-                       r.predefined as role_predefined,
-                       r.user_default as role_user_default,
-                       g.id as group_id,
-                       g.name as group_name
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        r.id as role_id,
+                        r.name as role_name,
+                        r.predefined as role_predefined,
+                        r.user_default as role_user_default,
+                        NULL as group_id,
+                        NULL as group_name
                     FROM catgenome.user u
-                       LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
-                       LEFT JOIN catgenome.role r ON ur.role_id = r.id
-                       LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
-                       LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
+                        LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
+                        LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                    UNION
+                    SELECT
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        NULL as role_id,
+                        NULL as role_name,
+                        NULL as role_predefined,
+                        NULL as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
+                    FROM catgenome.user u
+                        LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                        LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                 ]]>
             </value>
         </property>
@@ -190,13 +228,28 @@
                         r.name as role_name,
                         r.predefined as role_predefined,
                         r.user_default as role_user_default,
-                        g.id as group_id,
-                        g.name as group_name
+                        NULL as group_id,
+                        NULL as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                    WHERE
+                        u.id = ?
+                    UNION
+                    SELECT
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        NULL as role_id,
+                        NULL as role_name,
+                        NULL as role_predefined,
+                        NULL as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
+                    FROM catgenome.user u
                         LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
                         LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
+
                     WHERE
                         u.id = ?
                 ]]>
@@ -214,15 +267,31 @@
                         r.name as role_name,
                         r.predefined as role_predefined,
                         r.user_default as role_user_default,
-                        g.id as group_id,
-                        g.name as group_name
+                        NULL as group_id,
+                        NULL as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
                         LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
                         LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
+                    WHERE LOWER(g.name) = LOWER(?)
+                    UNION
+                    SELECT
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        NULL as role_id,
+                        NULL as role_name,
+                        NULL as role_predefined,
+                        NULL as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
+                    FROM catgenome.user u
+                        LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                        LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
+
                     WHERE
-                        LOWER(g.name) = ?
+                        LOWER(g.name) = LOWER(?)
                 ]]>
             </value>
         </property>
@@ -287,15 +356,28 @@
                         r.name as role_name,
                         r.predefined as role_predefined,
                         r.user_default as role_user_default,
-                        g.id as group_id,
-                        g.name as group_name
+                        NULL as group_id,
+                        NULL as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                    WHERE LOWER(u.name) IN @in@
+                    UNION
+                    SELECT
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        NULL as role_id,
+                        NULL as role_name,
+                        NULL as role_predefined,
+                        NULL as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
+                    FROM catgenome.user u
                         LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
                         LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                     WHERE
-                        LOWER(u.name) IN (@in@)
+                          LOWER(u.name) IN @in@
                 ]]>
             </value>
         </property>
@@ -309,14 +391,33 @@
                         r.id as role_id,
                         r.name as role_name,
                         r.predefined as role_predefined,
-                        r.user_default as role_user_default
+                        r.user_default as role_user_default,
+                        NULL as group_id,
+                        NULL as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
                         LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
                         LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
+                    WHERE LOWER(u.name) = LOWER(?) AND LOWER(g.name) = LOWER(?)
+                    UNION
+                    SELECT
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        NULL as role_id,
+                        NULL as role_name,
+                        NULL as role_predefined,
+                        NULL as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
+                    FROM catgenome.user u
+                        LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                        LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
+
                     WHERE
-                        u.name = ? AND g.name = ?
+                        LOWER(u.name) = LOWER(?) AND LOWER(g.name) = LOWER(?)
+
                 ]]>
             </value>
         </property>
@@ -324,22 +425,36 @@
             <value>
                 <![CDATA[
                     SELECT
-                      u.id as user_id,
-                      u.name as user_name,
-                      u.attributes as attributes,
-                      r.id as role_id,
-                      r.name as role_name,
-                      r.predefined as role_predefined,
-                      r.user_default as role_user_default,
-                      g.id as group_id,
-                      g.name as group_name
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        r.id as role_id,
+                        r.name as role_name,
+                        r.predefined as role_predefined,
+                        r.user_default as role_user_default,
+                        NULL as group_id,
+                        NULL as group_name
                     FROM catgenome.user u
-                      LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
-                      LEFT JOIN catgenome.role r ON ur.role_id = r.id
-                      LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
-                      LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
+                        LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
+                        LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                    WHERE u.id in (:IDS)
+                    UNION
+                    SELECT
+                        u.id as user_id,
+                        u.name as user_name,
+                        u.attributes as attributes,
+                        NULL as role_id,
+                        NULL as role_name,
+                        NULL as role_predefined,
+                        NULL as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
+                    FROM catgenome.user u
+                        LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                        LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
+
                     WHERE
-                        u.id in (:IDS)
+                         u.id in (:IDS)
                 ]]>
             </value>
         </property>

--- a/server/catgenome/src/main/resources/conf/catgenome/dao/user-dao.xml
+++ b/server/catgenome/src/main/resources/conf/catgenome/dao/user-dao.xml
@@ -40,10 +40,14 @@
                         r.id as role_id,
                         r.name as role_name,
                         r.predefined as role_predefined,
-                        r.user_default as role_user_default
+                        r.user_default as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
                     FROM catgenome.user u
-                        JOIN catgenome.user_role ur ON u.id = ur.user_id
-                        JOIN catgenome.role r ON ur.role_id = r.id
+                        LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
+                        LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                        LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                        LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                     WHERE
                         LOWER(u.name) LIKE :USER_NAME
                 ]]>
@@ -82,7 +86,10 @@
         <property name="loadExistingGroupsFromListQuery">
             <value>
                 <![CDATA[
-                    SELECT id, name FROM catgenome.security_group WHERE name IN (@in@)
+                    SELECT
+                        id,
+                        name
+                    FROM catgenome.security_group WHERE name IN (@in@)
                 ]]>
             </value>
         </property>
@@ -137,10 +144,14 @@
                         r.id as role_id,
                         r.name as role_name,
                         r.predefined as role_predefined,
-                        r.user_default as role_user_default
+                        r.user_default as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                        LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                        LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                     WHERE LOWER(u.name) = LOWER(?)
                 ]]>
             </value>
@@ -156,10 +167,14 @@
                        r.id as role_id,
                        r.name as role_name,
                        r.predefined as role_predefined,
-                       r.user_default as role_user_default
+                       r.user_default as role_user_default,
+                       g.id as group_id,
+                       g.name as group_name
                     FROM catgenome.user u
                        LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                        LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                       LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                       LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                 ]]>
             </value>
         </property>
@@ -174,10 +189,14 @@
                         r.id as role_id,
                         r.name as role_name,
                         r.predefined as role_predefined,
-                        r.user_default as role_user_default
+                        r.user_default as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                        LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                        LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                     WHERE
                         u.id = ?
                 ]]>
@@ -194,7 +213,9 @@
                         r.id as role_id,
                         r.name as role_name,
                         r.predefined as role_predefined,
-                        r.user_default as role_user_default
+                        r.user_default as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
@@ -244,18 +265,18 @@
         <property name="loadAllGroupsQuery">
             <value>
                 <![CDATA[
-                    SELECT name FROM catgenome.security_group
+                    SELECT id, name FROM catgenome.security_group
                 ]]>
             </value>
         </property>
         <property name="findGroupsQuery">
             <value>
                 <![CDATA[
-                    SELECT name FROM catgenome.security_group WHERE LOWER(name) LIKE ?
+                    SELECT id, name FROM catgenome.security_group WHERE LOWER(name) LIKE ?
                 ]]>
             </value>
         </property>
-        <property name="loadUsesByNamesQuery">
+        <property name="loadUsersByNamesQuery">
             <value>
                 <![CDATA[
                     SELECT
@@ -265,10 +286,14 @@
                         r.id as role_id,
                         r.name as role_name,
                         r.predefined as role_predefined,
-                        r.user_default as role_user_default
+                        r.user_default as role_user_default,
+                        g.id as group_id,
+                        g.name as group_name
                     FROM catgenome.user u
                         LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                         LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                        LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                        LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                     WHERE
                         LOWER(u.name) IN (@in@)
                 ]]>
@@ -305,10 +330,14 @@
                       r.id as role_id,
                       r.name as role_name,
                       r.predefined as role_predefined,
-                      r.user_default as role_user_default
+                      r.user_default as role_user_default,
+                      g.id as group_id,
+                      g.name as group_name
                     FROM catgenome.user u
                       LEFT JOIN catgenome.user_role ur ON u.id = ur.user_id
                       LEFT JOIN catgenome.role r ON ur.role_id = r.id
+                      LEFT JOIN catgenome.user_security_group ug ON ug.user_id = u.id
+                      LEFT JOIN catgenome.security_group g ON ug.group_id = g.id
                     WHERE
                         u.id in (:IDS)
                 ]]>

--- a/server/catgenome/src/test/java/com/epam/catgenome/dao/user/UserDaoTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/dao/user/UserDaoTest.java
@@ -31,7 +31,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import com.epam.catgenome.entity.security.NgbSecurityGroup;
 import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -144,22 +146,28 @@ public class UserDaoTest extends AbstractDaoTest {
         Assert.assertTrue(userByGroup.stream().noneMatch(u ->
                                                              u.getUserName().equals(TEST_USER3)));
 
-        Map<Long, List<String>> groupMap = userDao.loadGroups(Arrays.asList(user1.getId(), user2.getId(),
-                                                                            user3.getId()));
+        Map<Long, List<NgbSecurityGroup>> groupMap = userDao.loadGroupsByUsersIds(Arrays.asList(user1.getId(),
+                user2.getId(), user3.getId()));
 
         Assert.assertEquals(1, groupMap.get(user1.getId()).size());
         Assert.assertEquals(2, groupMap.get(user2.getId()).size());
         Assert.assertEquals(1, groupMap.get(user3.getId()).size());
 
-        List<String> foundGroups = userDao.findGroups("TEST_");
+        List<String> foundGroups = userDao.findGroups("TEST_")
+                .stream()
+                .map(NgbSecurityGroup::getGroupName)
+                .collect(Collectors.toList());
         Assert.assertEquals(TEST_GROUPS_1.size(), foundGroups.size());
         Assert.assertTrue(TEST_GROUPS_1.containsAll(foundGroups));
 
         Assert.assertFalse(userDao.isUserInGroup(user1.getUserName(), "TEST_GROUP_5"));
         Assert.assertTrue(userDao.isUserInGroup(user1.getUserName(), TEST_GROUP_1));
 
-        List<String> allLoadedGroups = userDao.loadAllGroups();
-        Collections.sort(allLoadedGroups);
+        List<String> allLoadedGroups = userDao.loadAllGroups()
+                .stream()
+                .map(NgbSecurityGroup::getGroupName)
+                .sorted()
+                .collect(Collectors.toList());
         Assert.assertEquals(TEST_GROUPS_1, allLoadedGroups);
 
         userDao.deleteUserGroups(user1.getId());


### PR DESCRIPTION
# Description
This PR provides SAML users auto-registration described in issue https://github.com/epam/NGB/issues/223

## Changes

The property `saml.user.auto.create` ha been changed. The following value are available:  AUTO, EXPLICIT, EXPLICIT_GROUP

- AUTO - creates a new NGB user if not exists
- EXPLICIT - requires users pre-registration id database (performs by admin)
- EXPLICIT_GROUP -  requires specific groups pre-registration. If users SAML groups have no intersections with registered NGB security groups the authentication will be failed.

Also, a new API method `/group/find` added that loads all groups or groups by prefix

## Acceptance criteria

- set property `saml.user.auto.create=EXPLICIT_GROUP`
- register user with specific group and grant permissions for that group for some items (e.g. datasets)
- authenticate SAML user with specific group

# Check list

- [x] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
