### PR TITLE
Issue #553: X-Frame-Options: DENY -- since version 2.6

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/app/JWTSecurityConfiguration.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/app/JWTSecurityConfiguration.java
@@ -65,6 +65,9 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("#{'${jwt.required.claims}'.split(',')}")
     private List<String> requiredClaims;
 
+    @Value("${security.frame-options.disable:false}")
+    private boolean frameOptionsDisable;
+
     @Autowired(required = false)
     private SAMLAuthenticationProvider samlAuthenticationProvider;
 
@@ -100,6 +103,10 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .and()
                 .addFilterBefore(getJwtAuthenticationFilter(),
                         UsernamePasswordAuthenticationFilter.class);
+
+        if (frameOptionsDisable) {
+            http.headers().frameOptions().disable();
+        }
     }
 
     @Bean

--- a/server/catgenome/src/main/java/com/epam/catgenome/app/NoSecurityConfiguration.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/app/NoSecurityConfiguration.java
@@ -24,6 +24,7 @@
 
 package com.epam.catgenome.app;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -38,9 +39,16 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @Order(3)
 public class NoSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
+    @Value("${security.frame-options.disable:false}")
+    private boolean frameOptionsDisable;
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests().antMatchers("/*").permitAll().and().csrf().disable();
+
+        if (frameOptionsDisable) {
+            http.headers().frameOptions().disable();
+        }
     }
 
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/app/SAMLSecurityConfiguration.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/app/SAMLSecurityConfiguration.java
@@ -156,6 +156,9 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${saml.lb.enabled:false}")
     private boolean loadBalancerEnabled;
 
+    @Value("${security.frame-options.disable:false}")
+    private boolean frameOptionsDisable;
+
     /**
      * Optional Load balancer configuration
      */
@@ -192,6 +195,10 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers(getUnsecuredResources()).permitAll()
             .antMatchers(getSecuredResourcesRoot()).authenticated();
         http.logout().logoutSuccessUrl("/");
+
+        if (frameOptionsDisable) {
+            http.headers().frameOptions().disable();
+        }
     }
 
     public String[] getUnsecuredResources() {


### PR DESCRIPTION
# Description

The current PR provides implementation for issue #553 
- a new property `security.frame-options.disable` was added. Default: false. If true `X-Frame-Options` will not be present at the response.  

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
