### PR TITLE
Hide CLI tab if Role Model is disabled on the server

### DIFF
--- a/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.controller.js
+++ b/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.controller.js
@@ -10,10 +10,11 @@ export default class ngbMainSettingsDlgController {
         return 'ngbMainSettingsDlgController';
     }
 
+    isRoleModelEnabled = false;
     showTrackHeadersIsDisabled = false;
 
     /* @ngInject */
-    constructor(dispatcher, projectContext, localDataService, $mdDialog, ngbMainSettingsDlgService, $scope, settings, moment, userDataService) {
+    constructor(dispatcher, projectContext, localDataService, $mdDialog, ngbMainSettingsDlgService, $scope, settings, moment, userDataService, utilsDataService) {
         this._dispatcher = dispatcher;
         this._localDataService = localDataService;
         this.userIsAdmin = false;
@@ -31,6 +32,10 @@ export default class ngbMainSettingsDlgController {
         userDataService.currentUserIsAdmin().then(isAdmin => {
             this.userIsAdmin = isAdmin;
             $scope.$apply();
+        });
+
+        utilsDataService.isRoleModelEnabled().then(res => {
+            this.isRoleModelEnabled = res;
         });
 
         this.scope = $scope;

--- a/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.tpl.html
+++ b/client/client/app/shared/components/ngbMainSettings/ngbMainSettingsDlg/ngbMainSettingsDlg.tpl.html
@@ -12,8 +12,8 @@
         </md-toolbar>
 
         <md-dialog-content style="min-width:600px;max-width: 800px;max-height:80vh;">
-            <md-tabs md-center-tabs md-dynamic-height md-border-bottom md-stretch-tabs="always">
-                <md-tab label="CLI">
+            <md-tabs md-center-tabs md-autoselect md-no-pagination md-dynamic-height md-border-bottom md-stretch-tabs="always">
+                <md-tab label="CLI" ng-show="ctrl.isRoleModelEnabled">
                     <md-content class="md-padding">
                         <div class="column">
                             <div class="row"><h4>Access key</h4></div>

--- a/client/client/dataServices/utils/utils-data-service.js
+++ b/client/client/dataServices/utils/utils-data-service.js
@@ -22,7 +22,7 @@ export class UtilsDataService extends DataService {
             }).then((result) => {
                 resolve(result);
             });
-        })
+        });
     }
 
     getDefaultTrackSettings() {
@@ -32,7 +32,17 @@ export class UtilsDataService extends DataService {
             }).then((result) => {
                 resolve(result);
             });
-        })
+        });
+    }
+
+    isRoleModelEnabled() {
+        return new Promise((resolve) => {
+            this.get('isRoleModelEnabled').then((result) => {
+                resolve(`${result}`.toLowerCase() === 'true');
+            }).catch(() => {
+                resolve(false);
+            });
+        });
     }
 
     generateShortUrl(fullUrl, alias) {
@@ -50,6 +60,6 @@ export class UtilsDataService extends DataService {
                     `${baseUrl}/navigate?alias=${result}`;
                 resolve(a.href);
             });
-        })
+        });
     }
 }


### PR DESCRIPTION
# Description

## Background

Fix for the #253 

## Changes

Added additional check to the UI whether the Role model is enabled on the server side.

## Acceptance criteria

CLI tab in the main settings dialogue shouldn't be present if the Role model is disabled on the server.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
