### PR TITLE
issue 446 add additional field for blast result - seqAccessionVersion

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/blast/result/BlastSequence.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/blast/result/BlastSequence.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 @Builder
 public class BlastSequence {
     private String sequenceId;
+    private String sequenceAccessionVersion;
     private String organism;
     private Long taxId;
     private Double maxScore;
@@ -54,6 +55,7 @@ public class BlastSequence {
                 .max(Comparator.comparing(Entry::getBitScore)).orElse(entries.get(0));
         return BlastSequence.builder()
                 .sequenceId(maxScoringEntry.getSeqSeqId())
+                .sequenceAccessionVersion(maxScoringEntry.getSeqAccVersion())
                 .organism(maxScoringEntry.getSeqSciName())
                 .taxId(maxScoringEntry.getSeqTaxId())
                 .matches(entries.size())


### PR DESCRIPTION
Provides implementation for #446 
This PR adds new field for BlastSequence. It turns out that blast reports SeqAccessionVersion out of the box, so we can just add it to results and provide correct information for UI to generate blast link