### PR TITLE
Issue #304: Fixed NCBI database integration

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/vo/externaldb/NCBIGeneVO.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/vo/externaldb/NCBIGeneVO.java
@@ -63,6 +63,7 @@ public class NCBIGeneVO {
     private String refSeqStatus;
     @JsonProperty(value = "gene_summary")
     private String geneSummary;
+    private String ensemblGeneId;
 
     @JsonProperty(value = "official_symbol")
     private String officialSymbol;
@@ -273,6 +274,14 @@ public class NCBIGeneVO {
 
     public void setGeneLink(String geneLink) {
         this.geneLink = geneLink;
+    }
+
+    public String getEnsemblGeneId() {
+        return ensemblGeneId;
+    }
+
+    public void setEnsemblGeneId(String ensemblGeneId) {
+        this.ensemblGeneId = ensemblGeneId;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/HttpDataManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/HttpDataManager.java
@@ -36,10 +36,11 @@ import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jettison.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -55,7 +56,7 @@ public class HttpDataManager {
     private static final String EXCEPTION_MESSAGE = "Couldn't fetch data for URL %s";
     private static final int MILLIS_IN_SECOND = 1000;
     private static final String HTTP_HEADER_RETRY_AFTER = "Retry-After";
-    private static final Logger LOGGER = Logger.getLogger(HttpDataManager.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpDataManager.class);
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String APPLICATION_JSON = "application/json";
     private static final String WAITING_FORMAT = "Waiting (%d)...";
@@ -83,6 +84,7 @@ public class HttpDataManager {
             throws ExternalDbUnavailableException {
 
         final String location = getLocationStub(locationStub, params);
+        LOGGER.debug("Hitting URL: {}", location);
 
         String resultData = getResultFromURL(location);
 
@@ -204,7 +206,7 @@ public class HttpDataManager {
             throws IOException, ExternalDbUnavailableException {
         String result;
         if (status == HttpURLConnection.HTTP_OK) {
-            LOGGER.info("HTTP_OK reply from destination server");
+            LOGGER.info("HTTP_OK reply from destination server {}", location);
 
             InputStream inputStream = conn.getInputStream();
             BufferedReader streamReader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
@@ -219,7 +221,7 @@ public class HttpDataManager {
 
         } else {
 
-            LOGGER.severe("Unexpected HTTP status:" + conn.getResponseMessage() + " for " + location);
+            LOGGER.error("Unexpected HTTP status:" + conn.getResponseMessage() + " for " + location);
             throw new ExternalDbUnavailableException(
                     String.format("Unexpected HTTP status: %d %s for URL %s", status,
                             conn.getResponseMessage(), location));

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIAuxiliaryManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIAuxiliaryManager.java
@@ -46,6 +46,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 @Service
 public class NCBIAuxiliaryManager extends NCBIDataManager {
 
+    public static final String SYMBOL_SEARCH_FIELD = "symbol";
+
     /**
      * Fetches organism info from NCBI's taxonomy database
      * <p>
@@ -77,7 +79,7 @@ public class NCBIAuxiliaryManager extends NCBIDataManager {
 
     public String searchDbForId(String db, String term) throws ExternalDbUnavailableException {
 
-        String searchResult = searchById(db, term);
+        String searchResult = searchById(db, term, SYMBOL_SEARCH_FIELD);
         JsonNode idlist;
         try {
             JsonNode root;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIAuxiliaryManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIAuxiliaryManager.java
@@ -70,7 +70,7 @@ public class NCBIAuxiliaryManager extends NCBIDataManager {
      *
      * @param db   db name
      * @param term term name
-     * @param field
+     * @param field a field to search for. If null, search for all the fields
      * @return String with data
      * @throws ExternalDbUnavailableException
      */

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIAuxiliaryManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIAuxiliaryManager.java
@@ -45,9 +45,6 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 @Service
 public class NCBIAuxiliaryManager extends NCBIDataManager {
-
-    public static final String SYMBOL_SEARCH_FIELD = "symbol";
-
     /**
      * Fetches organism info from NCBI's taxonomy database
      * <p>
@@ -73,13 +70,14 @@ public class NCBIAuxiliaryManager extends NCBIDataManager {
      *
      * @param db   db name
      * @param term term name
+     * @param field
      * @return String with data
      * @throws ExternalDbUnavailableException
      */
 
-    public String searchDbForId(String db, String term) throws ExternalDbUnavailableException {
+    public String searchDbForId(String db, String term, String field) throws ExternalDbUnavailableException {
 
-        String searchResult = searchById(db, term, SYMBOL_SEARCH_FIELD);
+        String searchResult = searchById(db, term, field);
         JsonNode idlist;
         try {
             JsonNode root;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIDataManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIDataManager.java
@@ -93,12 +93,12 @@ public class NCBIDataManager extends HttpDataManager {
      * @return string with data
      * @throws ExternalDbUnavailableException
      */
-    public String searchById(String db, String term) throws ExternalDbUnavailableException {
+    public String searchById(String db, String term, String field) throws ExternalDbUnavailableException {
 
         List<ParameterNameValue> parametersList = new ArrayList<>();
 
         parametersList.add(new ParameterNameValue("db", db));
-        parametersList.add(new ParameterNameValue("term", term));
+        parametersList.add(new ParameterNameValue("term", term + "[" + field + "]"));
         parametersList.add(new ParameterNameValue(RETMODE_PARAM, "json"));
 
         ParameterNameValue[] parameterNameValues = parametersList.toArray(

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIDataManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIDataManager.java
@@ -98,7 +98,7 @@ public class NCBIDataManager extends HttpDataManager {
         List<ParameterNameValue> parametersList = new ArrayList<>();
 
         parametersList.add(new ParameterNameValue("db", db));
-        parametersList.add(new ParameterNameValue("term", term + "[" + field + "]"));
+        parametersList.add(new ParameterNameValue("term", field != null ? term + "[" + field + "]" : term));
         parametersList.add(new ParameterNameValue(RETMODE_PARAM, "json"));
 
         ParameterNameValue[] parameterNameValues = parametersList.toArray(

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIDataManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIDataManager.java
@@ -90,6 +90,7 @@ public class NCBIDataManager extends HttpDataManager {
     /**
      * @param db   DB name
      * @param term tern name
+     * @param field a field to search for. If null, search for all the fields
      * @return string with data
      * @throws ExternalDbUnavailableException
      */

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIGeneManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIGeneManager.java
@@ -75,6 +75,7 @@ public class NCBIGeneManager {
     private static final String NCBI_PUBMED_HOMOLOG_URL = "https://www.ncbi.nlm.nih.gov/pubmed?LinkName="
             + "homologene_pubmed&from_uid=%s";
     private static final String NCBI_GENE_LINK = "https://www.ncbi.nlm.nih.gov/gene/%s";
+    private static final String SYMBOL_SEARCH_FIELD = "symbol";
 
     /**
      * Retrieves XML gene info from NCBI's gene database
@@ -159,7 +160,8 @@ public class NCBIGeneManager {
         String externalID = id;
         // if ID contains literals then we consider this external ID and perform search
         if (!id.matches("\\d+")) {
-            String ncbiId = ncbiAuxiliaryManager.searchDbForId(NCBIDatabase.GENE.name(), externalID);
+            String ncbiId = ncbiAuxiliaryManager.searchDbForId(NCBIDatabase.GENE.name(), externalID,
+                                                                SYMBOL_SEARCH_FIELD);
             if (StringUtils.isNotBlank(ncbiId)) {
                 externalID = ncbiId;
             } else {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIGeneManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIGeneManager.java
@@ -55,6 +55,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class NCBIGeneManager {
 
     private static final String RESULT_PATH = "result";
+    public static final String ENSEMBLE_GENE_PREFIX = "ENSG";
 
     private JsonMapper mapper = new JsonMapper();
 
@@ -160,8 +161,15 @@ public class NCBIGeneManager {
         String externalID = id;
         // if ID contains literals then we consider this external ID and perform search
         if (!id.matches("\\d+")) {
-            String ncbiId = ncbiAuxiliaryManager.searchDbForId(NCBIDatabase.GENE.name(), externalID,
-                                                                SYMBOL_SEARCH_FIELD);
+            String ncbiId;
+
+            if (id.startsWith(ENSEMBLE_GENE_PREFIX)) { // For ensemble geneIds (that starts with ENSG*), simple query
+                                                        // seems to return what's needed
+                ncbiId = ncbiAuxiliaryManager.searchDbForId(NCBIDatabase.GENE.name(), externalID, null);
+            } else {
+                ncbiId = ncbiAuxiliaryManager.searchDbForId(NCBIDatabase.GENE.name(), externalID, SYMBOL_SEARCH_FIELD);
+            }
+
             if (StringUtils.isNotBlank(ncbiId)) {
                 externalID = ncbiId;
             } else {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIGeneManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIGeneManager.java
@@ -55,7 +55,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class NCBIGeneManager {
 
     private static final String RESULT_PATH = "result";
-    public static final String ENSEMBL_GENE_PREFIX = "ENSG";
+    public static final String ENSEMBL_GENE_PREFIX = "ENS";
 
     private JsonMapper mapper = new JsonMapper();
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIShortVarManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIShortVarManager.java
@@ -95,7 +95,7 @@ public class NCBIShortVarManager {
         String contigLabel = snp.getContigLabel();
 
         if (StringUtils.isNotBlank(contigLabel)) {
-            String annotationId = ncbiAuxiliaryManager.searchDbForId("annotinfo", contigLabel);
+            String annotationId = ncbiAuxiliaryManager.searchDbForId("annotinfo", contigLabel, null);
             if (StringUtils.isNotBlank(annotationId)) {
                 JsonNode jsonNode = ncbiAuxiliaryManager.fetchAnnotationInfoById(annotationId);
                 String annotreleaseid = jsonNode.get("annotreleaseid").toString();

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/parser/NCBIGeneInfoParser.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/parser/NCBIGeneInfoParser.java
@@ -86,6 +86,7 @@ public class NCBIGeneInfoParser {
     private static final XPathExpression ENTREZ_GENE_TYPE_XPATH;
     private static final XPathExpression ENTREZ_GENE_SUMMARY_XPATH;
     private static final XPathExpression REFSEQ_STATUS_XPATH;
+    private static final XPathExpression ENSEMBL_GENE_ID;
     // Interactions xpaths
 
     private static final XPathExpression INTERACTIONS_XPATH;
@@ -177,6 +178,8 @@ public class NCBIGeneInfoParser {
 
             GROUP_LABEL_XPATH = X_PATH.compile("/ExchangeSet/Rs/Assembly/@groupLabel");
             CONTIG_LABEL_XPATH = X_PATH.compile("/ExchangeSet/Rs/Assembly/Component/@contigLabel");
+            ENSEMBL_GENE_ID = X_PATH.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_db/" +
+                    "Dbtag/Dbtag_db[text()=\"Ensembl\"]/../Dbtag_tag/Object-id/Object-id_str");
         } catch (XPathExpressionException e) {
             throw new NgbException(e);
         }
@@ -244,6 +247,7 @@ public class NCBIGeneInfoParser {
             ncbiGeneVO.setLocusTag(LOCUS_TAG_XPATH.evaluate(document));
             ncbiGeneVO.setLineage(LINEAGE_XPATH.evaluate(document));
             ncbiGeneVO.setRnaName(RNA_NAME_XPATH.evaluate(document));
+            ncbiGeneVO.setEnsemblGeneId(ENSEMBL_GENE_ID.evaluate(document));
 
             NodeList alsoKnown = (NodeList) ALSO_KNOWN_AS_XPATH.evaluate(document, XPathConstants.NODESET);
             List<String> alsoKnownList = new ArrayList<>(alsoKnown.getLength());

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/parser/NCBIGeneInfoParser.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/parser/NCBIGeneInfoParser.java
@@ -63,7 +63,7 @@ import static com.epam.catgenome.component.MessageHelper.getMessage;
 public class NCBIGeneInfoParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(NCBIGeneInfoParser.class);
-    private static final XPath xPath = XPathFactory.newInstance().newXPath();
+    private static final XPath X_PATH = XPathFactory.newInstance().newXPath();
     // eSearch-related xpaths
 
     private static final String ESEARCH_QUERY_XPATH = "/eSearchResult/QueryKey";
@@ -113,63 +113,70 @@ public class NCBIGeneInfoParser {
     private static final XPathExpression GROUP_LABEL_XPATH;
     private static final XPathExpression CONTIG_LABEL_XPATH;
 
-    private static final DocumentBuilderFactory builderFactory;
+    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY;
 
     static {
-        builderFactory = DocumentBuilderFactory.newInstance();
-        builderFactory.setNamespaceAware(false);
-        builderFactory.setValidating(false); // disable all validation to speed up processing of large (46k lines)
-        try {                                // XML documents. We expect NCBI responses to be correct anyway
-            builderFactory.setFeature("http://xml.org/sax/features/namespaces", false);
-            builderFactory.setFeature("http://xml.org/sax/features/validation", false);
-            builderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
-            builderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        // disable all validation to speed up processing of large (46k lines XML documents.
+        // We expect NCBI responses to be correct anyway
+        DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+        DOCUMENT_BUILDER_FACTORY.setNamespaceAware(false);
+        DOCUMENT_BUILDER_FACTORY.setValidating(false);
+        try {
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/namespaces", false);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/validation", false);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar",
+                    false);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",
+                    false);
         } catch (ParserConfigurationException e) {
             LOG.error("Failed to set XML parsing settings", e);
         }
 
         try {
 
-            ORGANISM_SCIENTIFIC_XPATH = xPath.compile(ORGANISM_XPATH + "/Org-ref_taxname");
-            ORGANISM_COMMON_XPATH = xPath.compile(ORGANISM_XPATH + "/Org-ref_common");
-            REFSEQ_STATUS_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_comments/Gene-commentary/Gene-commentary_heading" +
+            ORGANISM_SCIENTIFIC_XPATH = X_PATH.compile(ORGANISM_XPATH + "/Org-ref_taxname");
+            ORGANISM_COMMON_XPATH = X_PATH.compile(ORGANISM_XPATH + "/Org-ref_common");
+            REFSEQ_STATUS_XPATH = X_PATH.compile(GENE_XPATH +
+                    "/Entrezgene_comments/Gene-commentary/Gene-commentary_heading" +
                     "[text()=\"RefSeq Status\"]/../Gene-commentary_label");
-            ENTREZ_GENE_SUMMARY_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_summary");
-            PRIMARY_SOURCE_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_db/" +
+            ENTREZ_GENE_SUMMARY_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_summary");
+            PRIMARY_SOURCE_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_db/" +
                     "Dbtag[1]/Dbtag_tag/Object-id/Object-id_str");
-            ENTREZ_GENE_TYPE_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_type/@value");
-            PRIMARY_SOURCE_PREFIX_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_db/" +
+            ENTREZ_GENE_TYPE_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_type/@value");
+            PRIMARY_SOURCE_PREFIX_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_db/" +
                     "Dbtag[1]/Dbtag_db");
 
             // Interactions xpaths
-            INTERACTIONS_XPATH = xPath.compile("//Gene-commentary_heading[text()=\"Interactions\"]/../Gene-commentary_comment/Gene-commentary");
-            REF_ID_XPATH = xPath.compile("Gene-commentary_source/Other-source/Other-source_src/" +
+            INTERACTIONS_XPATH = X_PATH.compile(
+                    "//Gene-commentary_heading[text()=\"Interactions\"]/../Gene-commentary_comment/Gene-commentary");
+            REF_ID_XPATH = X_PATH.compile("Gene-commentary_source/Other-source/Other-source_src/" +
                     "Dbtag/Dbtag_tag/Object-id/*[self::Object-id_id or self::Object-id_str]");
-            REF_NAME_XPATH = xPath.compile("Gene-commentary_source/Other-source/Other-source_src/Dbtag/Dbtag_db");
+            REF_NAME_XPATH = X_PATH.compile("Gene-commentary_source/Other-source/Other-source_src/Dbtag/Dbtag_db");
 
-            OTHSOURCE_ID_XPATH = xPath.compile("Other-source_src/Dbtag/Dbtag_tag/Object-id/*[self::Object-id_id or self::Object-id_str]");
-            OTHSOURCE_REF_NAME_XPATH = xPath.compile("Other-source_src/Dbtag/Dbtag_db");
-            OTHSOURCE_ANCHOR_NAME_XPATH = xPath.compile("Other-source_anchor");
+            OTHSOURCE_ID_XPATH = X_PATH.compile(
+                    "Other-source_src/Dbtag/Dbtag_tag/Object-id/*[self::Object-id_id or self::Object-id_str]");
+            OTHSOURCE_REF_NAME_XPATH = X_PATH.compile("Other-source_src/Dbtag/Dbtag_db");
+            OTHSOURCE_ANCHOR_NAME_XPATH = X_PATH.compile("Other-source_anchor");
 
-            OFFICIAL_FULL_NAME_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_desc");
-            OFFICIAL_SYMBOL_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_locus");
-            LOCUS_TAG_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_locus-tag");
-            ALSO_KNOWN_AS_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/"
+            OFFICIAL_FULL_NAME_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_desc");
+            OFFICIAL_SYMBOL_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_locus");
+            LOCUS_TAG_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/Gene-ref_locus-tag");
+            ALSO_KNOWN_AS_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_gene/Gene-ref/"
                     + "Gene-ref_syn/Gene-ref_syn_E");
 
-            RNA_NAME_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_rna/RNA-ref/RNA-ref_ext/RNA-ref_ext_name");
-            LINEAGE_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_source/BioSource/BioSource_org/Org-ref/"
+            RNA_NAME_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_rna/RNA-ref/RNA-ref_ext/RNA-ref_ext_name");
+            LINEAGE_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_source/BioSource/BioSource_org/Org-ref/"
                     + "Org-ref_orgname/OrgName/OrgName_lineage");
-            ID_XPATH = xPath.compile(GENE_XPATH + "/Entrezgene_track-info/Gene-track/Gene-track_geneid");
+            ID_XPATH = X_PATH.compile(GENE_XPATH + "/Entrezgene_track-info/Gene-track/Gene-track_geneid");
 
-            PUBMED_ID_XPATH = xPath.compile("Pub_pmid/PubMedId");
-            GENE_COMMENTARY_TEXT_XPATH = xPath.compile("Gene-commentary_text");
-            GENE_COMMENTARY_PUB_LIST_XPATH = xPath.compile("Gene-commentary_refs/Pub");
-            GENE_COMMENTARY_XPATH = xPath.compile("Gene-commentary_comment/Gene-commentary");
-            OTHER_SOURCES_XPATH = xPath.compile("Gene-commentary_source/Other-source");
+            PUBMED_ID_XPATH = X_PATH.compile("Pub_pmid/PubMedId");
+            GENE_COMMENTARY_TEXT_XPATH = X_PATH.compile("Gene-commentary_text");
+            GENE_COMMENTARY_PUB_LIST_XPATH = X_PATH.compile("Gene-commentary_refs/Pub");
+            GENE_COMMENTARY_XPATH = X_PATH.compile("Gene-commentary_comment/Gene-commentary");
+            OTHER_SOURCES_XPATH = X_PATH.compile("Gene-commentary_source/Other-source");
 
-            GROUP_LABEL_XPATH = xPath.compile("/ExchangeSet/Rs/Assembly/@groupLabel");
-            CONTIG_LABEL_XPATH = xPath.compile("/ExchangeSet/Rs/Assembly/Component/@contigLabel");
+            GROUP_LABEL_XPATH = X_PATH.compile("/ExchangeSet/Rs/Assembly/@groupLabel");
+            CONTIG_LABEL_XPATH = X_PATH.compile("/ExchangeSet/Rs/Assembly/Component/@contigLabel");
         } catch (XPathExpressionException e) {
             throw new NgbException(e);
         }
@@ -219,7 +226,7 @@ public class NCBIGeneInfoParser {
         NCBIGeneVO ncbiGeneVO = new NCBIGeneVO();
 
         try {
-            DocumentBuilder builder = builderFactory.newDocumentBuilder();
+            DocumentBuilder builder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
 
             InputSource is = new InputSource(new StringReader(xml));
             Document document = builder.parse(is);
@@ -277,11 +284,11 @@ public class NCBIGeneInfoParser {
             String pubmedHistoryWebenv;
 
             if (NCBIUtility.NCBI_LINK == utility) {
-                pubmedHistoryQuery = xPath.evaluate(ELINK_QUERY_XPATH, xmlDocument);
-                pubmedHistoryWebenv = xPath.evaluate(ELINK_WEBENV_XPATH, xmlDocument);
+                pubmedHistoryQuery = X_PATH.evaluate(ELINK_QUERY_XPATH, xmlDocument);
+                pubmedHistoryWebenv = X_PATH.evaluate(ELINK_WEBENV_XPATH, xmlDocument);
             } else if (NCBIUtility.NCBI_SEARCH == utility) {
-                pubmedHistoryQuery = xPath.evaluate(ESEARCH_QUERY_XPATH, xmlDocument);
-                pubmedHistoryWebenv = xPath.evaluate(ESEARCH_WEBENV_XPATH, xmlDocument);
+                pubmedHistoryQuery = X_PATH.evaluate(ESEARCH_QUERY_XPATH, xmlDocument);
+                pubmedHistoryWebenv = X_PATH.evaluate(ESEARCH_WEBENV_XPATH, xmlDocument);
             } else {
                 pubmedHistoryQuery = StringUtils.EMPTY;
                 pubmedHistoryWebenv = StringUtils.EMPTY;

--- a/server/catgenome/src/test/java/com/epam/catgenome/controller/ExternalDBControllerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/controller/ExternalDBControllerTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 
+import com.epam.catgenome.manager.externaldb.ncbi.NCBIGeneManager;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -98,6 +99,9 @@ public class ExternalDBControllerTest extends AbstractControllerTest {
     @InjectMocks
     @Spy
     private ExternalDBController dbControllerMock;
+
+    @Mock
+    private NCBIGeneManager ncbiGeneManager;
 
     @Autowired
     private ApplicationContext context;

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/externaldb/NCBIAuxiliaryManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/externaldb/NCBIAuxiliaryManagerTest.java
@@ -79,7 +79,7 @@ public class NCBIAuxiliaryManagerTest {
         Mockito.doReturn("{\"esearchresult\":{\"idlist\":[99464]}}").when(ncbiAuxiliaryManager).fetchData(Mockito
                 .anyString(), Mockito.any(ParameterNameValue[].class));
 
-        String id = ncbiAuxiliaryManager.searchDbForId("testDb", "test");
+        String id = ncbiAuxiliaryManager.searchDbForId("testDb", "test", null);
         assertEquals(id, "99464");
     }
 

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/externaldb/NCBIShortVarManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/externaldb/NCBIShortVarManagerTest.java
@@ -130,7 +130,7 @@ public class NCBIShortVarManagerTest {
 
         //Mockito.when(ncbiAuxiliaryManager.searchDbForId("annotinfo", contigLabel))
 
-        Mockito.when(ncbiAuxiliaryManager.searchDbForId(Mockito.any(), Mockito.any())).thenReturn("99464");
+        Mockito.when(ncbiAuxiliaryManager.searchDbForId(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn("99464");
 
         String annotInfoJson = readFile("ncbi_summary_annotinfo_99464.json");
         String clinvarJson = readFile("ncbi_summary_clinvar_7412.json");

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/externaldb/NCBIShortVarManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/externaldb/NCBIShortVarManagerTest.java
@@ -130,7 +130,8 @@ public class NCBIShortVarManagerTest {
 
         //Mockito.when(ncbiAuxiliaryManager.searchDbForId("annotinfo", contigLabel))
 
-        Mockito.when(ncbiAuxiliaryManager.searchDbForId(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn("99464");
+        Mockito.when(ncbiAuxiliaryManager.searchDbForId(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn("99464");
 
         String annotInfoJson = readFile("ncbi_summary_annotinfo_99464.json");
         String clinvarJson = readFile("ncbi_summary_clinvar_7412.json");


### PR DESCRIPTION
# Description

## Background

This PR fixed issue #304 

## Changes

The reason for such behavior is that NCBI query was not exactly correct. Initial query looked like the following:
https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=GENE&term=DNMT3A&retmode=json.
From results of which the first one was taken, which wasn't correct NCBI gene record.

Fixed a query to search only for 'symbol' field, which appears to be what we want:
https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=GENE&term=DNMT3A[symbol]&retmode=json
Now first record is expected DNMT3A.

These are main changes, preformed in NCBIAuxiliaryManager class.

Additionally, optimized the `NCBIGeneInfoParser` class by pre-compiling all XPath queries on application startup.
Also fixed Ensembl integration as there were similar issue.

## Acceptance criteria

@NadiraGaliamova, please verify that the issue is fixed.

# Check list

- [*] Unit tests are provided - no new functionality introduced
- [*] Integration tests are provided (if CLI/API was changed) - no new functionality introduced
- [*] Documentation is updated - no new functionality introduced
