### PR TITLE
Add new variant for the auth cookie field name

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/security/jwt/JwtFilterAuthenticationFilter.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/security/jwt/JwtFilterAuthenticationFilter.java
@@ -89,7 +89,7 @@ public class JwtFilterAuthenticationFilter extends OncePerRequestFilter {
 
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if ("HttpAuthorization".equals(cookie.getName())) {
+                if ("HttpAuthorization".equals(cookie.getName()) || "bearer".equals(cookie.getName())) {
                     return cookie;
                 }
             }


### PR DESCRIPTION
# Description
This PR adds new variant for auth cookie field name for authorization in NGB

## Background

To be able to auth with CloudPipeline JWT token, when NGB is run as CloudPipeline tool run, we need to add new variant for name of cookie where NGB will search for JWT.