### PR TITLE
Ability to add project description by file path

### DIFF
--- a/docs/md/cli/command-reference.md
+++ b/docs/md/cli/command-reference.md
@@ -532,6 +532,7 @@ ngb add_description [<DATASET_NAME>|<DATASET_ID>] <DESCRIPTION_FILE_PATH>  [opti
 
 //Options:
 //-n (--name)           Use specified value for description name. If not specified - fasta file name will be used. Should be unique and mustn't be a number (it will be recognized as ID).
+//--send-content        Use to read description file and send as binary data. Otherwise only the file path will be sent.
 ```
 *Description*
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/project/ProjectController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/project/ProjectController.java
@@ -498,9 +498,10 @@ public class ProjectController extends AbstractRESTController {
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<ProjectDescription> upsertProjectDescription(@PathVariable final Long projectId,
+            @RequestParam(value = "path", required = false) final String path,
             @RequestParam(value = "name", required = false) final String name,
-            @RequestParam("file") final MultipartFile multipart) throws IOException {
-        return Result.success(projectSecurityService.upsertProjectDescription(projectId, name, multipart));
+            @RequestParam(value = "file", required = false) final MultipartFile multipart) throws IOException {
+        return Result.success(projectSecurityService.upsertProjectDescription(projectId, name, path, multipart));
     }
 
     @GetMapping("/project/description/{id}")

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/project/ProjectDescriptionService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/project/ProjectDescriptionService.java
@@ -54,6 +54,7 @@ public class ProjectDescriptionService {
     @Transactional
     public ProjectDescription upsert(final Long projectId, final String name, final String path,
                                      final MultipartFile multipartFile) throws IOException {
+        Assert.isTrue(path != null || multipartFile != null, "Description file path or content should be defined");
         projectManager.load(projectId);
 
         String descriptionName;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/project/ProjectSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/project/ProjectSecurityService.java
@@ -115,9 +115,9 @@ public class ProjectSecurityService {
     }
 
     @PreAuthorize(ROLE_ADMIN + OR + ROLE_PROJECT_MANAGER)
-    public ProjectDescription upsertProjectDescription(final Long projectId, final String name,
+    public ProjectDescription upsertProjectDescription(final Long projectId, final String name, final String path,
                                                        final MultipartFile file) throws IOException {
-        return projectDescriptionService.upsert(projectId, name, file);
+        return projectDescriptionService.upsert(projectId, name, path, file);
     }
 
     @PreAuthorize(ROLE_ADMIN + OR + ROLE_PROJECT_MANAGER +  OR + "hasPermissionOnProject(#projectId, 'READ')")

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/app/Application.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/app/Application.java
@@ -256,6 +256,9 @@ public class Application {
     @Option(name = "--taxid", usage = "specifies taxonomy id")
     private Long taxId;
 
+    @Option(name = "--send-content", usage = "defines if file content should be sent directly to server")
+    private boolean sendContent;
+
     @Option(name = "--step", usage = "specifies Bam file coverage interval size")
     private Integer step;
 
@@ -368,6 +371,7 @@ public class Application {
         options.setHeatmapColumnAnnotationType(HeatmapAnnotationType.from(heatmapColumnAnnotationType));
         options.setReference(reference);
         options.setTaxId(taxId);
+        options.setSendContent(sendContent);
         options.setStep(step);
         return options;
     }

--- a/server/ngb-cli/src/main/java/com/epam/ngb/cli/app/ApplicationOptions.java
+++ b/server/ngb-cli/src/main/java/com/epam/ngb/cli/app/ApplicationOptions.java
@@ -124,6 +124,7 @@ public class ApplicationOptions {
     private HeatmapAnnotationType heatmapColumnAnnotationType;
     private String reference;
     private Long taxId;
+    private boolean sendContent;
 
     /**
      * Option for BAM file coverage registration, specifies a coverage interval size.


### PR DESCRIPTION
# Description

## Background

We need API to be able to add project description by path.
CLI add_description command should support option to send description to NGB server as binary data or to send just the description file path. In the last case NGB server has to read the file content.