### PR TITLE
Refactored class names to avoid elements' blocking by the AdBlock

### DIFF
--- a/client/client/app/shared/components/ngbUserManagement/ngbUserManagementDlg/ngbUserManagementDlg.controller.js
+++ b/client/client/app/shared/components/ngbUserManagement/ngbUserManagementDlg/ngbUserManagementDlg.controller.js
@@ -160,7 +160,7 @@ export default class ngbUserManagementDlgController extends BaseController {
             openFrom: $ev,
             panelClass: 'simple-popover',
             position: position,
-            template: items.map(item => `<span class="group-role-tag${item.isAD ? ' ad-group' : ''}">${item.name}</span>`).join('')
+            template: items.map(item => `<span class="group-role-tag${item.isAD ? ' domain-group' : ''}">${item.name}</span>`).join('')
         };
         this.$mdPanel.open(config).then(popover => {
             this.popoverRef = popover;

--- a/client/client/app/shared/components/ngbUserManagement/ngbUserManagementDlg/ngbUserManagementDlg.scss
+++ b/client/client/app/shared/components/ngbUserManagement/ngbUserManagementDlg/ngbUserManagementDlg.scss
@@ -27,7 +27,7 @@
   }
 }
 
-.group-role-tag.ad-group {
+.group-role-tag.domain-group {
   color: #777;
 }
 

--- a/client/client/app/shared/components/ngbUserManagement/ngbUserManagementDlg/ngbUserManagementDlg.service.js
+++ b/client/client/app/shared/components/ngbUserManagement/ngbUserManagementDlg/ngbUserManagementDlg.service.js
@@ -137,7 +137,7 @@ export default class ngbUserManagementDlgService {
                                 <span
                                     ng-repeat="group in row.entity.groups track by $index"
                                     class="group-role-tag bordered"
-                                    ng-class="{'ad-group': group.isAD}">
+                                    ng-class="{'domain-group': group.isAD}">
                                     {{group.name}}
                                 </span>
                             </div>
@@ -145,7 +145,7 @@ export default class ngbUserManagementDlgService {
                                 <span
                                     ng-repeat="group in row.entity.groups.slice(0, 3) track by $index"
                                     class="group-role-tag bordered"
-                                    ng-class="{'ad-group': group.isAD}">
+                                    ng-class="{'domain-group': group.isAD}">
                                     {{group.name}}
                                 </span>
                                 <ng-md-icon


### PR DESCRIPTION
# Description

## Background

Class names like `ad-group` cause some info to be blocked by the AdBlock.

## Changes

Refactored `ad-group` class to `domain-group`.

## Acceptance criteria

The AdBlock shouldn't block domain groups in the users' list anymore.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
