### PR TITLE
issue 377 fix paging when query contains sorting by int field

### DIFF
--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/FeatureIndexManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/FeatureIndexManagerTest.java
@@ -146,6 +146,8 @@ public class FeatureIndexManagerTest extends AbstractManagerTest {
     private static final int TEST_START_INDEX = 65000;
     private static final int TEST_END_INDEX = 200_000;
     private static final int DEFAULT_PAGE_SIZE = 10;
+    public static final int SMALL_PAGE_SIZE = 8;
+    public static final int LAST = 1;
 
     private Logger logger = LoggerFactory.getLogger(FeatureIndexManagerTest.class);
 
@@ -1262,6 +1264,33 @@ public class FeatureIndexManagerTest extends AbstractManagerTest {
 
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void searchGenesByFilterWithSortingAndPaging() throws IOException {
+        final GeneFilterForm geneFilterForm = getSmallGeneFilter();
+        geneFilterForm.setFeatureTypes(Collections.singletonList(FeatureType.GENE));
+        geneFilterForm.setOrderBy(Collections.singletonList(new OrderBy("START_INDEX", true)));
+
+        IndexSearchResult<FeatureIndexEntry> result = featureIndexManager.searchGenesByReference(
+                geneFilterForm, referenceId);
+
+        assertEquals(SMALL_PAGE_SIZE, result.getEntries().size());
+        assertNotNull(result.getPointer());
+
+        final Integer maxInt = result.getEntries().stream()
+                .map(FeatureIndexEntry::getStartIndex)
+                .max(Comparator.naturalOrder())
+                .orElse(0);
+
+        assertEquals(maxInt, result.getEntries().get(0).getStartIndex());
+
+        geneFilterForm.setPointer(result.getPointer());
+        result = featureIndexManager.searchGenesByReference(geneFilterForm, referenceId);
+
+        assertEquals(LAST, result.getEntries().size());
+
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void searchGenesByFilterWithIncorrectSortingName() throws IOException {
         final GeneFilterForm geneFilterForm = getSimpleGeneFilter();
         geneFilterForm.setOrderBy(Collections.singletonList(new OrderBy("TEST_TEST", true)));
@@ -1316,6 +1345,13 @@ public class FeatureIndexManagerTest extends AbstractManagerTest {
         final GeneFilterForm geneFilterForm = new GeneFilterForm();
         geneFilterForm.setFeatureId("ENSFCA");
         geneFilterForm.setPageSize(DEFAULT_PAGE_SIZE);
+        return geneFilterForm;
+    }
+
+    private GeneFilterForm getSmallGeneFilter() {
+        final GeneFilterForm geneFilterForm = new GeneFilterForm();
+        geneFilterForm.setFeatureId("ENSFCA");
+        geneFilterForm.setPageSize(SMALL_PAGE_SIZE);
         return geneFilterForm;
     }
 

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/protein/ProteinSequenceManagerIntegrationTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/protein/ProteinSequenceManagerIntegrationTest.java
@@ -83,6 +83,12 @@ public class ProteinSequenceManagerIntegrationTest extends AbstractManagerTest {
     public static final String GENE_ATTR_AMINOACID_SEQ = "AAAAA";
     public static final String CALCULATED_AMINO_ACID_SEQ = "QQRRTQNP";
     public static final String CDS_CALCULATED_SEQ = "FG";
+    public static final int END_INDEX_30 = 30;
+    public static final int END_INDEX_15 = 15;
+    public static final int START_INDEX_7 = 7;
+    public static final double SCALE_FACTOR = 1D;
+    public static final int END_INDEX_10 = 10;
+    public static final int START_INDEX_2 = 2;
     @Autowired
     private GffManager gffManager;
 
@@ -130,10 +136,10 @@ public class ProteinSequenceManagerIntegrationTest extends AbstractManagerTest {
         // Load protein sequence.
         TrackQuery track = new TrackQuery();
         track.setId(geneFile.getId());
-        track.setStartIndex(2);
-        track.setEndIndex(30);
+        track.setStartIndex(START_INDEX_2);
+        track.setEndIndex(END_INDEX_30);
         track.setChromosomeId(reference.getChromosomes().get(0).getId());
-        track.setScaleFactor(1D);
+        track.setScaleFactor(SCALE_FACTOR);
 
         ProteinSequence seq = proteinSequenceManager.loadProteinSequence(
                 ProteinSequenceConstructRequest.builder()
@@ -158,10 +164,10 @@ public class ProteinSequenceManagerIntegrationTest extends AbstractManagerTest {
         // Load protein sequence.
         TrackQuery track = new TrackQuery();
         track.setId(geneFile.getId());
-        track.setStartIndex(2);
-        track.setEndIndex(10);
+        track.setStartIndex(START_INDEX_2);
+        track.setEndIndex(END_INDEX_10);
         track.setChromosomeId(reference.getChromosomes().get(0).getId());
-        track.setScaleFactor(1D);
+        track.setScaleFactor(SCALE_FACTOR);
 
         ProteinSequence seq = proteinSequenceManager.loadProteinSequence(
                 ProteinSequenceConstructRequest.builder()
@@ -174,10 +180,10 @@ public class ProteinSequenceManagerIntegrationTest extends AbstractManagerTest {
 
         track = new TrackQuery();
         track.setId(geneFile.getId());
-        track.setStartIndex(7);
-        track.setEndIndex(15);
+        track.setStartIndex(START_INDEX_7);
+        track.setEndIndex(END_INDEX_15);
         track.setChromosomeId(reference.getChromosomes().get(0).getId());
-        track.setScaleFactor(1D);
+        track.setScaleFactor(SCALE_FACTOR);
 
         seq = proteinSequenceManager.loadProteinSequence(
                 ProteinSequenceConstructRequest.builder()


### PR DESCRIPTION
This PR fixes a bug when was impossible to load next page for gene or variation table results, if sorting field has an `Int` type