### PR TITLE
Issue #439: Ability to download NGB files from the GUI - API part for local data

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/AbstractRESTController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/AbstractRESTController.java
@@ -34,13 +34,18 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.epam.catgenome.manager.FileManager;
+
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Source:      AbstractRESTController.java
@@ -128,5 +133,26 @@ public abstract class AbstractRESTController {
         }
 
         return dst;
+    }
+
+    /**
+     * Writes passed content to {@code HttpServletResponse} to allow it's downloading from
+     * the client
+     * @param response to write data
+     * @param stream content to download
+     * @param fileName file name
+     */
+    protected void writeStreamToResponse(final HttpServletResponse response,
+                                         final InputStream stream,
+                                         final String fileName) throws IOException {
+        try (InputStream inputStream = stream) {
+            // Set the content type and attachment header.
+            response.addHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + fileName);
+            response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+
+            // Copy the stream to the response's output stream.
+            IOUtils.copy(inputStream, response.getOutputStream());
+            response.flushBuffer();
+        }
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/dataitem/DataItemController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/dataitem/DataItemController.java
@@ -27,18 +27,16 @@ package com.epam.catgenome.controller.dataitem;
 import static com.epam.catgenome.component.MessageHelper.getMessage;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
 import com.epam.catgenome.entity.BiologicalDataItemFormat;
 import com.epam.catgenome.manager.dataitem.DataItemSecurityService;
+import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.epam.catgenome.constant.MessagesConstants;
 import com.epam.catgenome.controller.AbstractRESTController;
@@ -48,6 +46,14 @@ import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletResponse;
 
 /**
  *  <p>
@@ -122,5 +128,18 @@ public class DataItemController extends AbstractRESTController {
     public final Result<BiologicalDataItem> findFileBiBioItemId(@RequestParam(value = "id") final Long id)
             throws IOException {
         return Result.success(dataItemSecurityService.findFileByBioItemId(id));
+    }
+
+    @GetMapping("/dataitem/{id}/download")
+    @ApiOperation(
+            value = "Downloads a file specified by biological item id",
+            notes = "Downloads a file specified by biological item id",
+            produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public void downloadFileByBiologicalItemId(@PathVariable(value = "id") final Long id,
+                                               final HttpServletResponse response) throws IOException {
+        final BiologicalDataItem biologicalDataItem = dataItemSecurityService.findFileByBioItemId(id);
+        final InputStream content = dataItemSecurityService.loadFileContent(biologicalDataItem);
+        final String name = FilenameUtils.getName(biologicalDataItem.getPath());
+        writeStreamToResponse(response, content, name);
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/dataitem/DataItemController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/dataitem/DataItemController.java
@@ -27,13 +27,12 @@ package com.epam.catgenome.controller.dataitem;
 import static com.epam.catgenome.component.MessageHelper.getMessage;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
+import com.epam.catgenome.entity.BiologicalDataItemFile;
 import com.epam.catgenome.entity.BiologicalDataItemFormat;
 import com.epam.catgenome.manager.dataitem.DataItemSecurityService;
-import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -138,8 +137,7 @@ public class DataItemController extends AbstractRESTController {
     public void downloadFileByBiologicalItemId(@PathVariable(value = "id") final Long id,
                                                final HttpServletResponse response) throws IOException {
         final BiologicalDataItem biologicalDataItem = dataItemSecurityService.findFileByBioItemId(id);
-        final InputStream content = dataItemSecurityService.loadFileContent(biologicalDataItem);
-        final String name = FilenameUtils.getName(biologicalDataItem.getPath());
-        writeStreamToResponse(response, content, name);
+        final BiologicalDataItemFile biologicalDataItemFile = dataItemSecurityService.loadItemFile(biologicalDataItem);
+        writeStreamToResponse(response, biologicalDataItemFile.getContent(), biologicalDataItemFile.getFileName());
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/BiologicalDataItemFile.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/BiologicalDataItemFile.java
@@ -1,0 +1,37 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.entity;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.io.InputStream;
+
+@Builder
+@Data
+public class BiologicalDataItemFile {
+    private InputStream content;
+    private String fileName;
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
@@ -175,6 +175,8 @@ public class DataItemManager {
     public InputStream loadFileContent(final BiologicalDataItem biologicalDataItem) throws IOException {
         final String dataItemPath = biologicalDataItem.getPath();
         if (BiologicalDataItemResourceType.FILE.equals(biologicalDataItem.getType())) {
+            Assert.state(Files.exists(Paths.get(dataItemPath)),
+                    getMessage(ERROR_BIO_ID_NOT_FOUND, biologicalDataItem.getId()));
             return Files.newInputStream(Paths.get(dataItemPath));
         }
         throw new UnsupportedOperationException("Download available for local data only");

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
@@ -29,12 +29,16 @@ import static com.epam.catgenome.constant.MessagesConstants.ERROR_BIO_ID_NOT_FOU
 import static com.epam.catgenome.constant.MessagesConstants.ERROR_UNSUPPORTED_FILE_FORMAT;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.epam.catgenome.entity.BiologicalDataItemFormat;
+import com.epam.catgenome.entity.BiologicalDataItemResourceType;
 import com.epam.catgenome.manager.wig.FacadeWigManager;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -166,5 +170,13 @@ public class DataItemManager {
         return bedManager.getFormats().stream()
                 .map(e -> Pair.of(e, BiologicalDataItemFormat.BED))
                 .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    }
+
+    public InputStream loadFileContent(final BiologicalDataItem biologicalDataItem) throws IOException {
+        final String dataItemPath = biologicalDataItem.getPath();
+        if (BiologicalDataItemResourceType.FILE.equals(biologicalDataItem.getType())) {
+            return Files.newInputStream(Paths.get(dataItemPath));
+        }
+        throw new UnsupportedOperationException("Download available for local data only");
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemSecurityService.java
@@ -37,6 +37,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -74,5 +75,10 @@ public class DataItemSecurityService {
     @PreAuthorize(ROLE_USER)
     public Map<String, BiologicalDataItemFormat> getFormats() {
         return dataItemManager.getFormats();
+    }
+
+    @PreAuthorize(ROLE_USER)
+    public InputStream loadFileContent(final BiologicalDataItem biologicalDataItem) throws IOException {
+        return dataItemManager.loadFileContent(biologicalDataItem);
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemSecurityService.java
@@ -28,6 +28,7 @@ package com.epam.catgenome.manager.dataitem;
 
 
 import com.epam.catgenome.entity.BiologicalDataItem;
+import com.epam.catgenome.entity.BiologicalDataItemFile;
 import com.epam.catgenome.entity.BiologicalDataItemFormat;
 import com.epam.catgenome.security.acl.aspect.AclMaskList;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +78,7 @@ public class DataItemSecurityService {
     }
 
     @PreAuthorize(ROLE_USER)
-    public InputStream loadFileContent(final BiologicalDataItem biologicalDataItem) throws IOException {
-        return dataItemManager.loadFileContent(biologicalDataItem);
+    public BiologicalDataItemFile loadItemFile(final BiologicalDataItem biologicalDataItem) throws IOException {
+        return dataItemManager.loadItemFile(biologicalDataItem);
     }
 }


### PR DESCRIPTION
# Description

The current PR provides partial implementation for issue #439  

## Changes

This PR contains a new API method `GET /dataitem/<bioDataItemId>/download`. This method downloads corresponding data item file. The current changes provide implementation for `FILE` type only.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
