### PR TITLE
Sections of documentation on working with S3 files

### DIFF
--- a/docs/md/cli/command-reference.md
+++ b/docs/md/cli/command-reference.md
@@ -15,25 +15,25 @@ Sets NGB server API URL. By default CLI uses **localhost** to call API. If one n
 
 URL should be specified using the following format: **http://{NGB_SERVER_NAME_OR_IP}:{NGB_SERVER_PORT}/catgenome**
 
-When URL is set - it would be stored and used next time CLI is launched
+When URL is set - it would be stored and used next time CLI is launched.
 
 *Example*
-```
-//Sets remote server for CLI
-ngb set_srv http://10.248.33.51:8080/catgenome
+```bash
+# Sets remote server for CLI
+$ ngb set_srv http://10.248.33.51:8080/catgenome
 ```
 #### Set authorization token
 ```
 ngb set_token|st [<JWT_TOKEN>]
-
 ```
 *Description*
 
 Sets JWT token to authorize CLI requests to NGB server API. Required if authorization is enabled on NGB.
+
 *Example*
-```
-//Sets remote server for CLI
-ngb set_token eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X3VzZXIiLCJ1c2VyX
+```bash
+# Sets remote server for CLI
+$ ngb set_token eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X3VzZXIiLCJ1c2VyX
 ```
 ## Display CLI version
 
@@ -55,15 +55,16 @@ ngb search|s [<QUERY>] [options]
 ```
 *Description*
 
-Searches for a specified string in reference and file names. By default, command will search for exactly equal name,  if -l option is specified - a search query will used as a substring.
+Searches for a specified string in reference and file names. By default, command will search for exactly equal name,  if `-l` option is specified - a search query will used as a substring.
 
 *Example*
-```
-//Search for all objects, that contain "vcf" substring in their names and ouput result as a human-readable table
-ngb search -l vcf -t
+```bash
+# Search for all objects, that contain "vcf" substring in their names and
+# ouput result as a human-readable table
+$ ngb search -l vcf -t
 
-//Search file, named exactly "sample_1.bam" and ouput result as a json string
-ngb search sample_1.bam
+# Search file, named exactly "sample_1.bam" and ouput result as a json string
+$ ngb search sample_1.bam
 ```
 
 ## Reference commands
@@ -89,13 +90,12 @@ remote source. NGB assumes that reference index will have the same name as refer
 **"/opt/genomes/hg38.fa"**, NGB will look for index file at path **"/opt/genomes/hg38.fa.fai"**.
 
 *Example*
-```
-//Register reference, use "grch.38.fa" as name
-ngb reg_ref /opt/genomes/grch.38.fa
+```bash
+# Register reference, use "grch.38.fa" as name
+$ ngb reg_ref /opt/genomes/grch.38.fa
 
-//Register reference, use "grch38" as name
-ngb rr /opt/genomes/grch.38.fa -n grch38
-
+# Register reference, use "grch38" as name
+$ ngb rr /opt/genomes/grch.38.fa -n grch38
 ```
 ### List reference sequences
 ```
@@ -107,13 +107,12 @@ ngb list_ref|lr [options]
 ```
 *Description*
 
-Lists all reference sequences registered on the NGB server. The command output format is specified by
--t and -j options, default format is Json.
+Lists all reference sequences registered on the NGB server. The command output format is specified by `-t` and `-j` options, default format is Json.
 
 *Example*
-```
-//List all reference files from the server
-ngb list_ref -t
+```bash
+# List all reference files from the server
+$ ngb list_ref -t
 ```
 
 ### Delete reference sequence
@@ -129,12 +128,12 @@ ngb del_ref|dr [<REFERENCE_NAME|REFERENCE_ID>] [options]
 Deletes a specified reference sequence file from NGB server. Reference file can be addressed by name or an identifier (retrieved from **reg_ref** command, at registration time or search command)
 
 *Example*
-```
-//Delete reference with name "grch38"
-ngb del_ref grch38
+```bash
+# Delete reference with name "grch38"
+$ ngb del_ref grch38
 
-//Delete reference with id 1
-ngb dr 1
+# Delete reference with id 1
+$ ngb dr 1
 ```
 
 ### Add gene file to the reference
@@ -151,12 +150,12 @@ Adds a gene (GFF or GTF) file to the reference on NGB server. Reference file can
 If gene file is already registered on NGb server, it can be addressed by name or by an identifier. Otherwise a path to the gene file should be provided.
 
 *Example*
-```
-//Add a regitered gene file to the reference with name "grch38"
-ngb add_genes grch38 genes.gtf
+```bash
+# Add a regitered gene file to the reference with name "grch38"
+$ ngb add_genes grch38 genes.gtf
 
-//Add a new gene file to the reference with name ID "1"
-ngb ag 1 /opt/tracks/genes.gtf
+# Add a new gene file to the reference with name ID "1"
+$ ngb ag 1 /opt/tracks/genes.gtf
 ```
 
 ### Remove gene file from the reference
@@ -172,12 +171,12 @@ ngb remove_genes|rg [<REFERENCE_NAME|REFERENCE_ID>] [options]
 Removes any gene file from the reference on NGB server. Reference file can be addressed by name or an identifier (retrieved from **reg_ref** command, at registration time or search command)
 
 *Example*
-```
-//Remove gene file from the reference with name "grch38"
-ngb remove_genes grch38
+```bash
+# Remove gene file from the reference with name "grch38"
+$ ngb remove_genes grch38
 
-//Remove gene file from the reference with ID "1"
-ngb rg 1
+# Remove gene file from the reference with ID "1"
+$ ngb rg 1
 ```
 
 ### Add annotation file to the reference
@@ -194,12 +193,12 @@ Adds an annotation (GFF, GTF, BED, VCF) file to the reference on NGB server. Ref
 If annotation file is already registered on NGB server, it can be addressed by name or by an identifier. Otherwise a path to the annotation file should be provided.
 
 *Example*
-```
-//Add a regitered gene file to the reference with name "grch38"
-ngb add_ann grch38 annotation.gtf
+```bash
+# Add a regitered gene file to the reference with name "grch38"
+$ ngb add_ann grch38 annotation.gtf
 
-//Add a new annotation file to the reference with name ID "1"
-ngb an 1 /opt/tracks/annotation.gtf
+# Add a new annotation file to the reference with name ID "1"
+$ ngb an 1 /opt/tracks/annotation.gtf
 ```
 
 ### Remove annotation file from the reference
@@ -216,9 +215,9 @@ Removes an annotation (GFF, GTF, BED, VCF) file from the reference on NGB server
 Annotation file can be addressed by name or by an identifier.
 
 *Example*
-```
-//Remove an annotation file from the reference with name "grch38"
-ngb remove_ann grch38 annotation.gtf
+```bash
+# Remove an annotation file from the reference with name "grch38"
+$ ngb remove_ann grch38 annotation.gtf
 ```
 
 ### Add species to the reference
@@ -232,12 +231,12 @@ ngb add_spec|as [<REFERENCE_NAME|REFERENCE_ID>] [<REGISTERED_SPECIES_VERSION>] [
 *Description*
 
 Adds a species version to the reference on NGB server. Reference file can be addressed by name or an identifier (retrieved from **reg_ref** command, at registration time or search command).
-Note: species with specified version should be already registered on NGB server.
+> **Note**: species with specified version should be already registered on NGB server.
 
 *Example*
-```
-//Add a regitered species version to the reference with name "grch38"
-ngb add_spec grch38 "hg19"
+```bash
+# Add a regitered species version to the reference with name "grch38"
+$ ngb add_spec grch38 "hg19"
 ```
 
 ### Remove species from the reference
@@ -253,9 +252,9 @@ ngb remove_spec [<REFERENCE_NAME|REFERENCE_ID>] [options]
 Removes a species version from the reference on NGB server. Reference file can be addressed by name or an identifier (retrieved from **reg_ref** command, at registration time or search command).
 
 *Example*
-```
-//Remove an annotation file from the reference with name "grch38"
-ngb remove_spec grch38
+```bash
+# Remove an annotation file from the reference with name "grch38"
+$ ngb remove_spec grch38
 ```
 
 ## File commands
@@ -275,7 +274,7 @@ ngb reg_file|rf [<REFERENCE_NAME>|<REFERENCE_ID>] [<PATH_TO_NGS_FILE>] [options]
 Registers a specified file. At least two arguments have to be specified:
 Previously registered reference sequence file from NGB server. Reference file can be addressed by name or an identifier.
 
-Filesystem path to the file to be registered. BAM, VCF, GFF, GTF, BED, SEG, WIG, BED GRAPH files are accepted. BGZipped files are also accepted in a format <FILE_NAME>.<FILE_EXT>.gz, e.g.: my_variants.vcf.gz. (`bgzip` tool is available as a part of [htslib](http://www.htslib.org/) package. Or NGB CLI `sort` command can used for that as well).
+Filesystem path to the file to be registered. BAM, VCF, GFF, GTF, BED, SEG, WIG, BED GRAPH files are accepted. BGZipped files are also accepted in a format <FILE_NAME>.<FILE_EXT>.gz, e.g.: my_variants.vcf.gz. (**bgzip** tool is available as a part of [htslib](http://www.htslib.org/) package. Or NGB CLI **sort** command can used for that as well).
 
 BAM file path must be followed by a `?` symbol and a path to an index file (.BAI) 
 (if a folder with BAM file also contains index for this BAM with the same name, CLI will find this index automatically. It also works well for vcf, bed and gene files). 
@@ -285,7 +284,7 @@ To register files from external cloud data storages (AWS S3), file path must be 
 > **Note**: for ability to work with files from AWS S3, do not forget to configure your NGB instance before start (see *"Configure for working with AWS S3"* paragraph [here](../installation/standalone.md)).
 
 *Example*
-```
+```bash
 # Register file, use "sample.vcf" as a name for reference with id 18
 $ ngb reg_file 18 /opt/tracks/sample.vcf
 
@@ -319,14 +318,15 @@ ngb del_file|df [<FILE_NAME>|<FILE_ID>] [options]
 *Description*
 
 Deletes a specified file from NGB server. File can be addressed by name or an identifier (retrieved from **reg_file** command, at registration time or **search** command)
+> **Note**: file couldn't be deleted, if it is added to any dataset. For deleting such file first remove it from all datasets. 
 
 *Example*
-```
-//Delete file with name "my_sample"
-ngb del_file my_sample
+```bash
+# Delete file with name "my_sample"
+$ ngb del_file my_sample
 
-//Delete file with id 18
-ngb df 18
+# Delete file with id 18
+$ ngb df 18
 ```
 
 ### Build feature index for a file
@@ -344,15 +344,15 @@ This can be useful to reindex a file or to create one if a file was registered w
 Feature index is used for search and filtering capabilities for BED/VCF/GFF/GTF files.
 File could be address by name or an identifier.
 
-*Note: this command is used for internal NGB indexing - it could not be used to index BAM/CRAM files*
+> **Note**: this command is used for internal NGB indexing - it could not be used to index BAM/CRAM files
 
 *Example*
-```
-//Build index for "sample.vcf" file 
-ngb index_file sample.vcf
+```bash
+# Build index for "sample.vcf" file 
+$ ngb index_file sample.vcf
 
-//Build index for a file with identifier "18"
-ngb if 18
+# Build index for a file with identifier "18"
+$ ngb if 18
 ```
 
 ## Datasets commands
@@ -379,23 +379,24 @@ Files can be addressed:
 * For previously registered files (see **reg_file** command) - by name or an identifier
 * For new files - by filesystem path (see **reg_file** command for a list of supported files)
 
-*Note: both options can be used in one command*
+> **Note**: both options can be used in one command
 
 *Example*
-```
-//Create new dataset with name "new_dataset" and use reference, named "grch38", do not add any files at the moment
-ngb reg_dataset grch38 new_dataset
+```bash
+# Create new dataset with name "new_dataset" and use reference, named "grch38",
+# do not add any files at the moment
+$ ngb reg_dataset grch38 new_dataset
 
-//Create new dataset with name "new_dataset" and use reference with id "1"
-ngb rd 1 new_dataset
+# Create new dataset with name "new_dataset" and use reference with id "1"
+$ ngb rd 1 new_dataset
 
-//Create new dataset with name "new_dataset" and reference "grch38", add two files
-//(previously registered: "my_sample", "sample.vcf") to "new_dataset"
-ngb rd grch38 new_dataset my_sample sample.vcf
+# Create new dataset with name "new_dataset" and reference "grch38",
+# add two files (previously registered: "my_sample", "sample.vcf") to "new_dataset"
+$ ngb rd grch38 new_dataset my_sample sample.vcf
 
-//Create new dataset with name "new_dataset" and reference "grch38", register
-//two files and add them to new_dataset
-ngb rd grch38  new_dataset /opt/tracks/sample.vcf /opt/tracks/sample.bam /opt/tracks/sample.bam.bai
+# Create new dataset with name "new_dataset" and reference "grch38",
+# register two files and add them to new_dataset
+$ ngb rd grch38 new_dataset /opt/tracks/sample.vcf /opt/tracks/sample.bam /opt/tracks/sample.bam.bai
 ```
 
 ### Add file(-s) to dataset
@@ -414,18 +415,18 @@ Files can be addressed:
 * For previously registered files (see **reg_file** command) - by name or an identifier
 * For new files - by filesystem path (see **reg_file** command for a list of supported files)
 
-*Note: both options can be used in one command*
+> **Note**: both options can be used in one command
 
 *Example*
-```
-//Add one file (named "my_sample") to dataset named "new_dataset"
-ngb add_dataset new_dataset my_sample
+```bash
+# Add one file (named "my_sample") to dataset named "new_dataset"
+$ ngb add_dataset new_dataset my_sample
 
-//Add two files (named "my_sample" and "sample.vcf") to dataset named "new_dataset"
-ngb add new_dataset my_sample sample.vcf
+# Add two files (named "my_sample" and "sample.vcf") to dataset named "new_dataset"
+$ ngb add new_dataset my_sample sample.vcf
 
-//Add three files (with identifiers: "1","2" and "3") to dataset with id "1"
-ngb add 1 1 2 3
+# Add three files (with identifiers: "1","2" and "3") to dataset with id "1"
+$ ngb add 1 1 2 3
 ```
 
 ### Remove file from dataset
@@ -438,20 +439,20 @@ ngb remove_dataset|rmd [<DATASET_NAME>|<DATASET_ID>] [<FILE_NAME>|<FILE_ID>] [op
 ```
 *Description*
 
-Removes a file from a specified dataset. Dataset can be addressed by name or by an identifier (retrieved from **reg_dataset** command, at registration time, or **search** command)
+Removes a file from a specified dataset. Dataset can be addressed by name or by an identifier (retrieved from **reg_dataset** command, at registration time, or **search** command).
 
-Only previously registered files (see **reg_file** command)  can be addressed. A file name or an identifier can be used.
+Only previously registered files (see **reg_file** command) can be addressed. A file name or an identifier can be used.
 
 *Example*
-```
-//Remove one file (named "my_sample") from dataset named "new_dataset"
-ngb remove_dataset new_dataset my_sample
+```bash
+# Remove one file (named "my_sample") from dataset named "new_dataset"
+$ ngb remove_dataset new_dataset my_sample
 
-//Remove two files (named "my_sample" and "sample.vcf") from dataset named "new_dataset"
-ngb rmd new_dataset my_sample sample.vcf
+# Remove two files (named "my_sample" and "sample.vcf") from dataset named "new_dataset"
+$ ngb rmd new_dataset my_sample sample.vcf
 
-//Remove three files (with identifiers: "1","2" and "3") from dataset with id "1"
-ngb rmd 1 1 2 3
+# Remove three files (with identifiers: "1","2" and "3") from dataset with id "1"
+$ ngb rmd 1 1 2 3
 ```
 
 ### Move dataset (change dataset's hierarchy)
@@ -463,19 +464,16 @@ ngb move_dataset|md [<DATASET_NAME>|<DATASET_ID>] [options]
 ```
 *Description*
 
-Changes the dataset's hierarchy. Without options the command will move the specified dataset
-to the top level od datasets' hierarchy (dataset's parent will be removed). If option -p (--parent)
-is specified the dataset's parent will be changed to this option value.
+Changes the dataset's hierarchy. Without options the command will move the specified dataset to the top level od datasets' hierarchy (dataset's parent will be removed). If option `-p` is specified the dataset's parent will be changed to this option value.
 
 *Example*
-```
-//Make dataset with ID 21 a top level dataset without a parent
-ngb move_dataset 21
+```bash
+# Make dataset with ID 21 a top level dataset without a parent
+$ ngb move_dataset 21
 
-//Make dataset with name "data_parent" the parent dataset for a dataset with name "data_1" 
-ngb md data_1 -p data_parent
+# Make dataset with name "data_parent" the parent dataset for a dataset with name "data_1" 
+$ ngb md data_1 -p data_parent
 ```
-
 
 ### List datasets
 ```
@@ -488,20 +486,16 @@ ngb list_dataset|ld [options]
 ```
 *Description*
 
-Lists datasets registered on NGB server. By default the command will output only top-level
-datasets without nested datasets. Dataset's hierarchy may be loaded with an option 'parent': if 
-a parent dataset is set, the command will output the parent itself and all nested datasets. Parent
-dataset may be addressed by name or ID.
+Lists datasets registered on NGB server. By default the command will output only top-level datasets without nested datasets. Dataset's hierarchy may be loaded with an option `--parent`: if a parent dataset is set, the command will output the parent itself and all nested datasets. Parent dataset may be addressed by name or ID.
 
 *Example*
-```
-//List all top-level datasets from the server
-ngb list_dataset
+```bash
+# List all top-level datasets from the server
+$ ngb list_dataset
 
-//List hierarchy tree for a dataset with the name "data_1"
-ngb ld -p data_1
+# List hierarchy tree for a dataset with the name "data_1"
+$ ngb ld -p data_1
 ```
-
 
 ### Delete dataset
 ```
@@ -519,14 +513,13 @@ Deletes a specified dataset from NGB server. Dataset could be addressed by name 
 Files that were added to a dataset are not deleted by this command, as soon they might be used (now or later) in other datasets.
 
 *Example*
-```
-//Delete dataset, named "new_dataset"
-ngb del_dataset new_dataset
+```bash
+# Delete dataset, named "new_dataset"
+$ ngb del_dataset new_dataset
 
-//Delete dataset with id "1"
-ngb dd 1
+# Delete dataset with id "1"
+$ ngb dd 1
 ```
-
 
 ### Generate URL for browsing selected files
 ```
@@ -541,16 +534,17 @@ ngb url [<DATASET_NAME>|<DATASET_ID>] [<FILE_IDS>|<FILE_NAMES>] [options]
 Create an URL, that will open NGB browser with selected tracks, opened on a optionally specified position
 
 *Example*
-```
+```bash
+# Create URL for dataset with name 'data' and files with IDs 42, 45 and a file with name 'sample.vcf'
+$ ngb url data 42 45 sample.vcf
 
-//Create URL for dataset with name 'data' and files with IDs 42, 45 and a file with name 'sample.vcf'
-ngb url data 42 45 sample.vcf
+# Create URL for dataset with ID '5' and a file with name 'sample.vcf'
+# on a chromosome 1 on positions from 13476 to 23476
+$ ngb url 5 sample.vcf -loc 1:13476-23476
 
-//Create URL for dataset with ID '5' and a file with name 'sample.vcf' on a chromosome 1 on positions from 13476 to 23476
-ngb url 5 sample.vcf -loc 1:13476-23476
-
-//Create URL for dataset with name 'data' and a file with name 'sample.vcf' on a chromosome 1
-ngb url data sample.vcf -loc 1
+# Create URL for dataset with name 'data' and a file with name 'sample.vcf'
+# on a chromosome 1
+$ ngb url data sample.vcf -loc 1
 ```
 
 
@@ -569,12 +563,12 @@ Registers a species. Two arguments have to be specified:
 * Species name
 * Species version
 
-Note: species version should be unique. During registration a species with already registered version a proper exception will be thrown.
+> **Note**: species version should be unique. During registration a species with already registered version a proper exception will be thrown.
 
 *Example*
-```
-//Create new species with name "human" and version "hg19"
-ngb reg_spec "human" "hg19"
+```bash
+# Create new species with name "human" and version "hg19"
+$ ngb reg_spec "human" "hg19"
 ```
 
 ### List species
@@ -590,9 +584,9 @@ ngb list_spec [options]
 List all species registered on NGB server.
 
 *Example*
-```
-//List all species registered on NGB server
-ngb list_spec
+```bash
+# List all species registered on NGB server
+$ ngb list_spec
 ```
 
 ### Delete species
@@ -608,9 +602,9 @@ ngb del_spec|ds [<SPECIES_VESRSION>] [options]
 Deletes a specified species from NGB server. Species is be addressed by version.
 
 *Example*
-```
-//Delete species with version "hg19"
-ngb del_spec "hg19"
+```bash
+# Delete species with version "hg19"
+$ ngb del_spec "hg19"
 ```
 
 
@@ -634,12 +628,16 @@ If this argument is not specified, sorted file will be stored in the same folder
 Sorted file will be automatically BGZip-compressed, if a target file name contains `.gz` postfix. If target file is not specified, file compression is inherited from the original file.
 
 *Example*
+```bash
+# Will sort given VCF file and place it in the same folder
+# with original file ('/samples/sample.vcf.gz') with name: sample.sorted.vcf.gz
+$ ngb sort /samples/sample.vcf.gz
+
+# Will sort given GFF file and place sorted file to the specified path
+# '/samples/sample-sorted.gff'
+$ ngb sort /samples/sample.gff /samples/sample-sorted.gff
+
+# Will sort given BED file, compress result and place sorted file
+# to the specified path '/samples/sorted_sample.bed.gz'
+$ ngb sort /samples/unsorted.bed /samples/sorted_sample.bed.gz
 ```
-//Will sort given VCF file and place it in the same folder with original file ('/samples/sample.vcf.gz') with name: sample.sorted.vcf.gz
-ngb sort /samples/sample.vcf.gz
-
-//Will sort given GFF file and place sorted file to the specified path '/samples/sample-sorted.gff'
-ngb sort /samples/sample.gff /samples/sample-sorted.gff
-
-//Will sort given BED file, compress result and place sorted file to the specified path '/samples/sorted_sample.bed.gz'
-ngb sort /samples/unsorted.bed /samples/sorted_sample.bed.gz

--- a/docs/md/cli/command-reference.md
+++ b/docs/md/cli/command-reference.md
@@ -273,29 +273,39 @@ ngb reg_file|rf [<REFERENCE_NAME>|<REFERENCE_ID>] [<PATH_TO_NGS_FILE>] [options]
 *Description*
 
 Registers a specified file. At least two arguments have to be specified:
-Previously registered reference sequence file from NGB server. Reference file can be addressed by name or an identifier
-Flesystem path to the file to be registered. BAM, VCF, GFF, GTF, BED, SEG, WIG, BED GRAPH files are accepted. BGZipped files are also accepted in a format <FILE_NAME>.<FILE_EXT>.gz, e.g.: my_variants.vcf.gz. (`bgzip` tool is available as a part of [htslib](http://www.htslib.org/) package. Or NGB CLI `sort` command can used for that as well)
-BAM file path has to be followed by a '?' symbol and a path to an index file (.BAI) 
-(If a folder with BAM file also contains index for this BAM with the same name, CLI will find this index automatically. 
-It also works well for vcf, bed and gene files). 
-If and only if cli located on the same filesystem with NGB server relative path can be used.
+Previously registered reference sequence file from NGB server. Reference file can be addressed by name or an identifier.
+
+Filesystem path to the file to be registered. BAM, VCF, GFF, GTF, BED, SEG, WIG, BED GRAPH files are accepted. BGZipped files are also accepted in a format <FILE_NAME>.<FILE_EXT>.gz, e.g.: my_variants.vcf.gz. (`bgzip` tool is available as a part of [htslib](http://www.htslib.org/) package. Or NGB CLI `sort` command can used for that as well).
+
+BAM file path must be followed by a `?` symbol and a path to an index file (.BAI) 
+(if a folder with BAM file also contains index for this BAM with the same name, CLI will find this index automatically. It also works well for vcf, bed and gene files). 
+If and only if CLI located on the same filesystem with NGB server relative path can be used.
+
+To register files from external cloud data storages (AWS S3), file path must be in full view (starting from `s3://`, then the bucket name, folder name and so on slash-separated, ending with <FILE_NAME>.<FILE_EXT>), e.g.: `s3://ngb-s3/fruitfly/agnX1.09-28.trim.dm606.realign.vcf`. In case with AWS S3 storages, path to the files with indexes (BAM, VCF, BED, genes files) must be strongly followed by a `?` symbol and a path to their index files. CLI will not find such indexes automatically.
+> **Note**: for ability to work with files from AWS S3, do not forget to configure your NGB instance before start (see *"Configure for working with AWS S3"* paragraph [here](../installation/standalone.md)).
 
 *Example*
 ```
-//Register file, use "sample.vcf" as name for reference with id 18
-ngb reg_file 18 /opt/tracks/sample.vcf
+# Register file, use "sample.vcf" as a name for reference with id 18
+$ ngb reg_file 18 /opt/tracks/sample.vcf
 
-//Register file, use "sample" as name for reference with name grch38
-ngb reg_file grch38 /opt/tracks/sample.vcf -n sample
+# Register file, use "sample" as a name for reference with the name grch38
+$ ngb reg_file grch38 /opt/tracks/sample.vcf -n sample
 
-//Register indexed file, use "sample.bam" as name
-ngb reg_file grch38 /opt/tracks/sample.bam?/opt/tracks/sample.bam.bai
+# Register indexed file, use "sample.bam" as a name
+$ ngb reg_file grch38 /opt/tracks/sample.bam?/opt/tracks/sample.bam.bai
 
-//Register indexed file, use "sample.bam" as name, index for the BAM file is contained in the same directory as the BAM file
-ngb reg_file grch38 /opt/tracks/sample.bam
+# Register indexed file, use "sample.bam" as a name, index for the BAM file is contained in the same directory as the BAM file
+$ ngb reg_file grch38 /opt/tracks/sample.bam
 
-//Register file with relative path
-ngb reg_file hg19 ../tracks/sample.vcf
+# Register file with relative path
+$ ngb reg_file hg19 ../tracks/sample.vcf
+
+# Register file from AWS S3, use "sample1" as a name
+$ ngb reg_file grch38 s3://ngb-s3/human/grch38_tracks/sample1.vcf -n sample1
+
+# Register indexed file from AWS S3, use "sample1.bam" as a name
+$ ngb reg_file grch38 s3://ngb-s3/human/grch38_tracks/sample1.bam?s3://ngb-s3/human/grch38_tracks/sample1.bam.bai --name sample1.bam
 ```
 
 ### Delete file

--- a/docs/md/installation/standalone.md
+++ b/docs/md/installation/standalone.md
@@ -52,12 +52,13 @@ $ pwd
 $ java -jar NGB/dist/catgenome.jar
 ```
 
-NGB will be avalable at http://localhost:8080/catgenome
+NGB will be available at http://localhost:8080/catgenome
 
 ## Configuring NGB instance
 
-By default NGB will run on port 8080 and locate all the data (files and database) in the runtime folder
-To customize the configuration the following options are available
+By default NGB will run on port 8080 and locate all the data (files and database) in the runtime folder.
+
+To customize the configuration the following options are available:
 
 ### Configure data storage
 
@@ -88,7 +89,7 @@ If you want to disable cache for headers and indexes of VCF, GTF, BED files, cha
 * **server.index.cache.enabled=false** - disables caching for headers and indexes
 
 If you want to secure NGB we provide several options:
-####1. JWT Authentication 
+#### 1. JWT Authentication 
 With this option user can be authenticated using third-party JWT tokens. To enable this authentication, set the following properties:
  * **jwt.security.enable=true** enables the JWT Authorization
  * **jwt.key.public=PUBLIC_KEY_VALUE** public key to perform JWT token validation
@@ -97,7 +98,7 @@ With this option user can be authenticated using third-party JWT tokens. To enab
 
 If this authentication is enabled for NGB each call to server API should include a valid JWT token either in header (**"Authorization: Bearer {TOKEN_VALUE}"**) or in cookies.
 
-####2. SAML SSO Authentication
+#### 2. SAML SSO Authentication
 With this option users can be authenticated in NGB with the help of a third-party Identity Provider (**IDP**). 
 This is particularly useful when NGB needs to be integrated into some existing infrastructure.
 To enable this authentication option, first create a SAML SSO endpoint in your IDP. Then set the following properties:
@@ -149,3 +150,63 @@ or in **application.properties** file in **config** folder in the runtime folder
 * server.compression.enabled=false
 
 See the full list of available options in the [Spring Documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html)
+
+### Configure for working with AWS S3
+
+If you want to add the ability of browsing NGS files from external data storages (AWS S3), you need to configure some AWS parameters before running **catgenome.jar**.
+You may do it in two ways:
+
+#### 1. Through configuration and credential files
+
+Create folder with name ".aws" in home directory location:
+```
+$ mkdir $HOME/.aws
+```
+In this folder create two files - `credentials` and `config` - with the following content:
+> **$HOME/.aws/credentials**
+> ```
+> [default]
+> aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+> aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+> ```
+> Where:
+>
+> `[default]` - profile name
+>
+> `aws_access_key_id` – AWS access key
+>
+> `aws_secret_access_key` – AWS secret key
+>
+> **Note**: Do not forget to replace values of *aws_access_key_id* and *aws_secret_access_key* variables with your own AWS access key and AWS secret key.
+
+> **$HOME/.aws/config**
+> ```
+> [default]
+> region=us-east-1
+> ```
+> Where:
+>
+> `[default]` - profile name
+>
+> `region` – default AWS region
+>
+> **Note**: Replace value of *region* variable, if needed.
+
+More information about `credentials` and `config` AWS files see [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
+
+#### 2. Through setting environment variables
+
+Set the following AWS environment variables:
+```
+$ export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+$ export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+$ export AWS_DEFAULT_REGION=us-east-1
+```
+Where:
+- `AWS_ACCESS_KEY_ID` – specifies an AWS access key
+- `AWS_SECRET_ACCESS_KEY` – specifies the secret key associated with the access key
+- `AWS_DEFAULT_REGION` – specifies the AWS region
+
+> **Note**: Do not forget to replace values of *AWS_ACCESS_KEY_ID* and *AWS_SECRET_ACCESS_KEY* variables with your own AWS access key and AWS secret key. And replace value of *AWS_DEFAULT_REGION* variable, if needed.
+
+After that you may run **catgenome.jar** file to start NGB instance as usually.


### PR DESCRIPTION
# Description

## Background

Documentation on working with AWS S3 files was added

## Changes

Sections in files *epam/NGB/docs/md/installation/standalone.md* (about NGB instance config for work with S3) and *epam/NGB/docs/md/cli/command-reference.md* (about S3 files registration) were added

## Acceptance criteria

Read the docs above

# Check list

- [ ] <del>Unit tests are provided</del>
- [ ] <del>Integration tests are provided (if CLI/API was changed)</del>
- [x] Documentation is updated
