### PR TITLE
Issue #522 Homologene support - fix empty species names for some organisms

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastTaxonomyManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/blast/BlastTaxonomyManager.java
@@ -71,7 +71,6 @@ import static org.apache.commons.lang3.StringUtils.join;
 @Slf4j
 public class BlastTaxonomyManager {
 
-    private static final String AUTHORITY = "authority";
     private static final String COMMON_NAME = "common name";
     private static final String SCIENTIFIC_NAME = "scientific name";
     private static final String TAXONOMY_LINE_DELIMITER = "|";
@@ -244,21 +243,17 @@ public class BlastTaxonomyManager {
         final List<String> synonyms = new ArrayList<>();
         final BlastTaxonomy.BlastTaxonomyBuilder blastTaxonomy = BlastTaxonomy.builder()
                 .taxId(taxId).synonyms(synonyms);
-        boolean hasAuthority = false;
         for (final TaxonomyRecord record : records) {
             final String name = record.line.split(TAXONOMY_TOKEN_DELIMITER_PATTERN)[1].trim();
             if (record.line.contains(COMMON_NAME)) {
                 blastTaxonomy.commonName(name);
             } else if (record.line.contains(SCIENTIFIC_NAME)) {
                 blastTaxonomy.scientificName(name);
-            } else if (record.line.contains(AUTHORITY)) {
-                hasAuthority = true;
-                synonyms.add(name);
             } else if (!excludeLine(record.line)) {
                 synonyms.add(name);
             }
         }
-        return hasAuthority ? blastTaxonomy.build() : null;
+        return blastTaxonomy.build();
     }
 
     private List<TaxonomyRecord> readTaxonomyLines(final String path) {

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/blast/BlastTaxonomyManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/blast/BlastTaxonomyManagerTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class BlastTaxonomyManagerTest extends TestCase {
 
     public static final int ORGANISMS_COUNT = 2;
-    public static final int TOTAL_ORGANISMS_COUNT = 12;
+    public static final int TOTAL_ORGANISMS_COUNT = 14;
 
     @Autowired
     private BlastTaxonomyManager blastTaxonomyManager;


### PR DESCRIPTION
# Description

## Background

[Homologene support](https://github.com/epam/NGB/issues/522)
Taxonomy DB import was changes to allow not "authority" containing records import.