### PR TITLE
Issue 828 Wrong index is created for compressed VCF stored in Azure Blob storage

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -815,7 +815,8 @@ public class VcfManager {
         final String fileName = FilenameUtils.getName(request.getPath());
 
         vcfFile.setCompressed((resourceType == BiologicalDataItemResourceType.FILE
-                || resourceType == BiologicalDataItemResourceType.S3) && IOHelper.isGZIPFile(fileName));
+                || resourceType == BiologicalDataItemResourceType.S3
+                || resourceType == BiologicalDataItemResourceType.AZ) && IOHelper.isGZIPFile(fileName));
         vcfFile.setName(request.getName() != null ? request.getName() : fileName);
         vcfFile.setPrettyName(request.getPrettyName());
         vcfFile.setId(vcfFileManager.createVcfFileId());


### PR DESCRIPTION
**Background**
[Wrong index is created for compressed VCF stored in Azure Blob storage](https://github.com/epam/NGB/issues/828)

