### PR TITLE
Issue #581 Tree node can have name not from heatmap row/column labels…

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/heatmap/HeatmapManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/heatmap/HeatmapManager.java
@@ -486,9 +486,8 @@ public class HeatmapManager {
         try (BufferedReader r = createReader(path)) {
             TreeParser tp = new TreeParser(r);
             Tree tree = tp.tokenize(FilenameUtils.getBaseName(path));
-            List<String> treeLabels = tree.nodes.stream()
-                    .map(TreeNode::getName)
-                    .filter(f -> !f.isEmpty() && !labels.contains(f))
+            List<TreeNode> treeLabels = tree.nodes.stream()
+                    .filter(n -> !n.getName().isEmpty() && 0 == n.numberChildren() && !labels.contains(n.getName()))
                     .collect(Collectors.toList());
             Assert.isTrue(treeLabels.isEmpty(), getMessage(MessagesConstants.ERROR_INCORRECT_FILE_FORMAT));
         }


### PR DESCRIPTION
… list if it is not a final tree leaf (has children)
(STRAIN1:0.5,(STRAIN2:1,STRAIN3:1)**1**:0.5);
# Description

## Background
[[Server] Heatmap support](https://github.com/epam/NGB/issues/581)

