### PR TITLE
Issue #462: Support of 'featureCounts' format - implementation for s3/az

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/dataitem/DataItemManager.java
@@ -159,6 +159,7 @@ public class DataItemManager {
                 bedManager.unregisterBedFile(itemId);
                 break;
             case GENE:
+            case FEATURE_COUNTS:
                 geneManager.unregisterGeneFile(itemId);
                 break;
             case WIG:

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -114,6 +114,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -315,15 +316,16 @@ public class GffManager {
             geneFile.setIndex(indexItem);
         }
 
-        long geneId = geneFile.getId();
-        biologicalDataItemManager.createBiologicalDataItem(geneFile);
-        geneFile.setBioDataItemId(geneFile.getId());
-        geneFile.setId(geneId);
-
-        log.info(getMessage(MessagesConstants.INFO_GENE_REGISTER, geneFile.getId(), geneFile.getPath()));
-        GeneRegisterer geneRegisterer = new GeneRegisterer(referenceGenomeManager, fileManager, featureIndexManager,
-                                                           geneFile);
         try {
+            long geneId = geneFile.getId();
+            biologicalDataItemManager.createBiologicalDataItem(geneFile);
+            geneFile.setBioDataItemId(geneFile.getId());
+            geneFile.setId(geneId);
+
+            log.info(getMessage(MessagesConstants.INFO_GENE_REGISTER, geneFile.getId(), geneFile.getPath()));
+            GeneRegisterer geneRegisterer = new GeneRegisterer(referenceGenomeManager, fileManager, featureIndexManager,
+                    geneFile);
+
             geneRegisterer.processRegistration(request);
             biologicalDataItemManager.createBiologicalDataItem(geneFile.getIndex());
             geneFileManager.create(geneFile);
@@ -331,7 +333,9 @@ public class GffManager {
             throw new RegistrationException("Error while Gene file registration: " + geneFile.getPath(), e);
         }  finally {
             if (geneFile.getId() != null && !geneFileManager.geneFileExists(geneFile.getId())) {
-                biologicalDataItemManager.deleteBiologicalDataItem(geneFile.getBioDataItemId());
+                if (Objects.nonNull(geneFile.getBioDataItemId())) {
+                    biologicalDataItemManager.deleteBiologicalDataItem(geneFile.getBioDataItemId());
+                }
                 try {
                     fileManager.deleteFeatureFileDirectory(geneFile);
                 } catch (IOException e) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -272,6 +272,7 @@ public class GffManager {
             new FeatureCountsToGffConvertor().convert(request.getPath(), gffFilePath, fileManager.getTempDir());
             request.setPath(gffFilePath);
             geneFile.setFormat(BiologicalDataItemFormat.FEATURE_COUNTS);
+            request.setType(BiologicalDataItemResourceType.FILE);
         }
 
         String path = request.getPath();

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -180,6 +180,9 @@ public class GffManager {
     @Value("#{'${feature.counts.extensions}'.split(',')}")
     private List<String> featureCountsExtensions;
 
+    @Value("${feature.counts.max.memory:500}")
+    private int featureCountsMaxMemory;
+
     private static final String EXON_FEATURE_NAME = "exon";
 
     private static final String PROTEIN_CODING = "protein_coding";
@@ -273,7 +276,8 @@ public class GffManager {
                     ? request.getName()
                     : Paths.get(request.getPath()).getFileName().toString());
             final String gffFilePath = buildGffFileNameFromFeatureCounts(request.getPath(), geneFileId);
-            new FeatureCountsToGffConvertor().convert(request.getPath(), gffFilePath, fileManager.getTempDir());
+            new FeatureCountsToGffConvertor().convert(request.getPath(), gffFilePath, fileManager.getTempDir(),
+                    featureCountsMaxMemory);
             request.setPath(gffFilePath);
             geneFile.setFormat(BiologicalDataItemFormat.FEATURE_COUNTS);
             request.setType(BiologicalDataItemResourceType.FILE);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -268,6 +268,9 @@ public class GffManager {
         final Long geneFileId = geneFileManager.createGeneFileId();
 
         if (isFeatureCounts(request.getPath())) {
+            request.setName(request.getName() != null
+                    ? request.getName()
+                    : Paths.get(request.getPath()).getFileName().toString());
             final String gffFilePath = buildGffFileNameFromFeatureCounts(request.getPath(), geneFileId);
             new FeatureCountsToGffConvertor().convert(request.getPath(), gffFilePath, fileManager.getTempDir());
             request.setPath(gffFilePath);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/featurecounts/FeatureCountsLineProcessor.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/featurecounts/FeatureCountsLineProcessor.java
@@ -43,7 +43,7 @@ import static com.epam.catgenome.manager.gene.featurecounts.FeatureCountsParserU
 @Slf4j
 public class FeatureCountsLineProcessor implements LineProcessor<SortingCollection<SortableRecord>> {
 
-    private static final int ESTIMATED_RECORD_SIZE = 150;
+    private static final int ESTIMATED_RECORD_SIZE = 500;
     private static final int DEFAULT_MAX_MEMORY = 500;
     private static final String COMMENT_MARKER = "#";
 
@@ -52,12 +52,12 @@ public class FeatureCountsLineProcessor implements LineProcessor<SortingCollecti
 
     private boolean headerProcessed;
 
-    public FeatureCountsLineProcessor(final File tmpDir, final Map<Integer, String> header) {
+    public FeatureCountsLineProcessor(final File tmpDir, final Map<Integer, String> header, final int maxMemory) {
         this.sortingCollection = SortingCollection.newInstance(
                 SortableRecord.class,
                 new SortableRecordCodec(),
                 AbstractFeatureSorter.getDefaultComparator(),
-                DEFAULT_MAX_MEMORY * 1024 * 1024 / ESTIMATED_RECORD_SIZE, tmpDir);
+                getMemory(maxMemory) * 1024 * 1024 / ESTIMATED_RECORD_SIZE, tmpDir);
         this.header = header;
     }
 
@@ -139,5 +139,9 @@ public class FeatureCountsLineProcessor implements LineProcessor<SortingCollecti
                 .min()
                 .orElseThrow(() -> new IllegalArgumentException(
                         String.format("Failed to calculate start for gene '%s'", geneId)));
+    }
+
+    private int getMemory(final int maxMemory) {
+        return maxMemory > 0 ? maxMemory : DEFAULT_MAX_MEMORY;
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/featurecounts/FeatureCountsToGffConvertor.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/featurecounts/FeatureCountsToGffConvertor.java
@@ -27,6 +27,7 @@ package com.epam.catgenome.manager.gene.featurecounts;
 import com.epam.catgenome.manager.gene.parser.StrandSerializable;
 import com.epam.catgenome.manager.gene.writer.Gff3FeatureImpl;
 import com.epam.catgenome.manager.gene.writer.Gff3Writer;
+import com.epam.catgenome.util.IOHelper;
 import com.epam.catgenome.util.sort.SortableRecord;
 import com.google.common.io.CharStreams;
 import com.google.common.io.LineProcessor;
@@ -35,12 +36,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,12 +58,12 @@ import static com.epam.catgenome.manager.gene.featurecounts.FeatureCountsParserU
 @Slf4j
 public class FeatureCountsToGffConvertor {
 
-    public void convert(final String featureCountsFilePath, final String gffFilePath, final File tmpFile) {
+    public void convert(final String featureCountsFilePath, final String gffFilePath, final File tmpDir) {
         try (Gff3Writer gff3Writer = new Gff3Writer(Paths.get(gffFilePath));
              Reader reader = getReader(featureCountsFilePath)) {
             final Map<Integer, String> header = new HashMap<>();
             final LineProcessor<SortingCollection<SortableRecord>> processor =
-                    new FeatureCountsLineProcessor(tmpFile, header);
+                    new FeatureCountsLineProcessor(tmpDir, header);
             final SortingCollection<SortableRecord> sortableRecords = CharStreams.readLines(reader, processor);
             StreamSupport.stream(sortableRecords.spliterator(), false)
                     .map(record -> recordToGffFeature(record, header))
@@ -73,9 +74,9 @@ public class FeatureCountsToGffConvertor {
         }
     }
 
-    private static InputStreamReader getReader(final String featureCountsFilePath) throws IOException {
-        return new InputStreamReader(Files.newInputStream(Paths.get(featureCountsFilePath)),
-                StandardCharsets.UTF_8);
+    private static BufferedReader getReader(final String featureCountsFilePath) throws IOException {
+        return new BufferedReader(new InputStreamReader(
+                IOHelper.openStream(featureCountsFilePath), StandardCharsets.UTF_8));
     }
 
     private Gff3FeatureImpl recordToGffFeature(final SortableRecord record, final Map<Integer, String> header) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/parser/GffFeature.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/parser/GffFeature.java
@@ -24,8 +24,12 @@
 
 package com.epam.catgenome.manager.gene.parser;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Source:      GffFeature.java
@@ -186,7 +190,7 @@ public class GffFeature implements GeneFeature {
         for (String group : groups) {
             String[] keyValue = group.split("=");
             if (keyValue.length == 2) {
-                attributes.put(keyValue[0], keyValue[1]);
+                attributes.put(decodeAttribute(keyValue[0]), decodeAttribute(keyValue[1]));
             }
         }
         return getGeneId();
@@ -327,6 +331,13 @@ public class GffFeature implements GeneFeature {
             return false;
         }
         return feature.equals(f.feature);
+    }
 
+    private String decodeAttribute(final String attribute) {
+        try {
+            return Objects.nonNull(attribute) ? URLDecoder.decode(attribute, StandardCharsets.UTF_8.toString()) : null;
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("Cannot decode GFF attribute", e);
+        }
     }
 }


### PR DESCRIPTION
# Description
The current PR implements issue #462 and provides support for S3/AZ providers

Also, this PR provides the following fixes:
- fix for `FEATURE_COUNTS` name by default
- fix for `FEATURE_COUNTS` items deletion
- fix for gene directory deletion on error
- fix for sorting collection record size estimation (a new property `feature.counts.max.mamory` can be used)
- fix for gff attributes decode

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
