### PR TITLE
Fix Uniprot integration

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/EnsemblDataManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/EnsemblDataManager.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.epam.catgenome.component.MessageHelper;
@@ -47,8 +48,6 @@ import com.epam.catgenome.exception.ExternalDbUnavailableException;
 @Service
 public class EnsemblDataManager {
 
-    private static final String ENSEMBL_SERVER = "http://rest.ensembl.org/";
-
     private static final String ENSEMBL_TOOL = "lookup/id";
 
     private static final String ENSEMBL_VARIATION_TOOL = "variation";
@@ -63,6 +62,9 @@ public class EnsemblDataManager {
     @Autowired
     private HttpDataManager httpDataManager;
 
+    @Value("${ensembl.base.url:http://rest.ensembl.org/}")
+    private String ensemblServer;
+
     /**
      * Method fetching gene data from Ensemble
      *
@@ -76,7 +78,7 @@ public class EnsemblDataManager {
             new ParameterNameValue(ENSEMBL_EXPAND_TOOL, "1"),
             new ParameterNameValue("utr", "1")};
 
-        String location = ENSEMBL_SERVER + ENSEMBL_TOOL + "/" + geneId + "?";
+        String location = ensemblServer + ENSEMBL_TOOL + "/" + geneId + "?";
 
         String geneData = httpDataManager.fetchData(location, params);
 
@@ -107,7 +109,7 @@ public class EnsemblDataManager {
             new ParameterNameValue(CONTENT_TYPE, APPLICATION_JSON),
             new ParameterNameValue(ENSEMBL_EXPAND_TOOL, "1")};
 
-        String location = String.format("%s%s/%s/%s?", ENSEMBL_SERVER, ENSEMBL_VARIATION_TOOL, species, variationId);
+        String location = String.format("%s%s/%s/%s?", ensemblServer, ENSEMBL_VARIATION_TOOL, species, variationId);
 
         String variationData = httpDataManager.fetchData(location, params);
         try {
@@ -143,7 +145,7 @@ public class EnsemblDataManager {
             new ParameterNameValue("feature", ENSEMBL_VARIATION_TOOL),
             new ParameterNameValue(CONTENT_TYPE, APPLICATION_JSON)};
 
-        String location = String.format("%s%s/%s/%s", ENSEMBL_SERVER, ENSEMBL_OVERLAP_TOOL, species,
+        String location = String.format("%s%s/%s/%s", ensemblServer, ENSEMBL_OVERLAP_TOOL, species,
                 chromosome + ":" + start + "-" + finish + "?");
 
         String variationData = httpDataManager.fetchData(location, params);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/UniprotDataManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/UniprotDataManager.java
@@ -31,6 +31,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.epam.catgenome.exception.ExternalDbUnavailableException;
@@ -44,14 +45,15 @@ import com.epam.catgenome.manager.externaldb.bindings.uniprot.Uniprot;
 @Service
 public class UniprotDataManager {
 
-    private static final String UNIPROT_SERVER = "http://www.uniprot.org/";
-
     private static final String UNIPROT_TOOL = "uniprot";
 
     private Uniprot fetchedUniprotData = null;
 
     @Autowired
     private HttpDataManager httpDataManager;
+
+    @Value("${uniprot.base.url:https://www.uniprot.org/}")
+    private String uniprotServer;
 
     /**
      * Method fetching data from UniProt
@@ -64,7 +66,7 @@ public class UniprotDataManager {
         ParameterNameValue[] params = new ParameterNameValue[]{new ParameterNameValue("query", geneId),
             new ParameterNameValue("format", "xml")};
 
-        String location = UNIPROT_SERVER + UNIPROT_TOOL + "/?";
+        String location = uniprotServer + UNIPROT_TOOL + "/?";
 
         String uniprotData = httpDataManager.fetchData(location, params);
 


### PR DESCRIPTION
This PR provides a fix for #371 #283 

## Changes

- Updated Uniprot base url from `http://www.uniprot.org/` to `https://www.uniprot.org/`
- Uniprot base url is now configurable via `catgenome.properties` file via `uniprot.base.url` property
- Ensembl base url is now configurable via `catgenome.properties` file via `ensembl.base.url` property

## Acceptance criteria

- Click on a gene -> `Show info`
- Go to `Unitprot` tab
- Gene info shall be dispayed

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
