### PR TITLE
Ability to download NGB files from the GUI - size implementation

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
@@ -201,6 +201,7 @@ public final class MessagesConstants {
     public static final String ERROR_UNSUPPORTED_FILE_FORMAT = "error.unsupported.file.format";
     public static final String ERROR_FILE_CORRUPTED_OR_EMPTY = "error.file.corrupted.or.empty";
     public static final String ERROR_DIRECTORY_NOT_FOUND = "error.directory.not.found";
+    public static final String ERROR_FILE_LOCAL_DOWNLOAD = "error.file.local.download";
 
     //PROJECT
     public static final String INFO_PROJECT_DELETED = "info.project.deleted";

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/BiologicalDataItemDownloadUrl.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/BiologicalDataItemDownloadUrl.java
@@ -35,4 +35,5 @@ public class BiologicalDataItemDownloadUrl {
     private final String url;
     private final BiologicalDataItemResourceType type;
     private final Date expires;
+    private final Long size;
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
@@ -233,7 +233,7 @@ public class DataItemManager {
                     .size(Files.size(dataItemPath))
                     .build();
         } catch (IOException e) {
-            throw new IllegalStateException(getMessage(ERROR_FILE_LOCAL_DOWNLOAD), e);
+            throw new IllegalStateException(getMessage(ERROR_FILE_LOCAL_DOWNLOAD, id), e);
         }
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
@@ -26,6 +26,7 @@ package com.epam.catgenome.manager.dataitem;
 
 import static com.epam.catgenome.component.MessageHelper.getMessage;
 import static com.epam.catgenome.constant.MessagesConstants.ERROR_BIO_ID_NOT_FOUND;
+import static com.epam.catgenome.constant.MessagesConstants.ERROR_FILE_LOCAL_DOWNLOAD;
 import static com.epam.catgenome.constant.MessagesConstants.ERROR_UNSUPPORTED_FILE_FORMAT;
 
 import java.io.IOException;
@@ -232,7 +233,7 @@ public class DataItemManager {
                     .size(Files.size(dataItemPath))
                     .build();
         } catch (IOException e) {
-            throw new IllegalStateException("Cannot generate download url for local file", e);
+            throw new IllegalStateException(getMessage(ERROR_FILE_LOCAL_DOWNLOAD), e);
         }
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/aws/S3Client.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/aws/S3Client.java
@@ -199,6 +199,7 @@ public final class S3Client {
                 .type(BiologicalDataItemResourceType.S3)
                 .url(generatedUrl.toExternalForm())
                 .expires(expires)
+                .size(getFileSize(url))
                 .build();
     }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/util/azure/AzureBlobClient.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/util/azure/AzureBlobClient.java
@@ -186,6 +186,7 @@ public class AzureBlobClient {
                 .url(downloadUrl)
                 .expires(expires)
                 .type(BiologicalDataItemResourceType.AZ)
+                .size(getFileSize(path))
                 .build();
     }
 

--- a/server/catgenome/src/main/resources/catgenome-messages.properties
+++ b/server/catgenome/src/main/resources/catgenome-messages.properties
@@ -215,6 +215,7 @@ error.file.id.not.found=File with BiologicalDataItemID {0} not found
 error.file.name.not.found=File with name {0} not found
 error.unsupported.file.format=File format {0} is not supported
 error.directory.not.found=File {0} is not a directory, or not found
+error.file.local.download=Cannot generate download url for local file with BiologicalDataItemID ''{0}''
 
 #Download file
 info.start.download.file=File start download from URL: ''{0}''


### PR DESCRIPTION
# Description
The current PR provides implementation for issue https://github.com/epam/NGB/issues/439#issuecomment-866705210

## Changes

The `size` field added to return object:
```
GET /dataitem/<bioDataItemId>/downloadUrl
{
    "url": "http://...",
    "type": "S3",
    "expires": "..",
    "size": 123
}
```

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
