### PR TITLE
Include commit SHA into the app version information

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,8 @@ if [[ "$APPVEYOR_REPO_BRANCH" == "release/"* ]]; then
   BUILD_DOCKER=buildDocker
 fi
 
-./gradlew buildJar buildCli buildDoc $BUILD_DOCKER -PbuildNumber=${APPVEYOR_BUILD_NUMBER} -PnoTest
+_build_number="${APPVEYOR_BUILD_NUMBER}"
+if [ "${APPVEYOR_REPO_COMMIT}" ]; then
+  _build_number="${_build_number}.${APPVEYOR_REPO_COMMIT}"
+fi
+./gradlew buildJar buildCli buildDoc $BUILD_DOCKER -PbuildNumber=${_build_number} -PnoTest

--- a/publish.sh
+++ b/publish.sh
@@ -3,6 +3,8 @@
 echo "Starting deployment"
 
 # Get current version
+#   Here we use a "short" version notation, i.e. {major}.{minor}.{patch}.${build}
+#   Commint SHA is not included in the artifacts naming. It is shown in the app only (e.g. in the GUI)
 NGB_VERSION=$(./gradlew :printVersion -PbuildNumber=$APPVEYOR_BUILD_NUMBER |  grep "Project version is " | sed 's/^.*is //')
 echo "Current version is ${NGB_VERSION}"
 


### PR DESCRIPTION
This PR shall address #726

* NGB version will now be reported as `{major}.{minor}.{patch}.{build}.{commit}` to simplify mapping of a specific distro to a code snapshot
* Build artifacts (docker image, JAR, WAR, etc.) will still use a short notation without a commit: `{major}.{minor}.{patch}.{build}`