### PR TITLE
Resizable Sashimi plots

### DIFF
--- a/client/client/modules/render/tracks/bam/bamConfig.js
+++ b/client/client/modules/render/tracks/bam/bamConfig.js
@@ -107,7 +107,7 @@ export default {
     },
     defaultHeight: 250,
     maxHeight: (state, config) => {
-        if (state.alignments) {
+        if (state.alignments || state.sashimi) {
             return Infinity;
         }
         let maxHeight = 0;
@@ -220,7 +220,8 @@ export default {
                 }
             },
             height: 150,
-            levelHeight: 20,
+            levelHeight: 10,
+            maxLevelHeight: 20,
             color: 0xE21F27,
             label: {
                 fill: 0xE21F27,

--- a/client/client/modules/render/tracks/bam/index.js
+++ b/client/client/modules/render/tracks/bam/index.js
@@ -227,7 +227,7 @@ export class BAMTrack extends ScrollableTrack {
 
     get trackIsResizable() {
         if (this.state) {
-            return this.state.alignments;
+            return this.state.alignments || this.state.sashimi;
         }
         return true;
     }

--- a/client/client/modules/render/tracks/bam/internal/renderer/bamRenderer.js
+++ b/client/client/modules/render/tracks/bam/internal/renderer/bamRenderer.js
@@ -468,6 +468,8 @@ Minimal zoom level is at ${noReadText.value}${noReadText.unit}`;
         this._sashimiContainer.visible = features.sashimi;
         this._sashimiLabelsContainer.removeChildren();
         if (features.sashimi) {
+            this._sashimiArea.height = this._height / 2.0;
+            this._sashimiRenderer.height = this._height / 2.0;
             this._sashimiArea.render(
                 this._viewport,
                 this._cacheService.cache.coverage.coordinateSystem,

--- a/client/client/modules/render/tracks/bam/internal/renderer/features/sashimiRenderer.js
+++ b/client/client/modules/render/tracks/bam/internal/renderer/features/sashimiRenderer.js
@@ -16,6 +16,7 @@ export class SashimiRenderer extends WIGRenderer {
             {
                 config: this._globalConfig,
                 graphics,
+                height: this.height * 2.0,
                 labelsContainer,
                 sashimi: true,
                 shouldRender,

--- a/client/client/modules/render/tracks/bam/internal/renderer/features/spliceJunctions/renderArea.js
+++ b/client/client/modules/render/tracks/bam/internal/renderer/features/spliceJunctions/renderArea.js
@@ -1,6 +1,6 @@
 export default function renderArea(viewport, drawingConfig) {
-    const {config, graphics, shouldRender, y, hovered} = drawingConfig;
-    const height = config.height;
+    const {config, graphics, shouldRender, y, hovered, height: predefinedHeight} = drawingConfig;
+    const height = predefinedHeight || config.height;
     graphics.clear();
     const centerLine = y + height / 2;
     if (shouldRender) {

--- a/client/client/modules/render/tracks/bam/internal/renderer/features/spliceJunctions/sashimiRenderer.js
+++ b/client/client/modules/render/tracks/bam/internal/renderer/features/spliceJunctions/sashimiRenderer.js
@@ -17,7 +17,7 @@ function intersects(candidate, test) {
 export function renderSashimiPlot(spliceJunctions, viewport, drawingConfig) {
     const {config, graphics, labelsContainer, shouldRender, hovered} = drawingConfig;
     graphics.clear();
-    const {centerLine} = renderArea(viewport, drawingConfig);
+    const {centerLine, height} = renderArea(viewport, drawingConfig);
     if (shouldRender) {
         graphics.lineStyle(config.border.thickness, config.border.stroke, 1);
         const sorted = spliceJunctions
@@ -31,6 +31,7 @@ export function renderSashimiPlot(spliceJunctions, viewport, drawingConfig) {
                     hovered.count === spliceJunction.count && hovered.strand === spliceJunction.strand
             }));
         sorted.sort(({length: a}, {length: b}) => a - b);
+        let maxLevels = 1;
         for (let i = 0; i < sorted.length; i++) {
             const spliceJunction = sorted[i];
             let up = 0;
@@ -50,9 +51,17 @@ export function renderSashimiPlot(spliceJunctions, viewport, drawingConfig) {
             } else {
                 spliceJunction.sashimi = up + 1;
             }
+            maxLevels = Math.max(Math.abs(spliceJunction.sashimi), maxLevels);
         }
+        const levelHeight = Math.max(
+            config.levelHeight,
+            Math.min(
+                config.maxLevelHeight,
+                (height / 2.0 - 15) / maxLevels
+            )
+        );
         const renderArc = (startPx, endPx, level) => {
-            const radius = Math.abs(level) * config.levelHeight;
+            const radius = Math.abs(level) * levelHeight;
             const xRadius = (endPx - startPx) / 2;
             const centerPoint = {
                 x: (endPx + startPx) / 2,
@@ -76,7 +85,7 @@ export function renderSashimiPlot(spliceJunctions, viewport, drawingConfig) {
             }
         };
         const renderLabel = (startPx, endPx, level, count) => {
-            const radius = Math.abs(level) * config.levelHeight;
+            const radius = Math.abs(level) * levelHeight;
             const multiplier = level < 0 ? 1 : -1;
             const centerPoint = {
                 x: (endPx + startPx) / 2,


### PR DESCRIPTION
This PR fixes cropping behavior for sashimi plots (#353). Now the arc' heights is calculated based on plot height and the maximum number of overlapping arcs