### PR TITLE
issue #341 Negative values for Wig and BedGraph tracks

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/BedGraphProcessor.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/BedGraphProcessor.java
@@ -171,7 +171,7 @@ public class BedGraphProcessor extends AbstractWigProcessor {
         while (query.hasNext()) {
             BedGraphFeature bedGraphFeature = query.peek();
             if (bedGraphFeature.getStart() < chunkStop && bedGraphFeature.getEnd() > chunkStart) {
-                score = score < bedGraphFeature.getValue() ? bedGraphFeature.getValue() : score;
+                score = Math.abs(score) < Math.abs(bedGraphFeature.getValue()) ? bedGraphFeature.getValue() : score;
             }
 
             if (chunkStop >= bedGraphFeature.getEnd()) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/WigProcessor.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/WigProcessor.java
@@ -95,7 +95,10 @@ public class WigProcessor extends AbstractWigProcessor {
                         List<BigSummary> summaries = bigWigFile.summarize(chr, chunkStart, chunkStop, 1, true, null);
                         TFloatList values = new TFloatArrayList();
                         BigSummary bigSummary = summaries.get(0);
-                        values.add((float) bigSummary.getMaxValue());
+                        double value = Math.abs(bigSummary.getMaxValue()) > Math.abs(bigSummary.getMinValue())
+                                ? bigSummary.getMaxValue()
+                                : bigSummary.getMinValue();
+                        values.add((float) value);
                         WigSection wigSection = new FixedStepSection(chr, chunkStart, chunkStop, 1, values);
                         sectionList.add(wigSection);
 
@@ -175,8 +178,11 @@ public class WigProcessor extends AbstractWigProcessor {
         }
         double res = 0.0;
         for (BigSummary summary : summarize) {
-            if (!Double.isNaN(summary.getMaxValue()) && !Double.isInfinite(summary.getMaxValue())) {
-                res += summary.getMaxValue();
+            double value = Math.abs(summary.getMaxValue()) > Math.abs(summary.getMinValue())
+                    ? summary.getMaxValue()
+                    : summary.getMinValue();
+            if (!Double.isNaN(value) && !Double.isInfinite(value)) {
+                res += value;
             }
         }
         return res;


### PR DESCRIPTION
relates to #341 
This PR allows for negative values to be send in Wig Track.
Now we use absolute value of segments in wig bigwig and bedgraph files to determinate value of whole segment when populate wig track.