### PR TITLE
Build PSQL version automatically

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,12 @@ _build_number="${APPVEYOR_BUILD_NUMBER}"
 if [ "${APPVEYOR_REPO_COMMIT}" ]; then
   _build_number="${_build_number}.${APPVEYOR_REPO_COMMIT}"
 fi
-./gradlew buildJar buildCli buildDoc $BUILD_DOCKER -PbuildNumber=${_build_number} -PnoTest
+
+# 1. Build JAR with H2 support and "everything" else (catgenome-h2.jar)
+# 2. Rebuild JAR with PSQL support only (catgenome-psql.jar)
+# 3. H2 version is also stored as `catgenome.jar` for backward compatability, if any service uses that
+./gradlew buildJar buildCli buildDoc $BUILD_DOCKER -PbuildNumber=${_build_number} -PnoTest && \
+mv dist/catgenome.jar dist/catgenome-h2.jar && \
+./gradlew buildJar -PbuildNumber=${_build_number} -PnoTest -Pdatabase=postgres && \
+mv dist/catgenome.jar dist/catgenome-psql.jar && \
+cp dist/catgenome-h2.jar dist/catgenome.jar

--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,8 @@ if [[ "$APPVEYOR_REPO_BRANCH" == "release/"* ]]; then
   BUILD_DOCKER=buildDocker
 fi
 
-./gradlew buildJar buildCli buildDoc $BUILD_DOCKER -PbuildNumber=${APPVEYOR_BUILD_NUMBER} -PnoTest
+_build_number="${APPVEYOR_BUILD_NUMBER}"
+if [ "${APPVEYOR_REPO_COMMIT}" ]; then
+  _build_number="${_build_number}.${APPVEYOR_REPO_COMMIT}"
+fi
+./gradlew buildJar buildCli buildDoc $BUILD_DOCKER -PbuildNumber=${_build_number} -PnoTest

--- a/publish.sh
+++ b/publish.sh
@@ -3,6 +3,8 @@
 echo "Starting deployment"
 
 # Get current version
+#   Here we use a "short" version notation, i.e. {major}.{minor}.{patch}.${build}
+#   Commint SHA is not included in the artifacts naming. It is shown in the app only (e.g. in the GUI)
 NGB_VERSION=$(./gradlew :printVersion -PbuildNumber=$APPVEYOR_BUILD_NUMBER |  grep "Project version is " | sed 's/^.*is //')
 echo "Current version is ${NGB_VERSION}"
 


### PR DESCRIPTION
NGB support Postgres DB to store the configuration info. But the artefacts, published into the [NGB Binary repository](https://ngb-oss-builds.s3.amazonaws.com/web/index.html?prefix=public/builds/) are built with H2 support only.
Now NGB distribution will include the following JARs:
* `catgenome.jar` - H2 version for backward compatability, if any service uses this name of the binary
* `catgenome-h2.jar` - H2 version of the NGB JAR
* `catgenome-psql.jar` - PSQL version of the NGB JAR

All the other artefacts (CLI, docs) are left as-is. Docker image is still built with H2 as well.

**Note**: this PR relies on #732. Might need to rebase this one, once merged. 

