### PR TITLE
Changed a way to fetch references in JS API

### DIFF
--- a/client/client/app/shared/services/api.service.js
+++ b/client/client/app/shared/services/api.service.js
@@ -23,8 +23,8 @@ export default class ngbApiService {
     $mdDialog;
     localDataService;
     dispatcher;
-    datasets;
-    references;
+    datasets = [];
+    references = [];
 
     constructor($state, projectContext, ngbDataSetsService, $mdDialog, localDataService, dispatcher) {
         Object.assign(this, {
@@ -35,10 +35,6 @@ export default class ngbApiService {
             ngbDataSetsService,
             projectContext,
         });
-        (async () => {
-            await this.projectContext.refreshReferences(true);
-            this.references = this.projectContext.references;
-        })();
     }
 
     /** returns a Promise */
@@ -235,7 +231,7 @@ export default class ngbApiService {
     }
 
     /** returns a Promise */
-    loadTracks(params) {
+    async loadTracks(params) {
         const forceSwitchRef = params.forceSwitchRef ? params.forceSwitchRef : false;
 
         if (!params.tracks || !params.referenceId) {
@@ -243,6 +239,11 @@ export default class ngbApiService {
                 isSuccessful: false,
                 message: 'Not enough params specified',
             });
+        }
+
+        if (!this.references || this.references.length === 0) {
+            await this.projectContext.refreshReferences(true);
+            this.references = this.projectContext.references || [];
         }
 
         const [chosenReference] = this.references.filter(r => r.id === params.referenceId);

--- a/docs/md/user-guide/embedding-js-demo.html
+++ b/docs/md/user-guide/embedding-js-demo.html
@@ -298,7 +298,7 @@ Force switch reference:&nbsp;
     }
 
     if (window.addEventListener) {
-        window.addEventListener("message", (event) => {
+        window.addEventListener("message", () => {
             if (event.data) {
                 console.log(event.data);
             }

--- a/docs/md/user-guide/embedding-js-demo.html
+++ b/docs/md/user-guide/embedding-js-demo.html
@@ -298,7 +298,7 @@ Force switch reference:&nbsp;
     }
 
     if (window.addEventListener) {
-        window.addEventListener("message", () => {
+        window.addEventListener("message", (event) => {
             if (event.data) {
                 console.log(event.data);
             }


### PR DESCRIPTION
# Description

## Background

Fix for the #294 

## Changes

Changed a way to fetch references in JS API in order to prevent cases when tracks are being loaded before references loading has finished.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
