### PR TITLE
BAM coverage incorrect reference procession fixed (GUI)

### DIFF
--- a/client/client/modules/render/tracks/bam/internal/cache/bamCache.js
+++ b/client/client/modules/render/tracks/bam/internal/cache/bamCache.js
@@ -505,7 +505,7 @@ export default class BamCache {
         }
         if (data.referenceBuffer) {
             this._referenceBuffers.push({
-                endIndex: data.minPosition + data.referenceBuffer.length,
+                endIndex: data.minPosition + data.referenceBuffer.length - 1,
                 reference: data.referenceBuffer,
                 startIndex: data.minPosition
             });


### PR DESCRIPTION
At certain positions **BAM coverage** stops displaying. That is due to incorrect **reference** procession for each BAM range request.

**This PR fixes this error.**