### PR TITLE
Update to log4j 2.17.0

### DIFF
--- a/server/ngb-cli/build.gradle
+++ b/server/ngb-cli/build.gradle
@@ -23,9 +23,9 @@ dependencies {
 
     //Logging
     compile group: "org.slf4j", name: "slf4j-api", version: "1.7.21"
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.16.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
 
     //CLI parsing
     compile group: 'args4j', name: 'args4j', version: '2.33'


### PR DESCRIPTION
# Description

## Background

See https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0

log4j 2.16 was recently discovered to be vulnerable to an infinite recursion DOS. Version 2.17 fixes LOG4J2-3230.


## Changes

Change the version from 2.16 to 2.17 for log4j.

## Acceptance criteria

This PR updates log4j to 2.17, which includes a patch for the issue.

# Check list

- [ ] Unit tests are provided
- [ ] Integration tests are provided (if CLI/API was changed)
- [ ] Documentation is updated
