### PR TITLE
Fix for bam track view

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/handlers/SAMRecordHandler.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/handlers/SAMRecordHandler.java
@@ -37,7 +37,6 @@ import com.epam.catgenome.entity.bam.BamTrackMode;
 import com.epam.catgenome.entity.bam.BaseCoverage;
 import com.epam.catgenome.entity.bam.BasePosition;
 import com.epam.catgenome.entity.bam.SpliceJunctionsEntity;
-import com.epam.catgenome.exception.SamAlignmentException;
 import com.epam.catgenome.manager.bam.filters.Filter;
 import com.epam.catgenome.manager.bam.sifters.DownsamplingSifter;
 import com.epam.catgenome.manager.reference.ReferenceManager;
@@ -435,8 +434,7 @@ public class SAMRecordHandler implements Handler<SAMRecord> {
 
         private void processMatch(List<BasePosition> basePositions, int cigarLength) {
             for (int j = 0; j < cigarLength; j++) {
-                checkIfBiasOutOfBound();
-                if (bufferBase != null && bufferBase.charAt(bias) != upperReadString.charAt(position)) {
+                if (checkIfBiasOutOfBound() && bufferBase != null && bufferBase.charAt(bias) != upperReadString.charAt(position)) {
                     basePositions.add(
                             new BasePosition(position + corrector, upperReadString.charAt(position))
                     );
@@ -448,12 +446,8 @@ public class SAMRecordHandler implements Handler<SAMRecord> {
             }
         }
 
-        private void checkIfBiasOutOfBound() {
-            if (0 > bias || bias >= endTrack) {
-                //add +1 for better readability
-                throw new SamAlignmentException(
-                        "Read contains match that falls out of reference at position " + (bias + 1));
-            }
+        private boolean checkIfBiasOutOfBound() {
+            return 0 <= bias && bias < endTrack;
         }
 
         private String getXSTag(List<SAMRecord.SAMTagAndValue> list) {

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/bam/SamRecordHandlerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/bam/SamRecordHandlerTest.java
@@ -35,7 +35,6 @@ import com.epam.catgenome.entity.bam.BamQueryOption;
 import com.epam.catgenome.entity.bam.BamTrackMode;
 import com.epam.catgenome.entity.bam.TrackDirectionType;
 import com.epam.catgenome.entity.reference.Reference;
-import com.epam.catgenome.exception.SamAlignmentException;
 import com.epam.catgenome.manager.bam.filters.Filter;
 import com.epam.catgenome.manager.bam.filters.MiddleSAMRecordFilter;
 import com.epam.catgenome.manager.bam.handlers.SAMRecordHandler;
@@ -130,21 +129,4 @@ public class SamRecordHandlerTest extends AbstractManagerTest {
         Assert.assertEquals(2, recordHandler.getSifter().getFilteredReadsCount());
     }
 
-    @Test(expected = SamAlignmentException.class)
-    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
-    public void matchBeyondReferenceUpperBorderTest() throws IOException {
-
-        final SAMRecord rec = set.addFrag("read3", 0, 100, false, false, "75M", "*", 151);
-
-        recordHandler.add(rec);
-    }
-
-    @Test(expected = SamAlignmentException.class)
-    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
-    public void matchBeyondReferenceLowerBorderTest() throws IOException {
-
-        final SAMRecord rec = set.addFrag("read4", 0, -4, false, false, "75M", "*", 151);
-
-        recordHandler.add(rec);
-    }
 }


### PR DESCRIPTION
# Description

The bug is described in #315 

Previously we would throw an exception if one of reads *out of bound instead of returning a track. Now we will just skip such bases (that out of bound) and continue with processing.
