### PR TITLE
GUI BigWig tracks: negative colors & hover info

### DIFF
--- a/client/client/modules/render/core/track/track.js
+++ b/client/client/modules/render/core/track/track.js
@@ -3,7 +3,7 @@ import PIXI from 'pixi.js';
 import {Subject} from 'rx';
 import {getRenderer} from '../configuration';
 import menuFactory from './menu';
-import {scaleModes} from '../../tracks/wig/modes';
+import {scaleModes, displayModes} from '../../tracks/wig/modes';
 import tooltipFactory from './tooltip';
 
 const DEBOUNCE_TIMEOUT = 100;
@@ -348,7 +348,8 @@ export class Track extends BaseTrack {
             this.state.coverageScaleFrom = state.data.from;
             this.state.coverageScaleTo = state.data.to;
             this.state.coverageScaleMode = scaleModes.manualScaleMode;
-            this.state.coverageLogScale = state.data.isLogScale;
+            this.state.coverageLogScale = this.state.coverageDisplayMode === displayModes.defaultDisplayMode &&
+                state.data.isLogScale;
             this._flags.dataChanged = true;
             this.reportTrackState();
             this.requestRenderRefresh();

--- a/client/client/modules/render/tracks/wig/index.js
+++ b/client/client/modules/render/tracks/wig/index.js
@@ -225,7 +225,7 @@ export class WIGTrack extends CachedTrack {
             }
             if (hoveredItem) {
                 const {dataItem} = hoveredItem;
-                this.tooltip.setContent([['Count', Math.ceil(dataItem.value)]]);
+                this.tooltip.setContent([['Count', dataItem.value]]);
                 this.tooltip.move({x, y});
                 this.tooltip.show({x, y});
                 return;

--- a/client/client/modules/render/tracks/wig/wigRenderer.js
+++ b/client/client/modules/render/tracks/wig/wigRenderer.js
@@ -46,11 +46,11 @@ export default class WIGRenderer extends CachedTrackRenderer {
             const { block, line } = this._renderItems(
                 wig.items.aboveBaseAxis,
                 this.trackState.wigColors
-                    ? (this.trackState.wigColors.positive || this._config.wig.color)
-                    : this._config.wig.color,
+                    ? (this.trackState.wigColors.positive || this._config.wig.positive)
+                    : this._config.wig.positive,
                 this.trackState.wigColors
-                    ? (this.trackState.wigColors.positive || this._config.wig.lineColor)
-                    : this._config.wig.lineColor,
+                    ? (this.trackState.wigColors.positive || this._config.wig.positive)
+                    : this._config.wig.positive,
                 viewport,
                 wig,
                 coordinateSystem,
@@ -62,11 +62,11 @@ export default class WIGRenderer extends CachedTrackRenderer {
             const { block, line } = this._renderItems(
                 wig.items.belowBaseAxis,
                 this.trackState.wigColors
-                    ? (this.trackState.wigColors.negative || this._config.wig.color)
-                    : this._config.wig.color,
+                    ? (this.trackState.wigColors.negative || this._config.wig.negative)
+                    : this._config.wig.negative,
                 this.trackState.wigColors
-                    ? (this.trackState.wigColors.negative || this._config.wig.lineColor)
-                    : this._config.wig.lineColor,
+                    ? (this.trackState.wigColors.negative || this._config.wig.negative)
+                    : this._config.wig.negative,
                 viewport,
                 wig,
                 coordinateSystem,


### PR DESCRIPTION
This PR fixes incorrect displaying of negative values of BigWig tracks (incorrect default colors) and incorrect item info on hover