### PR TITLE
issue #351 log if file has no Lucene index but don't fail

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
@@ -117,7 +117,7 @@ public final class MessagesConstants {
     public static final String ERROR_UNSUPPORTED_OPERATION = "error.unsupported.operation";
 
     //Feature index
-    public static final String ERROR_FEATURE_INDEX_NOT_FOUND = "error.feature.index.not.found";
+    public static final String INFO_FEATURE_INDEX_NOT_FOUND = "info.feature.index.not.found";
     public static final String INFO_FEATURE_INDEX_LOADING = "info.feature.index.loading";
     public static final String INFO_FEATURE_INDEX_WRITING = "info.feature.index.writing";
     public static final String ERROR_FEATURE_INEDX_TOO_LARGE = "error.feature.index.too.large";

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
@@ -882,8 +882,10 @@ public class FileManager {
             throw e;
         }
 
-        Assert.isTrue(!indexes.isEmpty(), getMessage(MessagesConstants.ERROR_FEATURE_INDEX_NOT_FOUND,
-                         featureFiles.stream().map(BaseEntity::getName).collect(Collectors.joining(", "))));
+        if (indexes.isEmpty()) {
+            LOGGER.info(getMessage(MessagesConstants.INFO_FEATURE_INDEX_NOT_FOUND,
+                    featureFiles.stream().map(BaseEntity::getName).collect(Collectors.joining(", "))));
+        }
 
         return indexes.toArray(new SimpleFSDirectory[indexes.size()]);
     }

--- a/server/catgenome/src/main/resources/catgenome-messages.properties
+++ b/server/catgenome/src/main/resources/catgenome-messages.properties
@@ -170,7 +170,7 @@ error.invalid.param.query.null = Track must be specified
 
 # Feature indexes
 info.feature.index.loading=Loading feature index for file {0} : ''{1}''
-error.feature.index.not.found=Error: feature index not found for file {0}
+info.feature.index.not.found=Feature index not found for file {0} Probably, it was registered with `--no_index` option
 info.feature.index.writing=Writing feature index for file {0} : ''{1}''
 info.feature.index.done=Created feature index for file {0} : ''{1}''
 info.feature.index.writing.for.project=Writing feature indexes for project ''{0}''


### PR DESCRIPTION
# Description

## Background

This PR is related to #351 

## Changes

check if files don't have any Lucene indices and return empty list instead of fail, as a result it will return to the client empty result but not an error
