### PR TITLE
Issue #395 BLAST Backend - allow to group BLAST results by sequence

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/blast/BlastController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/blast/BlastController.java
@@ -26,12 +26,14 @@ package com.epam.catgenome.controller.blast;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 import com.epam.catgenome.controller.vo.TaskVO;
 import com.epam.catgenome.entity.blast.BlastDataBase;
 import com.epam.catgenome.entity.blast.BlastTask;
+import com.epam.catgenome.entity.blast.result.BlastSequence;
 import com.epam.catgenome.manager.blast.dto.BlastRequestResult;
 import com.epam.catgenome.manager.blast.dto.TaskPage;
 import com.epam.catgenome.exception.BlastRequestException;
@@ -54,7 +56,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
@@ -67,7 +68,6 @@ public class BlastController extends AbstractRESTController {
     private final BlastTaskSecurityService blastTaskSecurityService;
 
     @GetMapping(value = "/task/{taskId}")
-    @ResponseBody
     @ApiOperation(
             value = "Returns a task by given id",
             notes = "Returns a task by given id",
@@ -80,7 +80,6 @@ public class BlastController extends AbstractRESTController {
     }
 
     @GetMapping(value = "/task/{taskId}/result")
-    @ResponseBody
     @ApiOperation(
             value = "Returns a task result",
             notes = "Returns a task result",
@@ -93,7 +92,6 @@ public class BlastController extends AbstractRESTController {
     }
 
     @GetMapping(value = "/task/{taskId}/raw")
-    @ResponseBody
     @ApiOperation(
             value = "Returns a file with task result",
             notes = "Returns a file with task result",
@@ -109,8 +107,20 @@ public class BlastController extends AbstractRESTController {
         response.flushBuffer();
     }
 
+    @GetMapping(value = "/task/{taskId}/group")
+    @ApiOperation(
+            value = "Returns BLAST tasks results grouped by sequence",
+            notes = "Returns BLAST tasks results grouped by sequence",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<Collection<BlastSequence>> getGroupedResult(@PathVariable final long taskId)
+            throws BlastRequestException {
+        return Result.success(blastTaskSecurityService.getGroupedResult(taskId));
+    }
+
     @PostMapping(value = "/tasks/count")
-    @ResponseBody
     @ApiOperation(
             value = "Returns tasks count",
             notes = "Returns tasks count",
@@ -123,7 +133,6 @@ public class BlastController extends AbstractRESTController {
     }
 
     @PostMapping(value = "/tasks")
-    @ResponseBody
     @ApiOperation(
             value = "Loads all tasks",
             notes = "DB fields mapping: id - task_id, "
@@ -138,7 +147,6 @@ public class BlastController extends AbstractRESTController {
     }
 
     @DeleteMapping(value = "/tasks")
-    @ResponseBody
     @ApiOperation(
             value = "Delete all not running tasks for current user",
             notes = "Delete all not running tasks for current user",
@@ -152,7 +160,6 @@ public class BlastController extends AbstractRESTController {
     }
 
     @PostMapping(value = "/task")
-    @ResponseBody
     @ApiOperation(
             value = "Creates new task or updates existing one",
             notes = "Creates new task or updates existing one",
@@ -166,7 +173,6 @@ public class BlastController extends AbstractRESTController {
     }
 
     @PutMapping(value = "/task/{taskId}/cancel")
-    @ResponseBody
     @ApiOperation(
             value = "Cancels a task with given id",
             notes = "Cancels a task with given id",
@@ -180,7 +186,6 @@ public class BlastController extends AbstractRESTController {
     }
 
     @DeleteMapping(value = "/task/{taskId}")
-    @ResponseBody
     @ApiOperation(
             value = "Deletes a task, specified by task ID",
             notes = "Deletes a task, specified by task ID",
@@ -194,7 +199,6 @@ public class BlastController extends AbstractRESTController {
     }
 
     @GetMapping(value = {"/databases/{type}", "/database"})
-    @ResponseBody
     @ApiOperation(
             value = "Returns databases by type",
             notes = "Returns databases by type",

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/blast/result/Alignment.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/blast/result/Alignment.java
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2021 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.entity.blast.result;
+
+import com.epam.catgenome.manager.blast.dto.Entry;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Alignment {
+    private String queryAccessionVersion;
+    private long queryStart;
+    private long queryEnd;
+    private long queryLength;
+    private String querySequence;
+    private double queryCoverageSubject;
+    private double queryCoverageHsp;
+    private double queryCoverageUniqueSubject;
+
+    private String sequenceAccessionVersion;
+    private String sequenceId;
+    private long sequenceTaxId;
+    private String sequenceScientificName;
+    private String sequenceCommonName;
+    private String sequenceStrand;
+    private long sequenceLength;
+    private long sequenceStart;
+    private long sequenceEnd;
+    private String sequence;
+
+    private String btop;
+    private double eValue;
+    private double bitScore;
+    private double score;
+    private long length;
+    private double percentIdentity;
+    private long numIdentity;
+    private long mismatch;
+    private long positive;
+    private long gapOpening;
+    private long gaps;
+    private double percentPositiveMatches;
+
+    public static Alignment fromEntry(final Entry entry) {
+        return Alignment.builder()
+                .queryAccessionVersion(entry.getQueryAccVersion())
+                .queryStart(entry.getQueryStart())
+                .queryEnd(entry.getQueryEnd())
+                .queryLength(entry.getQueryLen())
+                .querySequence(entry.getQseq())
+                .sequenceAccessionVersion(entry.getSeqAccVersion())
+                .sequenceId(entry.getSeqSeqId())
+                .sequenceLength(entry.getSeqLen())
+                .sequenceStart(entry.getSeqStart())
+                .sequenceEnd(entry.getSeqEnd())
+                .sequence(entry.getSseq())
+                .btop(entry.getBtop())
+                .eValue(entry.getExpValue())
+                .bitScore(entry.getBitScore())
+                .score(entry.getScore())
+                .length(entry.getLength())
+                .percentIdentity(entry.getPercentIdent())
+                .numIdentity(entry.getNumIdent())
+                .mismatch(entry.getMismatch())
+                .positive(entry.getPositive())
+                .gapOpening(entry.getGapOpen())
+                .gaps(entry.getGaps())
+                .percentPositiveMatches(entry.getPercentPos())
+                .sequenceTaxId(entry.getSeqTaxId())
+                .sequenceScientificName(entry.getSeqSciName())
+                .sequenceCommonName(entry.getSeqComName())
+                .sequenceStrand(entry.getSeqStrand())
+                .queryCoverageSubject(entry.getQueryCovS())
+                .queryCoverageHsp(entry.getQueryCovHsp())
+                .queryCoverageUniqueSubject(entry.getQueryCovUs())
+                .build();
+    }
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/blast/result/BlastSequence.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/blast/result/BlastSequence.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2021 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.entity.blast.result;
+
+import com.epam.catgenome.manager.blast.dto.Entry;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@Builder
+public class BlastSequence {
+    private String sequenceId;
+    private String organism;
+    private Long taxId;
+    private Double maxScore;
+    private Double totalScore;
+    private Double queryCoverage;
+    private Double eValue;
+    private Double percentIdentity;
+    private Integer matches;
+    private List<Alignment> alignments;
+
+    public static BlastSequence fromEntries(final List<Entry> entries) {
+        Assert.state(!CollectionUtils.isEmpty(entries), "Entries shall be provided");
+        final Entry maxScoringEntry = entries.stream()
+                .max(Comparator.comparing(Entry::getScore)).get();
+        return BlastSequence.builder()
+                .sequenceId(maxScoringEntry.getSeqSeqId())
+                .organism(maxScoringEntry.getSeqSciName())
+                .taxId(maxScoringEntry.getSeqTaxId())
+                .matches(entries.size())
+                .maxScore(maxScoringEntry.getScore())
+                .eValue(maxScoringEntry.getExpValue())
+                .queryCoverage(maxScoringEntry.getQueryCovS())
+                .percentIdentity(maxScoringEntry.getPercentIdent())
+                .totalScore(entries.stream().mapToDouble(Entry::getScore).sum())
+                .alignments(entries.stream()
+                        .map(Alignment::fromEntry)
+                        .sorted(Comparator.comparing(Alignment::getEValue))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastTaskSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastTaskSecurityService.java
@@ -29,6 +29,7 @@ package com.epam.catgenome.manager.blast;
 import com.epam.catgenome.controller.vo.TaskVO;
 import com.epam.catgenome.entity.blast.BlastDataBase;
 import com.epam.catgenome.entity.blast.BlastTask;
+import com.epam.catgenome.entity.blast.result.BlastSequence;
 import com.epam.catgenome.manager.blast.dto.BlastRequestResult;
 import com.epam.catgenome.manager.blast.dto.TaskPage;
 import com.epam.catgenome.exception.BlastRequestException;
@@ -42,6 +43,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,6 +93,11 @@ public class BlastTaskSecurityService {
     }
 
     @PreAuthorize(ROLE_USER)
+    public Collection<BlastSequence> getGroupedResult(final long taskId) throws BlastRequestException {
+        return blastTaskManager.getGroupedResult(taskId);
+    }
+
+    @PreAuthorize(ROLE_USER)
     public ResponseBody getRawResult(final long taskId) throws BlastRequestException {
         return blastTaskManager.getRawResult(taskId);
     }
@@ -104,4 +111,5 @@ public class BlastTaskSecurityService {
     public void deleteTasks() {
         blastTaskManager.deleteTasks();
     }
+
 }


### PR DESCRIPTION
Related to #395 #381

PR adds a new API method `GET /restapi/task/{taskId}/group` returning BLAST results grouped by sequence id.