### PR TITLE
[DOCS] Controls appearance management - prevent close of the last track

### DIFF
--- a/docs/md/user-guide/embedding-js.md
+++ b/docs/md/user-guide/embedding-js.md
@@ -372,6 +372,7 @@ Possible keys:
 * `vcfcolumns` (lowercased!): **Specify VCF columns to display** button
 * `vcfdownload` (lowercased!): **Download variants table** button
 * `genesdownload` (lowercased!): **Download genes table** button
+* `closelasttrack` (lowercased!) or `closeLastTrack`: hide close button for the single non-reference track
 
 The object to be passed to NGB window:
 
@@ -385,7 +386,8 @@ The object to be passed to NGB window:
     params: {
         close: false,
         maximize: true,
-        fit: false
+        fit: false,
+        closeLastTrack: false
     }
 }
 ```

--- a/docs/md/user-guide/embedding-js.md
+++ b/docs/md/user-guide/embedding-js.md
@@ -372,7 +372,7 @@ Possible keys:
 * `vcfcolumns` (lowercased!): **Specify VCF columns to display** button
 * `vcfdownload` (lowercased!): **Download variants table** button
 * `genesdownload` (lowercased!): **Download genes table** button
-* `closelasttrack` (lowercased!) or `closeLastTrack`: hide close button for the single non-reference track
+* `closelasttrack` or `closeLastTrack`: hide **Close** button for the single non-reference track
 
 The object to be passed to NGB window:
 

--- a/docs/md/user-guide/embedding-url.md
+++ b/docs/md/user-guide/embedding-url.md
@@ -58,7 +58,7 @@ http://...?screenshot=${screenshotVisibility}&toolbar=${toolbarVisibility}&layou
     * `vcfcolumns` (lowercased!): **Specify VCF columns to display** button. Accepted values: `On`, `Off`
     * `vcfdownload` (lowercased!): **Download variants table** button. Accepted values: `On`, `Off`
     * `genesdownload` (lowercased!): **Download genes table** button. Accepted values: `On`, `Off`
-    * `closelasttrack` or `closeLastTrack`: hide close button for the single non-reference track. Accepted values: `On`, `Off`
+    * `closelasttrack` or `closeLastTrack`: hide **Close** button for the single non-reference track. Accepted values: `On`, `Off`
 
 ## Examples
 

--- a/docs/md/user-guide/embedding-url.md
+++ b/docs/md/user-guide/embedding-url.md
@@ -58,6 +58,7 @@ http://...?screenshot=${screenshotVisibility}&toolbar=${toolbarVisibility}&layou
     * `vcfcolumns` (lowercased!): **Specify VCF columns to display** button. Accepted values: `On`, `Off`
     * `vcfdownload` (lowercased!): **Download variants table** button. Accepted values: `On`, `Off`
     * `genesdownload` (lowercased!): **Download genes table** button. Accepted values: `On`, `Off`
+    * `closelasttrack` or `closeLastTrack`: hide close button for the single non-reference track. Accepted values: `On`, `Off`
 
 ## Examples
 


### PR DESCRIPTION
This PR is related to the #707;

Docs (GUI JS API, GUI url format) were updated: `closeLastTrack` option for preventing the last non-reference track from being closed.
