### PR TITLE
Fix BaseEntities create and delete methods so acl aspects can be applied

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/controller/security/PermissionController.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/controller/security/PermissionController.java
@@ -39,10 +39,9 @@ import com.wordnik.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @Api(value = "Permissions")
 @ConditionalOnProperty(value = "security.acl.enable", havingValue = "true")
 public class PermissionController extends AbstractRESTController {
@@ -51,7 +50,6 @@ public class PermissionController extends AbstractRESTController {
     private AclPermissionSecurityService permissionApiService;
 
     @RequestMapping(value = "/grant", method = RequestMethod.POST)
-    @ResponseBody
     @ApiOperation(
             value = "Sets user's  permissions for an object.",
             notes = "Sets user's permissions for an object.",
@@ -64,7 +62,6 @@ public class PermissionController extends AbstractRESTController {
     }
 
     @RequestMapping(value = "/grant", method = RequestMethod.DELETE)
-    @ResponseBody
     @ApiOperation(
             value = "Deletes user's permissions for an object.",
             notes = "Deletes user's permissions for an object.",
@@ -80,7 +77,6 @@ public class PermissionController extends AbstractRESTController {
     }
 
     @RequestMapping(value = "/grant/all", method = RequestMethod.DELETE)
-    @ResponseBody
     @ApiOperation(
             value = "Deletes all permissions for an object.",
             notes = "Deletes all permissions for an object.",
@@ -94,7 +90,6 @@ public class PermissionController extends AbstractRESTController {
     }
 
     @RequestMapping(value = "/grant", method = RequestMethod.GET)
-    @ResponseBody
     @ApiOperation(
             value = "Loads all permissions for an object.",
             notes = "Loads all permissions for an object.",
@@ -108,7 +103,6 @@ public class PermissionController extends AbstractRESTController {
     }
 
     @RequestMapping(value = "grant/owner", method = RequestMethod.POST)
-    @ResponseBody
     @ApiOperation(
             value = "Change the owner of the particular acl object.",
             notes = "Change the owner of the particular acl object.",
@@ -119,5 +113,17 @@ public class PermissionController extends AbstractRESTController {
     public Result<AclSecuredEntry> changeOwner(@RequestParam Long id,
             @RequestParam AclClass aclClass, @RequestParam String userName) {
         return Result.success(permissionApiService.changeOwner(id, aclClass, userName));
+    }
+
+    @PostMapping(value = "grant/sync")
+    @ApiOperation(
+            value = "Synchronises all existing entities to ACL tables.",
+            notes = "Might be useful when security is enabled for previously registered data.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public void syncAclEntities() {
+        permissionApiService.syncEntities();
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/dao/BiologicalDataItemDao.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/dao/BiologicalDataItemDao.java
@@ -26,6 +26,7 @@ package com.epam.catgenome.dao;
 
 import static com.epam.catgenome.dao.BiologicalDataItemDao.BiologicalDataItemParameters.getRowMapper;
 import static com.epam.catgenome.entity.BiologicalDataItem.getBioDataItemId;
+import static com.epam.catgenome.util.Utils.addPagingInfoToQuery;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -56,6 +57,7 @@ import com.epam.catgenome.entity.seg.SegFile;
 import com.epam.catgenome.entity.vcf.VcfFile;
 import com.epam.catgenome.entity.wig.WigFile;
 
+import com.epam.catgenome.util.db.PagingInfo;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -90,6 +92,7 @@ public class BiologicalDataItemDao extends NamedParameterJdbcDaoSupport {
     private String loadBiologicalDataItemsByNamesStrictQuery;
     private String loadBiologicalDataItemsByNameQuery;
     private String loadBiologicalDataItemsByNameCaseInsensitiveQuery;
+    private String countBiologicalDataItemsQuery;
 
     @Autowired
     private DaoHelper daoHelper;
@@ -167,6 +170,17 @@ public class BiologicalDataItemDao extends NamedParameterJdbcDaoSupport {
         return getNamedParameterJdbcTemplate().query(loadBiologicalDataItemsQuery, getRowMapper());
     }
 
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public List<BiologicalDataItem> loadBiologicalDataItems(final PagingInfo paging) {
+        return getNamedParameterJdbcTemplate().query(addPagingInfoToQuery(loadBiologicalDataItemsQuery, paging),
+                getRowMapper());
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public Integer countBiologicalDataItems() {
+        return getJdbcTemplate().queryForObject(countBiologicalDataItemsQuery, Integer.class);
+    }
+
     @Transactional(propagation = Propagation.MANDATORY)
     public Long createBioItemId() {
         return daoHelper.createId(biologicalDataItemSequenceName);
@@ -242,7 +256,6 @@ public class BiologicalDataItemDao extends NamedParameterJdbcDaoSupport {
         return getNamedParameterJdbcTemplate().query(loadBiologicalDataItemsByNameQuery,
                 params, getRowMapper());
     }
-
 
     public enum BiologicalDataItemParameters {
         BIO_DATA_ITEM_ID,
@@ -696,5 +709,10 @@ public class BiologicalDataItemDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setUpdateOwnerQuery(String updateOwnerQuery) {
         this.updateOwnerQuery = updateOwnerQuery;
+    }
+
+    @Required
+    public void setCountBiologicalDataItemsQuery(String countBiologicalDataItemsQuery) {
+        this.countBiologicalDataItemsQuery = countBiologicalDataItemsQuery;
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/BiologicalDataItemManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/BiologicalDataItemManager.java
@@ -37,6 +37,7 @@ import com.epam.catgenome.entity.BiologicalDataItemFormat;
 import com.epam.catgenome.entity.project.Project;
 import com.epam.catgenome.manager.project.ProjectManager;
 import com.epam.catgenome.util.Utils;
+import com.epam.catgenome.util.db.PagingInfo;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -110,6 +111,16 @@ public class BiologicalDataItemManager {
     @Transactional(propagation = Propagation.SUPPORTS)
     public List<BiologicalDataItem> loadAllItems() {
         return biologicalDataItemDao.loadBiologicalDataItems();
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public List<BiologicalDataItem> loadAllItems(final PagingInfo paging) {
+        return biologicalDataItemDao.loadBiologicalDataItems(paging);
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public Integer countItems() {
+        return biologicalDataItemDao.countBiologicalDataItems();
     }
 
     /**

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamFileManager.java
@@ -76,13 +76,14 @@ public class BamFileManager implements SecuredEntityManager {
      * @param bamFile a {@code BamFile} instance to be persisted
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void create(BamFile bamFile) {
+    public BamFile create(BamFile bamFile) {
         Assert.notNull(bamFile);
         Assert.notNull(bamFile.getName());
         Assert.notNull(bamFile.getReferenceId());
         Assert.notNull(bamFile.getPath());
 
         bamFileDao.createBamFile(bamFile);
+        return bamFile;
     }
 
     /**
@@ -102,7 +103,7 @@ public class BamFileManager implements SecuredEntityManager {
      * @param bamFile a {@code BamFile} to delete
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void delete(BamFile bamFile) {
+    public BamFile delete(BamFile bamFile) {
         List<Project> projectsWhereFileInUse = projectDao.loadProjectsByBioDataItemId(bamFile.getBioDataItemId());
         Assert.isTrue(projectsWhereFileInUse.isEmpty(), MessageHelper.getMessage(MessagesConstants.ERROR_FILE_IN_USE,
                 bamFile.getName(), bamFile.getId(), projectsWhereFileInUse.stream().map(BaseEntity::getName)
@@ -112,6 +113,7 @@ public class BamFileManager implements SecuredEntityManager {
         biologicalDataItemDao.deleteBiologicalDataItem(bamFile.getIndex().getId());
         biologicalDataItemDao.deleteBiologicalDataItem(bamFile.getBioDataItemId());
         metadataManager.delete(bamFile);
+        return bamFile;
     }
 
     @Override

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedFileManager.java
@@ -75,8 +75,9 @@ public class BedFileManager implements SecuredEntityManager {
      * @param bedFile a {@code BedFile} instance to be persisted
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void create(BedFile bedFile) {
+    public BedFile create(BedFile bedFile) {
         bedFileDao.createBedFile(bedFile);
+        return bedFile;
     }
 
     /**
@@ -107,7 +108,7 @@ public class BedFileManager implements SecuredEntityManager {
      * @param bedFile BedFile to delete
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void delete(BedFile bedFile) {
+    public BedFile delete(BedFile bedFile) {
         List<Project> projectsWhereFileInUse = projectDao.loadProjectsByBioDataItemId(bedFile.getBioDataItemId());
         List<Long> genomeIdsByAnnotation = referenceGenomeDao.
                 loadGenomeIdsByAnnotationDataItemId(bedFile.getBioDataItemId());
@@ -134,6 +135,7 @@ public class BedFileManager implements SecuredEntityManager {
         biologicalDataItemDao.deleteBiologicalDataItem(bedFile.getIndex().getId());
         biologicalDataItemDao.deleteBiologicalDataItem(bedFile.getBioDataItemId());
         metadataManager.delete(bedFile);
+        return bedFile;
     }
 
     @Override

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bucket/BucketManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bucket/BucketManager.java
@@ -58,7 +58,7 @@ public class BucketManager implements SecuredEntityManager {
      * @param bucket {@code Bucket} to save
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public Bucket save(final Bucket bucket) {
+    public Bucket create(final Bucket bucket) {
         Assert.notNull(bucket, MessagesConstants.ERROR_NULL_PARAM);
         Assert.notNull(bucket.getAccessKeyId(), MessagesConstants.ERROR_NULL_PARAM);
         Assert.notNull(bucket.getBucketName(), MessagesConstants.ERROR_NULL_PARAM);
@@ -68,7 +68,6 @@ public class BucketManager implements SecuredEntityManager {
         bucketDao.createBucket(bucket);
         return bucket;
     }
-
 
     /**
      * Loads a persisted {@code Bucket} record by it's ID

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneFileManager.java
@@ -84,8 +84,9 @@ public class GeneFileManager implements SecuredEntityManager {
      * @param geneFile a {@code GeneFile} instance to be persisted
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void create(GeneFile geneFile) {
+    public GeneFile create(GeneFile geneFile) {
         geneFileDao.createGeneFile(geneFile);
+        return geneFile;
     }
 
     /**
@@ -94,7 +95,7 @@ public class GeneFileManager implements SecuredEntityManager {
      * @param geneFile a {@code GeneFile} record to remove
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void delete(GeneFile geneFile) {
+    public GeneFile delete(GeneFile geneFile) {
         List<Project> projectsWhereFileInUse = projectDao.loadProjectsByBioDataItemId(geneFile.getBioDataItemId());
         List<Long> genomeIdsByAnnotation = referenceGenomeDao.
                 loadGenomeIdsByAnnotationDataItemId(geneFile.getBioDataItemId());
@@ -119,6 +120,7 @@ public class GeneFileManager implements SecuredEntityManager {
         biologicalDataItemDao.deleteBiologicalDataItem(geneFile.getIndex().getId());
         biologicalDataItemDao.deleteBiologicalDataItem(geneFile.getBioDataItemId());
         metadataManager.delete(geneFile);
+        return geneFile;
     }
 
     /**
@@ -176,5 +178,4 @@ public class GeneFileManager implements SecuredEntityManager {
     public Long createGeneFileId() {
         return geneFileDao.createGeneFileId();
     }
-
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/maf/MafFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/maf/MafFileManager.java
@@ -70,8 +70,9 @@ public class MafFileManager implements SecuredEntityManager {
      * @param mafFile instance to create
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void create(MafFile mafFile) {
+    public MafFile create(MafFile mafFile) {
         mafFileDao.createMafFile(mafFile);
+        return mafFile;
     }
 
     /**
@@ -123,7 +124,7 @@ public class MafFileManager implements SecuredEntityManager {
      * @param mafFile {@code MafFile} ID to delete
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void deleteMafFile(final MafFile mafFile) {
+    public MafFile delete(final MafFile mafFile) {
         List<Project> projectsWhereFileInUse = projectDao.loadProjectsByBioDataItemId(mafFile.getBioDataItemId());
         Assert.isTrue(projectsWhereFileInUse.isEmpty(), MessageHelper.getMessage(
                 MessagesConstants.ERROR_FILE_IN_USE, mafFile.getName(), mafFile.getId(),
@@ -132,5 +133,6 @@ public class MafFileManager implements SecuredEntityManager {
         biologicalDataItemDao.deleteBiologicalDataItem(mafFile.getIndex().getId());
         biologicalDataItemDao.deleteBiologicalDataItem(mafFile.getBioDataItemId());
         metadataManager.delete(mafFile);
+        return mafFile;
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/maf/MafManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/maf/MafManager.java
@@ -179,7 +179,7 @@ public class MafManager {
         MafFile fileToDelete = mafFileManager.load(mafFileId);
         Assert.notNull(fileToDelete, MessagesConstants.ERROR_NO_SUCH_FILE);
 
-        mafFileManager.deleteMafFile(fileToDelete);
+        mafFileManager.delete(fileToDelete);
         fileManager.deleteFeatureFileDirectory(fileToDelete);
 
         return fileToDelete;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/project/ProjectManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/project/ProjectManager.java
@@ -380,7 +380,7 @@ public class ProjectManager implements SecuredEntityManager {
      *                             with nested projects
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public Project deleteProject(final Long projectId, final Boolean force) throws IOException {
+    public Project delete(final Long projectId, final Boolean force) throws IOException {
         // Throws an error if there is no such project
         final Project projectToDelete = this.load(projectId);
         //if force flag is disabled that we can't delete parent project

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/project/ProjectSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/project/ProjectSecurityService.java
@@ -111,7 +111,7 @@ public class ProjectSecurityService {
 
     @PreAuthorize(ROLE_ADMIN + OR + "projectCanBeDeleted(#projectId, #force)")
     public Project deleteProject(long projectId, Boolean force) throws IOException {
-        return projectManager.deleteProject(projectId, force);
+        return projectManager.delete(projectId, force);
     }
 
     @PreAuthorize(ROLE_ADMIN + OR + ROLE_PROJECT_MANAGER)

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/BookmarkManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/BookmarkManager.java
@@ -137,11 +137,12 @@ public class BookmarkManager implements SecuredEntityManager {
      * @param bookmarkId {@code Long} an ID of a bookmark to delete
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void delete(Long bookmarkId) {
+    public Bookmark delete(Long bookmarkId) {
         Bookmark bookmark = bookmarkDao.loadBookmarkById(bookmarkId);
         Assert.notNull(bookmark);
         bookmarkDao.deleteBookmarkItems(bookmarkId);
         bookmarkDao.deleteBookmark(bookmarkId);
+        return bookmark;
     }
 
     /**
@@ -172,5 +173,4 @@ public class BookmarkManager implements SecuredEntityManager {
     public AclClass getSupportedClass() {
         return AclClass.BOOKMARK;
     }
-
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceGenomeManager.java
@@ -151,7 +151,7 @@ public class ReferenceGenomeManager implements SecuredEntityManager {
      * @param reference an instnce to delete
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void delete(final Reference reference) {
+    public Reference delete(final Reference reference) {
         Assert.notNull(reference, MessagesConstants.ERROR_INVALID_PARAM);
         Assert.notNull(reference.getId(), MessagesConstants.ERROR_INVALID_PARAM);
 
@@ -169,6 +169,7 @@ public class ReferenceGenomeManager implements SecuredEntityManager {
         referenceGenomeDao.unregisterReferenceGenome(reference.getId());
         biologicalDataItemDao.deleteBiologicalDataItem(reference.getBioDataItemId());
         metadataManager.delete(reference);
+        return reference;
     }
 
     /**

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/seg/SegFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/seg/SegFileManager.java
@@ -72,7 +72,7 @@ public class SegFileManager implements SecuredEntityManager {
      * @param segFile to save
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void create(SegFile segFile) {
+    public SegFile create(SegFile segFile) {
         if (segFile.getBioDataItemId() == null) {
             long realId = segFile.getId();
             biologicalDataItemDao.createBiologicalDataItem(segFile);
@@ -81,6 +81,7 @@ public class SegFileManager implements SecuredEntityManager {
             segFileDao.createSegFile(segFile);
         }
         segFileDao.createSamples(segFile.getSamples(), segFile.getId());
+        return segFile;
     }
 
     /**
@@ -116,7 +117,7 @@ public class SegFileManager implements SecuredEntityManager {
      * @param segFile to delete
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void delete(SegFile segFile) {
+    public SegFile delete(SegFile segFile) {
         List<Project> projectsWhereFileInUse = projectDao.loadProjectsByBioDataItemId(segFile.getBioDataItemId());
         Assert.isTrue(projectsWhereFileInUse.isEmpty(), MessageHelper.getMessage(MessagesConstants.ERROR_FILE_IN_USE,
                 segFile.getName(), segFile.getId(), projectsWhereFileInUse.stream().map(BaseEntity::getName)
@@ -127,6 +128,7 @@ public class SegFileManager implements SecuredEntityManager {
         biologicalDataItemDao.deleteBiologicalDataItem(segFile.getIndex().getId());
         biologicalDataItemDao.deleteBiologicalDataItem(segFile.getBioDataItemId());
         metadataManager.delete(segFile);
+        return segFile;
     }
 
     @Override
@@ -142,5 +144,4 @@ public class SegFileManager implements SecuredEntityManager {
     public AclClass getSupportedClass() {
         return AclClass.SEG;
     }
-
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfFileManager.java
@@ -139,7 +139,7 @@ public class VcfFileManager implements SecuredEntityManager {
      * @param vcfFile file to delete
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void deleteVcfFile(final VcfFile vcfFile) {
+    public VcfFile delete(final VcfFile vcfFile) {
         Assert.notNull(vcfFile, MessagesConstants.ERROR_INVALID_PARAM);
         Assert.notNull(vcfFile.getId(), MessagesConstants.ERROR_INVALID_PARAM);
 
@@ -152,6 +152,7 @@ public class VcfFileManager implements SecuredEntityManager {
         biologicalDataItemDao.deleteBiologicalDataItem(vcfFile.getIndex().getId());
         biologicalDataItemDao.deleteBiologicalDataItem(vcfFile.getBioDataItemId());
         metadataManager.delete(vcfFile);
+        return vcfFile;
     }
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -242,7 +242,7 @@ public class VcfManager {
         Assert.isTrue(vcfFileId > 0, MessagesConstants.ERROR_INVALID_PARAM);
         final VcfFile vcfFile = vcfFileManager.load(vcfFileId);
         Assert.notNull(vcfFile, MessagesConstants.ERROR_NO_SUCH_FILE);
-        vcfFileManager.deleteVcfFile(vcfFile);
+        vcfFileManager.delete(vcfFile);
         if (vcfFile.getType() == BiologicalDataItemResourceType.GA4GH) {
             return vcfFile;
         }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/FacadeWigManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/FacadeWigManager.java
@@ -161,7 +161,7 @@ public class FacadeWigManager {
 
             prepareWigFileToWork(wigFile);
 
-            wigFileManager.save(wigFile);
+            wigFileManager.create(wigFile);
         } catch (IOException e) {
             throw new RegistrationException(getMessage(MessagesConstants.ERROR_REGISTER_FILE, request.getName()), e);
         } finally {
@@ -277,5 +277,4 @@ public class FacadeWigManager {
             return new WigProcessor(biologicalDataItemManager, fileManager);
         }
     }
-
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/WigFileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/WigFileManager.java
@@ -79,14 +79,14 @@ public class WigFileManager implements SecuredEntityManager {
      * @param wigFile a {@code WigFile} instance to be persisted
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void save(WigFile wigFile) {
-
+    public WigFile create(WigFile wigFile) {
         Assert.notNull(wigFile.getName());
         Assert.notNull(wigFile.getReferenceId());
         Assert.notNull(wigFile.getPath());
         Assert.notNull(wigFile.getType());
         Assert.notNull(wigFile.getFormat());
         wigFileDao.createWigFile(wigFile);
+        return wigFile;
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -111,7 +111,7 @@ public class WigFileManager implements SecuredEntityManager {
      * @param wigFile to delete
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void delete(WigFile wigFile) {
+    public WigFile delete(WigFile wigFile) {
         List<Project> projectsWhereFileInUse = projectDao.loadProjectsByBioDataItemId(wigFile.getBioDataItemId());
         Assert.isTrue(projectsWhereFileInUse.isEmpty(), MessageHelper.getMessage(MessagesConstants.ERROR_FILE_IN_USE,
                 wigFile.getName(), wigFile.getId(), projectsWhereFileInUse.stream().map(BaseEntity::getName)
@@ -123,6 +123,7 @@ public class WigFileManager implements SecuredEntityManager {
             biologicalDataItemDao.deleteBiologicalDataItem(wigFile.getIndex().getId());
         }
         metadataManager.delete(wigFile);
+        return wigFile;
     }
 
     @Override
@@ -138,5 +139,4 @@ public class WigFileManager implements SecuredEntityManager {
     public AclClass getSupportedClass() {
         return AclClass.WIG;
     }
-
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/security/acl/AclPermissionSecurityService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/security/acl/AclPermissionSecurityService.java
@@ -72,4 +72,9 @@ public class AclPermissionSecurityService {
     public AclSecuredEntry changeOwner(Long id, AclClass aclClass, String userName) {
         return permissionManager.changeOwner(id, aclClass, userName);
     }
+
+    @PreAuthorize(ROLE_ADMIN)
+    public void syncEntities() {
+        permissionManager.syncEntities();
+    }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/security/acl/JdbcMutableAclServiceImpl.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/security/acl/JdbcMutableAclServiceImpl.java
@@ -134,12 +134,12 @@ public class JdbcMutableAclServiceImpl extends JdbcMutableAclService {
 
     public MutableAcl getAcl(AbstractSecuredEntity securedEntity) {
         ObjectIdentity identity = new ObjectIdentityImpl(securedEntity);
-        if (retrieveObjectIdentityPrimaryKey(identity) != null) {
+        try {
             Acl acl = readAclById(identity);
             Assert.isInstanceOf(MutableAcl.class, acl, MessageHelper.getMessage(
                     MessagesConstants.ERROR_MUTABLE_ACL_RETURN));
             return (MutableAcl) acl;
-        } else {
+        } catch (NotFoundException e) {
             return null;
         }
     }

--- a/server/catgenome/src/main/java/com/epam/catgenome/security/acl/aspect/AclAspect.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/security/acl/aspect/AclAspect.java
@@ -167,5 +167,4 @@ public class AclAspect {
             aclService.updateAcl(acl);
         }
     }
-
 }

--- a/server/catgenome/src/main/resources/conf/catgenome/dao/biological-data-item-dao.xml
+++ b/server/catgenome/src/main/resources/conf/catgenome/dao/biological-data-item-dao.xml
@@ -736,5 +736,15 @@
                 ]]>
             </value>
         </property>
+        <property name="countBiologicalDataItemsQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        count(*)
+                    FROM
+                        catgenome.biological_data_item b
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/bam/BamManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/bam/BamManagerTest.java
@@ -503,7 +503,7 @@ public class BamManagerTest extends AbstractManagerTest {
         bucket.setBucketName(s3BucketName);
         bucket.setAccessKeyId(s3AccessKey);
         bucket.setSecretAccessKey(s3SecretKey);
-        bucketManager.save(bucket);
+        bucketManager.create(bucket);
 
         IndexedFileRegistrationRequest request = new IndexedFileRegistrationRequest();
         request.setPath(s3FilePath);

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/bucket/BucketManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/bucket/BucketManagerTest.java
@@ -68,7 +68,7 @@ public class BucketManagerTest extends AbstractManagerTest {
         bucket.setSecretAccessKey(SECRET_KEY);
         bucket.setBucketName(BUCKET_NAME);
         bucket.setAccessKeyId(ACCESS_KEY);
-        bucket = bucketManager.save(bucket);
+        bucket = bucketManager.create(bucket);
 
         final Bucket loadBucket = bucketManager.load(bucket.getId());
 

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/lineage/LineageManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/lineage/LineageManagerTest.java
@@ -79,7 +79,7 @@ public class LineageManagerTest extends TestCase {
 
     @After
     public void teardown() throws IOException {
-        projectManager.deleteProject(project.getId(), true);
+        projectManager.delete(project.getId(), true);
     }
 
     @Test

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/project/ProjectManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/project/ProjectManagerTest.java
@@ -213,7 +213,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
                 .get(0)), item.getId());
 
         // Now delete project
-        projectManager.deleteProject(project.getId(), false);
+        projectManager.delete(project.getId(), false);
         try {
             projectManager.load(project.getId());
             Assert.fail("No exception happened, but should happen");
@@ -283,7 +283,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
         // check that we cannot delete parent dataset without force option
         boolean catchException = false;
         try {
-            projectManager.deleteProject(root.getId(), false);
+            projectManager.delete(root.getId(), false);
         } catch (IllegalArgumentException e) {
             catchException = true;
         }
@@ -292,7 +292,7 @@ public class ProjectManagerTest extends AbstractManagerTest {
         }
 
         // check that we can delete parent dataset with force option
-        projectManager.deleteProject(root.getId(), true);
+        projectManager.delete(root.getId(), true);
         assertNullLoadProjectWithNested(root);
     }
 


### PR DESCRIPTION
# Description

## Background

Application can't get ACLs for objects because they are not created during entities registration.
