### PR TITLE
issue 496 add new sort field to save right order by default

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/gene/GeneFilterForm.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/gene/GeneFilterForm.java
@@ -83,6 +83,10 @@ public class GeneFilterForm extends AbstractFilterForm {
         final List<SortField> sortFields = new ArrayList<>();
         sortFields.add(new SortField(GeneIndexSortField.CHROMOSOME_NAME.getFieldName(),
                 GeneIndexSortField.CHROMOSOME_NAME.getType(), false));
+        sortFields.add(new SortField(GeneIndexSortField.START_INDEX.getFieldName(),
+                GeneIndexSortField.START_INDEX.getType(), false));
+        sortFields.add(new SortField(GeneIndexSortField.FEATURE_NAME.getFieldName(),
+                GeneIndexSortField.FEATURE_NAME.getType(), false));
         return new Sort(sortFields.toArray(new SortField[0]));
     }
 


### PR DESCRIPTION
# Description

## Background

This PR relates to #496 and add fields for default sorting to be able to save right sort order after changes for gene table were made
