### PR TITLE
issue #844 improve search dataitem queries

### DIFF
--- a/server/catgenome/src/main/resources/conf/catgenome/dao/biological-data-item-dao.xml
+++ b/server/catgenome/src/main/resources/conf/catgenome/dao/biological-data-item-dao.xml
@@ -155,12 +155,7 @@
                         LEFT JOIN catgenome.lineage_tree l ON l.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.pathway pw ON pw.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.biological_data_item i ON
-                                i.bio_data_item_id = m.index_id
-                                OR i.bio_data_item_id = g.index_id
-                                OR i.bio_data_item_id = v.index_id
-                                OR i.bio_data_item_id = bd.index_id
-                                OR i.bio_data_item_id = s.index_id
-                                OR i.bio_data_item_id = r.index_id
+                                i.bio_data_item_id = COALESCE(m.index_id, g.index_id, v.index_id, bd.index_id, s.index_id, r.index_id)
                     WHERE b.bio_data_item_id IN @in@
                 ]]>
             </value>
@@ -268,12 +263,7 @@
                         LEFT JOIN catgenome.lineage_tree l ON l.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.pathway pw ON pw.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.biological_data_item i ON
-                                i.bio_data_item_id = m.index_id
-                                OR i.bio_data_item_id = g.index_id
-                                OR i.bio_data_item_id = v.index_id
-                                OR i.bio_data_item_id = bd.index_id
-                                OR i.bio_data_item_id = s.index_id
-                                OR i.bio_data_item_id = r.index_id
+                                i.bio_data_item_id = COALESCE(m.index_id, g.index_id, v.index_id, bd.index_id, s.index_id, r.index_id)
                 ]]>
             </value>
         </property>
@@ -387,12 +377,7 @@
                         LEFT JOIN catgenome.lineage_tree l ON l.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.pathway pw ON pw.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.biological_data_item i ON
-                                i.bio_data_item_id = m.index_id
-                                OR i.bio_data_item_id = g.index_id
-                                OR i.bio_data_item_id = v.index_id
-                                OR i.bio_data_item_id = bd.index_id
-                                OR i.bio_data_item_id = s.index_id
-                                OR i.bio_data_item_id = r.index_id
+                                i.bio_data_item_id = COALESCE(m.index_id, g.index_id, v.index_id, bd.index_id, s.index_id, r.index_id)
                     WHERE b.name = :NAME
                 ]]>
             </value>
@@ -500,12 +485,7 @@
                         LEFT JOIN catgenome.lineage_tree l ON l.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.pathway pw ON pw.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.biological_data_item i ON
-                                i.bio_data_item_id = m.index_id
-                                OR i.bio_data_item_id = g.index_id
-                                OR i.bio_data_item_id = v.index_id
-                                OR i.bio_data_item_id = bd.index_id
-                                OR i.bio_data_item_id = s.index_id
-                                OR i.bio_data_item_id = r.index_id
+                                i.bio_data_item_id = COALESCE(m.index_id, g.index_id, v.index_id, bd.index_id, s.index_id, r.index_id)
                     WHERE b.name IN @in@
                 ]]>
             </value>
@@ -613,12 +593,7 @@
                         LEFT JOIN catgenome.lineage_tree l ON l.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.pathway pw ON pw.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.biological_data_item i ON
-                                i.bio_data_item_id = m.index_id
-                                OR i.bio_data_item_id = g.index_id
-                                OR i.bio_data_item_id = v.index_id
-                                OR i.bio_data_item_id = bd.index_id
-                                OR i.bio_data_item_id = s.index_id
-                                OR i.bio_data_item_id = r.index_id
+                                i.bio_data_item_id = COALESCE(m.index_id, g.index_id, v.index_id, bd.index_id, s.index_id, r.index_id)
                     WHERE LOWER(b.name) = :NAME
                 ]]>
             </value>
@@ -726,12 +701,7 @@
                         LEFT JOIN catgenome.lineage_tree l ON l.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.pathway pw ON pw.bio_data_item_id = b.bio_data_item_id
                         LEFT JOIN catgenome.biological_data_item i ON
-                                i.bio_data_item_id = m.index_id
-                                OR i.bio_data_item_id = g.index_id
-                                OR i.bio_data_item_id = v.index_id
-                                OR i.bio_data_item_id = bd.index_id
-                                OR i.bio_data_item_id = s.index_id
-                                OR i.bio_data_item_id = r.index_id
+                                i.bio_data_item_id = COALESCE(m.index_id, g.index_id, v.index_id, bd.index_id, s.index_id, r.index_id)
                     WHERE LOWER(b.name) LIKE :NAME
                 ]]>
             </value>

--- a/server/catgenome/src/test/java/com/epam/catgenome/dao/BiologicalDataItemDaoTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/dao/BiologicalDataItemDaoTest.java
@@ -61,6 +61,8 @@ import com.epam.catgenome.manager.gene.GeneFileManager;
 @ContextConfiguration({"classpath:applicationContext-test.xml"})
 public class BiologicalDataItemDaoTest extends AbstractTransactionalJUnit4SpringContextTests {
     private static final String TEST_OWNER = "TEST_USER";
+    public static final String TEST_GENE_FILE_NAME = "testGeneFile";
+    public static final String TEST_GENE_FILE_NAME_2 = "testGeneFile2";
 
     @Autowired
     private BiologicalDataItemDao biologicalDataItemDao;
@@ -102,7 +104,7 @@ public class BiologicalDataItemDaoTest extends AbstractTransactionalJUnit4Spring
         biologicalDataItemDao.createBiologicalDataItem(item);
 
         Reference reference = createTestReference(item);
-        GeneFile geneFile = createTestGeneFile(reference);
+        GeneFile geneFile = createTestGeneFile(reference, TEST_GENE_FILE_NAME);
         referenceGenomeDao.updateReferenceGeneFileId(reference.getId(), geneFile.getId());
 
         List<BiologicalDataItem> loadedItems = biologicalDataItemDao.loadBiologicalDataItemsByIds(Collections
@@ -136,7 +138,7 @@ public class BiologicalDataItemDaoTest extends AbstractTransactionalJUnit4Spring
         biologicalDataItemDao.createBiologicalDataItem(item);
 
         Reference reference = createTestReference(item);
-        GeneFile geneFile = createTestGeneFile(reference);
+        GeneFile geneFile = createTestGeneFile(reference, TEST_GENE_FILE_NAME);
         referenceGenomeDao.updateReferenceGeneFileId(reference.getId(), geneFile.getId());
 
         List<BiologicalDataItem> loadedItems = biologicalDataItemDao.loadFilesByNameStrict(TEST_NAME);
@@ -171,7 +173,7 @@ public class BiologicalDataItemDaoTest extends AbstractTransactionalJUnit4Spring
         biologicalDataItemDao.createBiologicalDataItem(item);
 
         Reference reference = createTestReference(item);
-        GeneFile geneFile = createTestGeneFile(reference);
+        GeneFile geneFile = createTestGeneFile(reference, TEST_GENE_FILE_NAME);
         referenceGenomeDao.updateReferenceGeneFileId(reference.getId(), geneFile.getId());
 
         for (final String match : MATCHING_NAMES) {
@@ -185,11 +187,67 @@ public class BiologicalDataItemDaoTest extends AbstractTransactionalJUnit4Spring
         }
     }
 
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void testSearchNotStrictProperLoadAllFields() {
+        BiologicalDataItem item = new BiologicalDataItem();
+        item.setName(TEST_NAME);
+        item.setPath(TEST_PATH);
+        item.setSource(TEST_PATH);
+        item.setFormat(BiologicalDataItemFormat.REFERENCE);
+        item.setType(BiologicalDataItemResourceType.FILE);
+        item.setCreatedDate(new Date());
+        item.setOwner(TEST_OWNER);
+
+        biologicalDataItemDao.createBiologicalDataItem(item);
+
+        Reference reference = createTestReference(item);
+        GeneFile geneFile = createTestGeneFile(reference, TEST_GENE_FILE_NAME);
+        GeneFile geneFile2 = createTestGeneFile(reference, TEST_GENE_FILE_NAME_2);
+
+        List<BiologicalDataItem> loadedItems = biologicalDataItemDao.loadFilesByName(TEST_GENE_FILE_NAME);
+        Assert.assertFalse(loadedItems.isEmpty());
+        Assert.assertEquals(2, loadedItems.size());
+
+        final GeneFile foundGeneFile = loadedItems.stream()
+                .filter(bdi -> bdi.getName().equals(TEST_GENE_FILE_NAME)).findFirst()
+                .map(bdi -> (GeneFile) bdi)
+                .orElseThrow(IllegalStateException::new);
+        compareTwoBioDataItems(geneFile, foundGeneFile, () -> compareTwoGeneFiles(geneFile, foundGeneFile));
+
+        final GeneFile foundGeneFile2 = loadedItems.stream()
+                .filter(bdi -> bdi.getName().equals(TEST_GENE_FILE_NAME_2)).findFirst()
+                .map(bdi -> (GeneFile) bdi)
+                .orElseThrow(IllegalStateException::new);
+        compareTwoBioDataItems(geneFile2, foundGeneFile2, () -> compareTwoGeneFiles(geneFile2, foundGeneFile2));
+    }
+
+    private void compareTwoBioDataItems(final BiologicalDataItem expected, final BiologicalDataItem actual,
+                                        final Runnable additionalCheck) {
+        Assert.assertEquals(expected.getId(), actual.getId());
+        Assert.assertEquals(expected.getPath(), actual.getPath());
+        Assert.assertEquals(expected.getName(), actual.getName());
+        Assert.assertEquals(expected.getFormat(), actual.getFormat());
+        additionalCheck.run();
+    }
+
+    private void compareTwoGeneFiles(GeneFile expected, GeneFile actual) {
+        BiologicalDataItem expectedIndex = expected.getIndex();
+        BiologicalDataItem actualIndex = actual.getIndex();
+        Assert.assertEquals(expectedIndex != null, actualIndex != null);
+        if (expectedIndex != null) {
+            Assert.assertEquals(expectedIndex.getId(), actualIndex.getId());
+            Assert.assertEquals(expectedIndex.getPath(), actualIndex.getPath());
+            Assert.assertEquals(expectedIndex.getName(), actualIndex.getName());
+            Assert.assertEquals(expectedIndex.getFormat(), actualIndex.getFormat());
+        }
+    }
+
     private Reference createTestReference(BiologicalDataItem item) {
         Reference reference = new Reference();
 
         reference.setSize(1L);
-        reference.setName("testReference");
+        reference.setName(item.getName());
         reference.setPath(TEST_PATH);
         reference.setSource(TEST_PATH);
         reference.setType(BiologicalDataItemResourceType.FILE);
@@ -204,7 +262,7 @@ public class BiologicalDataItemDaoTest extends AbstractTransactionalJUnit4Spring
         return referenceGenomeDao.createReferenceGenome(reference, referenceGenomeDao.createReferenceGenomeId());
     }
 
-    private GeneFile createTestGeneFile(Reference reference) {
+    private GeneFile createTestGeneFile(Reference reference, String geneFileName) {
         BiologicalDataItem indexItem = new BiologicalDataItem();
         indexItem.setCreatedDate(new Date());
         indexItem.setPath(TEST_PATH);
@@ -218,7 +276,7 @@ public class BiologicalDataItemDaoTest extends AbstractTransactionalJUnit4Spring
 
         GeneFile geneFile = new GeneFile();
         geneFile.setId(geneFileManager.createGeneFileId());
-        geneFile.setName("testGeneFile");
+        geneFile.setName(geneFileName);
         geneFile.setCompressed(false);
         geneFile.setPath(TEST_PATH);
         geneFile.setSource(TEST_PATH);


### PR DESCRIPTION
# Description

## Background

Related to #844. 

## Changes

Improving search queries by ridding off `JOIN` with several `OR` (such combination will force full table scan for each joined row) in favor to `COALESCE` function.