### PR TITLE
issue #351 Fix for tests

### DIFF
--- a/server/catgenome/src/test/java/com/epam/catgenome/controller/VcfControllerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/controller/VcfControllerTest.java
@@ -28,7 +28,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.eclipse.jetty.server.Server;
 import org.junit.Assert;
@@ -70,7 +69,6 @@ import com.epam.catgenome.helper.EntityHelper;
 import com.epam.catgenome.manager.FeatureIndexManager;
 import com.epam.catgenome.manager.project.ProjectManager;
 import com.epam.catgenome.manager.reference.ReferenceGenomeManager;
-import com.epam.catgenome.util.TestUtils;
 
 /**
  * Source:      VcfControllerTest.java
@@ -272,8 +270,9 @@ public class VcfControllerTest extends AbstractControllerTest {
 
         projectManager.create(project); // Index is created when vcf file is added
 
-        TestUtils.assertFail(() -> featureIndexManager.filterVariations(new VcfFilterForm(), project.getId()),
-                             Collections.singletonList(IllegalArgumentException.class));
+        Assert.assertTrue(
+                featureIndexManager.filterVariations(new VcfFilterForm(), project.getId()).getEntries().isEmpty()
+        );
     }
 
     @Test

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/FeatureIndexManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/FeatureIndexManagerTest.java
@@ -897,8 +897,9 @@ public class FeatureIndexManagerTest extends AbstractManagerTest {
 
         fileManager.deleteFileFeatureIndex(vcfFile);
 
-        TestUtils.assertFail(() -> featureIndexManager.filterVariations(vcfFilterForm),
-                             singletonList(IllegalArgumentException.class));
+        Assert.assertTrue(
+                featureIndexManager.filterVariations(vcfFilterForm).getEntries().isEmpty()
+        );
 
         vcfManager.reindexVcfFile(vcfFile.getId(), false);
         entryList = featureIndexManager.filterVariations(vcfFilterForm);
@@ -922,8 +923,9 @@ public class FeatureIndexManagerTest extends AbstractManagerTest {
         Assert.assertTrue(searchResult.isExceedsLimit());
 
         fileManager.deleteFileFeatureIndex(geneFile);
-        TestUtils.assertFail(() -> featureIndexDao.searchFeatures(TEST_GENE_PREFIX.toLowerCase(), geneFile, 10),
-                             singletonList(IllegalArgumentException.class));
+        Assert.assertTrue(
+                featureIndexDao.searchFeatures(TEST_GENE_PREFIX.toLowerCase(), geneFile, 10).getEntries().isEmpty()
+        );
 
         gffManager.reindexGeneFile(geneFile.getId(), false, false);
         searchResult = featureIndexDao.searchFeatures("ens", geneFile, 10);
@@ -954,8 +956,8 @@ public class FeatureIndexManagerTest extends AbstractManagerTest {
 
         projectManager.create(project); // Index is created when vcf file is added
 
-        TestUtils.assertFail(() -> featureIndexManager.filterVariations(new VcfFilterForm(), project.getId()),
-                             singletonList(IllegalArgumentException.class));
+        Assert.assertTrue(
+                featureIndexManager.filterVariations(new VcfFilterForm(), project.getId()).getEntries().isEmpty());
     }
 
     @Test
@@ -971,8 +973,9 @@ public class FeatureIndexManagerTest extends AbstractManagerTest {
         GeneFile geneFile = gffManager.registerGeneFile(geneRequest);
         Assert.assertNotNull(geneFile);
 
-        TestUtils.assertFail(() -> featureIndexDao.searchFeatures(TEST_GENE_PREFIX.toLowerCase(), geneFile, 10),
-                             singletonList(IllegalArgumentException.class));
+        Assert.assertTrue(
+                featureIndexDao.searchFeatures(TEST_GENE_PREFIX.toLowerCase(), geneFile, 10).getEntries().isEmpty()
+        );
     }
 
     @Test


### PR DESCRIPTION
# Description

## Background

Changes for the tests, now we check opposite - that calling `filterVariations` and other methods that call `FileManager.getIndexesForFiles` with files that where registered with `--no-index` option is fine, and no exception will be thrown but empty result

