### PR TITLE
issue 445 add functionality to fetch information from NCBI for specfic feature

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
@@ -110,6 +110,7 @@ public final class MessagesConstants {
     public static final String ERROR_REFERENCE_REGISTRATION_PARAMS = "error.reference.registration.params.ambiguous";
     public static final String ERROR_DURING_SORTING = "error.file.sorting";
     public static final String INFO_SORT_SUCCESS = "info.file.sorting";
+    public static final String ERROR_REFERENCE_NOT_FOUND_BY_TAX_ID = "error.reference.not.found.by.tax.id";
     public static final String ERROR_ILLEGAL_FEATURE_FILE_FORMAT = "error.file.feature.illegal.file.format";
     public static final String ERROR_ANNOTATION_FILE_ALREADY_EXIST = "error.annotation.file.feature.already.exist";
     public static final String ERROR_ANNOTATION_FILE_NOT_EXIST = "error.annotation.file.feature.not.exist";
@@ -130,6 +131,7 @@ public final class MessagesConstants {
     public static final String DEBUG_FEATURE_INDEX_QUERY_TIME = "debug.feature.index.query.time";
     public static final String ERROR_FEATURE_INDEX_SEARCH_FAILED = "error.feature.index.search.failed";
     public static final String ERROR_FEATURE_INDEX_INVALID_NUMBER_FORMAT = "error.feature.index.invalid.number.format";
+    public static final String ERROR_FEATURE_INDEX_ENTRY_NOT_FOUND = "error.feature.index.entry.not.found";
 
     public static final String INFO_UNREGISTER = "info.unregister.done";
     //Genes
@@ -224,6 +226,8 @@ public final class MessagesConstants {
     public static final String ERROR_NO_DATA_FOR_URL = "error.no.data.for.url";
     public static final String ERROR_UNEXPECTED_FORMAT = "error.error.unexpected.format";
     public static final String ERROR_NO_RESULT_BY_EXTERNAL_DB = "error.no.result.by.external.db";
+    public static final String ERROR_NCBI_CANT_LOAD_FEATURE_INFO = "error.ncbi.cant.load.feature.info";
+
 
     //BED
     public static final String ERROR_BED_PARSING = "error.bed.parsing.exception";

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/blast/BlastUtilController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/blast/BlastUtilController.java
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.controller.blast;
+
+import com.epam.catgenome.controller.AbstractRESTController;
+import com.epam.catgenome.controller.Result;
+import com.epam.catgenome.entity.blast.BlastDatabaseType;
+import com.epam.catgenome.entity.blast.result.BlastFeatureLocatable;
+import com.epam.catgenome.manager.blast.BlastUtilSecurityService;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Api(value = "blast-utils", description = "BLAST Utility Controller")
+@RequiredArgsConstructor
+public class BlastUtilController extends AbstractRESTController {
+
+    private final BlastUtilSecurityService blastUtilSecurityService;
+
+    @GetMapping(value = "/blast/coordinate")
+    @ApiOperation(
+            value = "Gets coordinates for feature based on feature accession version",
+            notes = "Gets coordinates for feature based on feature accession version " +
+                    "by requesting information from NCBI DB",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<BlastFeatureLocatable> fetchCoordinates(@RequestParam final String sequenceId,
+                                                          @RequestParam final Long referenceId,
+                                                          @RequestParam final BlastDatabaseType type) {
+        return Result.success(blastUtilSecurityService.fetchCoordinates(sequenceId, type, referenceId));
+    }
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/blast/BlastUtilController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/blast/BlastUtilController.java
@@ -56,8 +56,8 @@ public class BlastUtilController extends AbstractRESTController {
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<BlastFeatureLocatable> fetchCoordinates(@RequestParam final String sequenceId,
-                                                          @RequestParam final Long referenceId,
-                                                          @RequestParam final BlastDatabaseType type) {
-        return Result.success(blastUtilSecurityService.fetchCoordinates(sequenceId, type, referenceId));
+                                                          @RequestParam final BlastDatabaseType type,
+                                                          @RequestParam final Long taxId) {
+        return Result.success(blastUtilSecurityService.fetchCoordinates(sequenceId, type, taxId));
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/reference/ReferenceGenomeDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/reference/ReferenceGenomeDao.java
@@ -85,6 +85,12 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
 
     /**
      * {@code String} specifies parametrized SELECT statement used to all reference
+     * genomes that are available in the system at the moment and have specific taxId.
+     */
+    private String loadReferenceGenomesByTaxIdQuery;
+
+    /**
+     * {@code String} specifies parametrized SELECT statement used to all reference
      * genomes that are available in the system at the moment.
      */
     private String loadAllReferenceGenomesQuery;
@@ -112,6 +118,7 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
      * are available in the system for reference genomes identified by the given ID.
      */
     private String loadAllChromosomesByReferenceIdQuery;
+
 
     /**
      * {@code String} delete reference by specified id
@@ -250,6 +257,12 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
                 GenomeParameters.getReferenceGenomeMetaDataMapper());
     }
 
+    public List<Reference> loadReferenceGenomesByTaxId(final Long taxId) {
+        return getNamedParameterJdbcTemplate().query(loadReferenceGenomesByTaxIdQuery,
+                new MapSqlParameterSource(GenomeParameters.TAX_ID.name(), taxId),
+                GenomeParameters.getReferenceGenomeMapper());
+    }
+
     /**
      * Saves {@code List} of {@code Chromosome} entities with a specified ID in the database
      * as one reference
@@ -290,7 +303,6 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
                 GenomeParameters.getChromosomeMapper());
         return CollectionUtils.isNotEmpty(list) ? list.get(0) : null;
     }
-
 
     @Transactional(propagation = Propagation.SUPPORTS)
     public List<Chromosome> loadAllChromosomesByReferenceId(final Long referenceId) {
@@ -464,8 +476,14 @@ public class ReferenceGenomeDao extends NamedParameterJdbcDaoSupport {
         this.loadReferenceGenomeByNameQuery = loadReferenceGenomeByNameQuery;
     }
 
+    @Required
     public void setUpdateSpeciesQuery(String updateSpeciesQuery) {
         this.updateSpeciesQuery = updateSpeciesQuery;
+    }
+
+    @Required
+    public void setLoadReferenceGenomesByTaxIdQuery(String loadReferenceGenomesByTaxIdQuery) {
+        this.loadReferenceGenomesByTaxIdQuery = loadReferenceGenomesByTaxIdQuery;
     }
 
     enum GenomeParameters {

--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/blast/result/BlastFeatureLocatable.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/blast/result/BlastFeatureLocatable.java
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.entity.blast.result;
+
+import com.epam.catgenome.entity.blast.BlastDatabaseType;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class BlastFeatureLocatable {
+    String featureName;
+    BlastDatabaseType type;
+    String blastSeqId;
+    long referenceId;
+    long chromosomeId;
+    long start;
+    long end;
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FeatureIndexManager.java
@@ -374,7 +374,8 @@ public class FeatureIndexManager {
         return bookmarkSearchRes;
     }
 
-    public IndexSearchResult searchFeaturesByReference(String featureId, long referenceId) throws IOException {
+    public IndexSearchResult<FeatureIndexEntry> searchFeaturesByReference(final String featureId,
+                                                                          final long referenceId) throws IOException {
         if (featureId == null || featureId.length() < 2) {
             return new IndexSearchResult<>(Collections.emptyList(), false, 0);
         }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastUtilManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastUtilManager.java
@@ -1,0 +1,115 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.manager.blast;
+
+import com.epam.catgenome.entity.blast.BlastDatabaseType;
+import com.epam.catgenome.entity.blast.result.BlastFeatureLocatable;
+import com.epam.catgenome.entity.index.FeatureIndexEntry;
+import com.epam.catgenome.exception.ExternalDbUnavailableException;
+import com.epam.catgenome.manager.FeatureIndexManager;
+import com.epam.catgenome.manager.externaldb.ncbi.NCBIDataManager;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class BlastUtilManager {
+
+    private static final Pattern FEATURE_TAG_PATTERN = Pattern.compile(".*/(gene|locus_tag|operon)=\"(.*)\".*");
+    private static final String GENE_BANK_FORMAT = "gb";
+    private static final String PROTEIN_DB = "protein";
+    private static final String NUCLEOTIDE_DB = "nucleotide";
+    private static final String GENE_BANK_ORIGIN_TAG = "ORIGIN";
+    private static final String NEW_LINE = "\n";
+    private static final String GENE_FEATURE_TAG = "gene";
+    private static final String OPERON_FEATURE_TAG = "operon";
+    private static final String LOCUS_TAG_FEATURE_TAG = "locus_tag";
+
+    private final NCBIDataManager ncbiDataManager;
+    private final FeatureIndexManager featureIndexManager;
+
+    @SneakyThrows
+    public BlastFeatureLocatable fetchCoordinates(final String sequenceId, final BlastDatabaseType type,
+                                                  final Long referenceId) {
+        final String featureName = fetchFeatureNameFromNcbi(sequenceId, type);
+        Assert.notNull(featureName, "Can't load feature name from NCBI for sequence: " + sequenceId);
+        final Optional<FeatureIndexEntry> featureSearchResult =
+                featureIndexManager.searchFeaturesByReference(featureName, referenceId)
+                        .getEntries().stream()
+                        .filter(f -> f.getFeatureName().equalsIgnoreCase(featureName))
+                        .findFirst();
+        return featureSearchResult.map(feature -> BlastFeatureLocatable.builder()
+                .referenceId(referenceId)
+                .blastSeqId(sequenceId)
+                .type(type)
+                .featureName(feature.getFeatureName())
+                .chromosomeId(feature.getChromosome().getId())
+                .start(feature.getStartIndex())
+                .end(feature.getEndIndex())
+                .build())
+                .orElseThrow(
+                        () -> new IllegalStateException(
+                                "Can't find information about a feature by name: " + featureName
+                        )
+                );
+    }
+
+    private String fetchFeatureNameFromNcbi(final String sequenceId, 
+                                            final BlastDatabaseType type) throws ExternalDbUnavailableException {
+        String geneBankFile = ncbiDataManager.fetchTextById(getNcbiDbType(type), sequenceId, GENE_BANK_FORMAT);
+
+        final Map<String, String> featureTags = new HashMap<>();
+        for (String line : geneBankFile.split(NEW_LINE)) {
+            if(line.contains(GENE_BANK_ORIGIN_TAG)) {
+                break;
+            }
+            final Matcher matcher = FEATURE_TAG_PATTERN.matcher(line);
+            if (matcher.find()) {
+                featureTags.put(matcher.group(1), matcher.group(2));
+            }
+        }
+
+        if (featureTags.containsKey(GENE_FEATURE_TAG)) {
+            return featureTags.get(GENE_FEATURE_TAG);
+        } else if (featureTags.containsKey(OPERON_FEATURE_TAG)) {
+            return featureTags.get(OPERON_FEATURE_TAG);
+        } else {
+            return featureTags.get(LOCUS_TAG_FEATURE_TAG);
+        }
+    }
+
+    private String getNcbiDbType(final BlastDatabaseType type) {
+       return  type == BlastDatabaseType.PROTEIN ? PROTEIN_DB : NUCLEOTIDE_DB;
+    }
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastUtilSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastUtilSecurityService.java
@@ -41,7 +41,7 @@ public class BlastUtilSecurityService {
 
     @PreAuthorize(ROLE_USER)
     public BlastFeatureLocatable fetchCoordinates(final String sequenceId, final BlastDatabaseType type,
-                                                  final Long referenceId) {
-        return blastUtilManager.fetchCoordinates(sequenceId, type, referenceId);
+                                                  final Long taxId) {
+        return blastUtilManager.fetchCoordinates(sequenceId, type, taxId);
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastUtilSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastUtilSecurityService.java
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.manager.blast;
+
+import com.epam.catgenome.entity.blast.BlastDatabaseType;
+import com.epam.catgenome.entity.blast.result.BlastFeatureLocatable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+import static com.epam.catgenome.security.acl.SecurityExpressions.ROLE_USER;
+
+@Service
+@RequiredArgsConstructor
+public class BlastUtilSecurityService {
+
+    private final BlastUtilManager blastUtilManager;
+
+    @PreAuthorize(ROLE_USER)
+    public BlastFeatureLocatable fetchCoordinates(final String sequenceId, final BlastDatabaseType type,
+                                                  final Long referenceId) {
+        return blastUtilManager.fetchCoordinates(sequenceId, type, referenceId);
+    }
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIDataManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/ncbi/NCBIDataManager.java
@@ -49,6 +49,8 @@ import javax.annotation.PostConstruct;
 /**
  * <p>
  * A class that manages connections to NCBI external database
+ * NOTE: very useful information about possible arguments for different DBs
+ * https://www.ncbi.nlm.nih.gov/books/NBK25499/table/chapter4.T._valid_values_of__retmode_and/
  * </p>
  */
 @Slf4j

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
@@ -45,6 +45,7 @@ import com.epam.catgenome.manager.SecuredEntityManager;
 import com.epam.catgenome.security.acl.aspect.AclSync;
 import com.epam.catgenome.util.ListMapCollector;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -269,6 +270,18 @@ public class ReferenceGenomeManager implements SecuredEntityManager {
         }
 
         return result;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public List<Reference> loadAllReferenceGenomesByTaxId(final Long taxId) {
+        return ListUtils.emptyIfNull(referenceGenomeDao.loadReferenceGenomesByTaxId(taxId))
+                .stream().peek(ref -> {
+                    if (ref.getGeneFile() != null && ref.getGeneFile().getId() != null) {
+                        GeneFile geneFile = geneFileDao.loadGeneFile(ref.getGeneFile().getId());
+                        ref.setGeneFile(geneFile);
+                        ref.setAnnotationFiles(getAnnotationFilesByReferenceId(ref.getId()));
+                    }
+                }).collect(Collectors.toList());
     }
 
     /**

--- a/server/catgenome/src/main/resources/catgenome-messages.properties
+++ b/server/catgenome/src/main/resources/catgenome-messages.properties
@@ -55,6 +55,7 @@ error.reference.registration.params.ambiguous=Ambiguous request parameters: eith
   registration request must be specified
 error.file.sorting=Error during sorting {0} file
 info.file.sorting=File is successfully sorted and placed to {0}.
+error.reference.not.found.by.tax.id=Cannot find reference for taxId ''{0}''
 
 # cytobands
 info.cytobands.upload.done=Your file ''{0}'' containing cytobands has been processed successfully and now it is \
@@ -182,6 +183,7 @@ error.feature.index.search.failed=Error: Exception while searching through index
 error.feature.index.writing=Error while writing feature index
 error.feature.index.invalid.number.format=Illegal number format: ''{0}''
 error.feature.index.too.large=Feature index is too large to perform request.
+error.feature.index.entry.not.found=Cannot find information about a feature by name {0}
 
 # S3
 error.not.s3.bucket=This bucket is wrong.
@@ -203,6 +205,7 @@ error.parsing.exception=Parsing exception happened: {0}
 error.no.data.for.url=Couldn't fetch data for URL {0}
 error.unexpected.format=Unexpected result format {0}
 error.no.result.by.external.db=No result was were returned by external db
+error.ncbi.cant.load.feature.info=Cannot load feature name from NCBI for sequence ''{0}'' db ''{1}''
 
 #Bed
 error.bed.parsing.exception=Error parsing bed file

--- a/server/catgenome/src/main/resources/conf/catgenome/dao/reference-genome-dao.xml
+++ b/server/catgenome/src/main/resources/conf/catgenome/dao/reference-genome-dao.xml
@@ -115,6 +115,48 @@
             </value>
         </property>
 
+        <property name="loadReferenceGenomesByTaxIdQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        b.bio_data_item_id,
+                        b.name,
+                        b.type,
+                        b.path,
+                        b.format,
+                        b.created_date,
+                        b.bucket_id,
+                        b.pretty_name,
+                        b.owner,
+
+                        r.reference_genome_id,
+                        r.bio_data_item_id,
+                        r.reference_genome_size,
+                        null as compressed,
+                        r.gene_item_id,
+
+                        i.bio_data_item_id as index_id,
+                        i.name as index_name,
+                        i.type as index_type,
+                        i.path as index_path,
+                        i.format as index_format,
+                        i.bucket_id as index_bucket_id,
+                        i.created_date as index_created_date,
+                        i.owner as index_owner,
+
+                        s.species_name,
+                        s.species_version,
+                        s.tax_id
+
+                    FROM catgenome.reference_genome r
+                        JOIN catgenome.biological_data_item b ON r.bio_data_item_id = b.bio_data_item_id
+                        JOIN catgenome.biological_data_item i ON i.bio_data_item_id = r.index_id
+                        LEFT JOIN catgenome.genome_species s ON r.species_version = s.species_version
+                    WHERE LOWER(s.tax_id) = :TAX_ID
+                ]]>
+            </value>
+        </property>
+
         <property name="loadReferenceGenomeByBioIdQuery">
             <value>
                 <![CDATA[


### PR DESCRIPTION
This PR adds functionality to fetch feature location information for feature by `accession version` from NCBI
Algorithm:
- Fetch GeneBank file info from NCBI `protein` or `nucleotide` DB with the same `accession version`
- Search for features in GB file with property  `gene` `locus_tag` or `operon`
- choose from found list feature in order:
   - `gene`
   - `operon`
   - `locus_tag`
- Search for this feature in reference annotation file
   - If found - return location information of this feature
   - If not found fail with exception that tells that nothing is found for specific feature