### PR TITLE
changed track-tooltip min-width to fit internal content

### DIFF
--- a/client/client/modules/render/core/track/tooltip.js
+++ b/client/client/modules/render/core/track/tooltip.js
@@ -5,7 +5,7 @@ const tooltipElementContainer: HTMLElement = document.body;
 
 const defaultStyle = `
 width: auto;
-min-width: 200px;
+min-width: 285px;
 height: auto;
 z-index: 1000;
 margin: 2px;

--- a/client/client/modules/render/core/track/tooltip.js
+++ b/client/client/modules/render/core/track/tooltip.js
@@ -5,7 +5,7 @@ const tooltipElementContainer: HTMLElement = document.body;
 
 const defaultStyle = `
 width: auto;
-min-width: 285px;
+min-width: 200px;
 height: auto;
 z-index: 1000;
 margin: 2px;

--- a/client/client/modules/render/core/track/tooltip.js
+++ b/client/client/modules/render/core/track/tooltip.js
@@ -93,7 +93,7 @@ export default function tooltipFactory(track) {
                 return `<tr style="border-bottom: 1px solid #ececec">${line.map(mapLineElements).join('')}</tr>`;
             };
 
-            tooltipElement.innerHTML = `<div class='md-open-menu-container md-whiteframe-z2 md-active md-clickable' style='width:100%'><table style='width:100%'>${normalizeTooltipData(content).map(mapLine).join('')}</table></div>`;
+            tooltipElement.innerHTML = `<div class='md-open-menu-container md-whiteframe-z2 md-active md-clickable' style='width:auto'><table style='width:100%'>${normalizeTooltipData(content).map(mapLine).join('')}</table></div>`;
         },
         show(position) {
             if (this.delayedFn) {


### PR DESCRIPTION
# Description

## Background

Bug: when hoving over a gene track, the tooltip appears, but the width of the tooltip is calculated incorrectly, which results in a tooltip's shadow not covering the whole width.

## Changes

Bugfix: 'track-tooltip' min-width was changed from 200px to 285px to be in line with the calculated width of the tooltip contents. The number of symbols in the 'havana_gene' value field and 'gene_id' value field resulted in the calculated width of 284,7px.

## Acceptance criteria

The tooltip shadow is now displaying correctly, covering the whole width of the tooltip.

# Check list

- [ ] Unit tests are provided //not needed
- [ ] Integration tests are provided (if CLI/API was changed) //not needed
- [ ] Documentation is updated //not needed
