### PR TITLE
Issue #286

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/util/Utils.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/Utils.java
@@ -388,14 +388,16 @@ public final class Utils {
             InvocationTargetException e) {
             throw new InvocationTargetException(e, "Cannot instantiate object of class " + c);
         }
-        notRegisteredFile.setPath(processUrl(fileUrl));
+        String preprocessedUrl = processUrl(fileUrl);
+        notRegisteredFile.setPath(preprocessedUrl);
         notRegisteredFile.setCompressed(false);
-        notRegisteredFile.setType(BiologicalDataItemResourceType.getTypeFromPath(fileUrl));
+        notRegisteredFile.setType(BiologicalDataItemResourceType.getTypeFromPath(preprocessedUrl));
         notRegisteredFile.setReferenceId(chromosome.getReferenceId());
 
         BiologicalDataItem index = new BiologicalDataItem();
-        index.setType(BiologicalDataItemResourceType.getTypeFromPath(indexUrl));
-        index.setPath(processUrl(indexUrl));
+        String preprocessedIndexUrl = processUrl(indexUrl);
+        index.setPath(preprocessedIndexUrl);
+        index.setType(BiologicalDataItemResourceType.getTypeFromPath(preprocessedIndexUrl));
         notRegisteredFile.setIndex(index);
         return notRegisteredFile;
     }


### PR DESCRIPTION
# Description

Addresses #286 
Currently work with BAM files from s3 as unregistered file is unavailable. In order to fix this behavior lets change type of opened file from S3 to URL, in this case NGB will work with it as URL resource instead of S3, as expected, it will not try to open presigned url with s3 client but will open is as http resource.


