### PR TITLE
issue #356 do not pass default values for score and other  fields

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/bed/BedRecord.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/bed/BedRecord.java
@@ -42,7 +42,7 @@ public class BedRecord extends Block {
     private Integer thickStart;
     private Integer thickEnd;
     private String rgb;
-    private int blockCount;
+    private Integer blockCount;
     private int[] blockSizes;
     private int[] blockStarts;
     private String id;
@@ -158,11 +158,11 @@ public class BedRecord extends Block {
         return getStartIndex(); // if records have the same start, they are equals
     }
 
-    public int getBlockCount() {
+    public Integer getBlockCount() {
         return blockCount;
     }
 
-    public void setBlockCount(int blockCount) {
+    public void setBlockCount(Integer blockCount) {
         this.blockCount = blockCount;
     }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/parser/NggbBedFeature.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/parser/NggbBedFeature.java
@@ -47,7 +47,7 @@ public interface NggbBedFeature extends Feature {
 
     String getName();
 
-    float getScore();
+    Float getScore();
 
     String getLink();
 
@@ -55,7 +55,7 @@ public interface NggbBedFeature extends Feature {
 
     Integer getThickEnd();
 
-    int getBlockCount();
+    Integer getBlockCount();
 
     int[] getBlockSizes();
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/parser/NggbMultiFormatBedFeature.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/parser/NggbMultiFormatBedFeature.java
@@ -76,8 +76,8 @@ public class NggbMultiFormatBedFeature implements NggbBedFeature {
     }
 
     @Override
-    public float getScore() {
-        return 0;
+    public Float getScore() {
+        return null;
     }
 
     @Override
@@ -134,8 +134,8 @@ public class NggbMultiFormatBedFeature implements NggbBedFeature {
     }
 
     @Override
-    public int getBlockCount() {
-        return 0;
+    public Integer getBlockCount() {
+        return null;
     }
 
     public void setBlockCount(int blockCount) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/parser/NggbSimpleBedFeature.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/parser/NggbSimpleBedFeature.java
@@ -88,7 +88,7 @@ public class NggbSimpleBedFeature implements NggbBedFeature {
     }
 
     @Override
-    public float getScore() {
+    public Float getScore() {
         return score;
     }
 
@@ -152,7 +152,7 @@ public class NggbSimpleBedFeature implements NggbBedFeature {
     }
 
     @Override
-    public int getBlockCount() {
+    public Integer getBlockCount() {
         return blockCount;
     }
 


### PR DESCRIPTION
# Description
This PR change logic of serialization of BedRecords, and don't pass default values for score and other fields