### PR TITLE
Fix for findProject method of ngbDataSets

### DIFF
--- a/client/client/app/components/ngbDataSets/internal/utilities.js
+++ b/client/client/app/components/ngbDataSets/internal/utilities.js
@@ -180,6 +180,9 @@ export function mapTrackFn(track: Node){
 }
 
 export function findProject(datasets: Array<Node>, project) {
+    if (!datasets) {
+        return null;
+    }
     const {name} = project;
     for (let i = 0; i < datasets.length; i++) {
         const dataset = datasets[i];

--- a/client/client/app/components/ngbDataSets/internal/utilities.js
+++ b/client/client/app/components/ngbDataSets/internal/utilities.js
@@ -101,10 +101,12 @@ export function sortDatasets(content, sortFn) {
                 if (node._lazyItems) {
                     items = node._lazyItems;
                 }
-                items.sort(itemsSort);
-                items
-                    .filter(child => child.isProject)
-                    .forEach(fn);
+                if (items) {
+                    items.sort(itemsSort);
+                    items
+                      .filter(child => child.isProject)
+                      .forEach(fn);
+                }
             }
         }
     };

--- a/client/client/app/components/ngbDataSets/ngbDataSets.service.js
+++ b/client/client/app/components/ngbDataSets/ngbDataSets.service.js
@@ -20,12 +20,7 @@ export default class ngbDataSetsService {
     }
 
     async getDatasets() {
-        let projects = this.projectContext.datasets;
-        if (!this.projectContext.datasetsArePrepared) {
-            projects = projects.map(utilities.preprocessNode);
-            this.projectContext.datasetsArePrepared = true;
-        }
-        const datasets = this.applyGenomeFilter(projects);
+        const datasets = this.applyGenomeFilter(this.projectContext.datasets);
         ngbDataSetsService.sort(datasets);
         await this.updateSelectionFromState(datasets);
         return datasets;
@@ -58,8 +53,8 @@ export default class ngbDataSetsService {
                 const dataset = _datasets[i];
                 if (dataset.name.toLowerCase() === track.projectId.toLowerCase()) {
                     const items = dataset._lazyItems || dataset.items;
-                    for (let j = 0; j < items.length; i++) {
-                        if (items[i] && items[i].isTrack && items[i].name.toLowerCase() === track.name.toLowerCase()) {
+                    for (let j = 0; j < items.length; j++) {
+                        if (items[j] && items[j].isTrack && items[j].name.toLowerCase() === track.name.toLowerCase()) {
                             return true;
                         }
                     }


### PR DESCRIPTION
# Description

## Background

fix for the #299 

## Changes

Null check has been added to the `findProject` method in order to prevent errors like `Cannot read property 'length' of null`

## Acceptance criteria

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
