### PR TITLE
Issue 849 Launching target identification - fixes

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/target/opentargets/DiseaseAssociationManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/externaldb/target/opentargets/DiseaseAssociationManager.java
@@ -29,7 +29,7 @@ import com.epam.catgenome.entity.externaldb.target.opentargets.Disease;
 import com.epam.catgenome.entity.externaldb.target.opentargets.DiseaseAssociation;
 import com.epam.catgenome.manager.externaldb.target.AbstractAssociationManager;
 import com.epam.catgenome.manager.index.Filter;
-import com.epam.catgenome.manager.index.SortInfo;
+import com.epam.catgenome.manager.index.OrderInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -217,17 +217,17 @@ public class DiseaseAssociationManager extends AbstractAssociationManager<Diseas
     }
 
     @Override
-    public Sort getSort(final List<SortInfo> sortInfos) {
+    public Sort getSort(final List<OrderInfo> orderInfos) {
         final List<SortField> sortFields = new ArrayList<>();
-        if (sortInfos == null) {
+        if (orderInfos == null) {
             sortFields.add(new SortField(getDefaultSortField(), SortField.Type.STRING, false));
         } else {
-            for (SortInfo sortInfo: sortInfos) {
-                final SortField.Type sortType = sortInfo.getOrderBy().equals(IndexFields.DISEASE_NAME.name())
-                        || sortInfo.getOrderBy().equals(IndexFields.GENE_ID.name()) ?
+            for (OrderInfo orderInfo : orderInfos) {
+                final SortField.Type sortType = orderInfo.getOrderBy().equals(IndexFields.DISEASE_NAME.name())
+                        || orderInfo.getOrderBy().equals(IndexFields.GENE_ID.name()) ?
                         SortField.Type.STRING : SortField.Type.FLOAT;
-                final SortField sortField = new SortField(sortInfo.getOrderBy(),
-                        sortType, sortInfo.isReverse());
+                final SortField sortField = new SortField(orderInfo.getOrderBy(),
+                        sortType, orderInfo.isReverse());
                 sortFields.add(sortField);
             }
         }
@@ -238,8 +238,7 @@ public class DiseaseAssociationManager extends AbstractAssociationManager<Diseas
     public void addFieldQuery(final BooleanQuery.Builder builder, final Filter filter) {
         final BooleanQuery.Builder fieldBuilder = new BooleanQuery.Builder();
         for (String term: filter.getTerms()) {
-            Query query = IndexFields.GENE_ID.name().equals(filter.getField()) ||
-                    IndexFields.DISEASE_NAME.name().equals(filter.getField()) ?
+            Query query = IndexFields.DISEASE_NAME.name().equals(filter.getField()) ?
                     buildPrefixQuery(filter.getField(), term) : buildTermQuery(filter.getField(), term);
             fieldBuilder.add(query, BooleanClause.Occur.SHOULD);
         }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/index/AbstractIndexManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/index/AbstractIndexManager.java
@@ -75,7 +75,7 @@ public abstract class AbstractIndexManager<T> {
         try (Directory index = new SimpleFSDirectory(Paths.get(indexDirectory));
              IndexReader indexReader = DirectoryReader.open(index)) {
             IndexSearcher searcher = new IndexSearcher(indexReader);
-            TopDocs topDocs = searcher.search(query, hits, getSort(request.getSortInfos()));
+            TopDocs topDocs = searcher.search(query, hits, getSort(request.getOrderInfos()));
             ScoreDoc[] scoreDocs = topDocs.scoreDocs;
 
             final int from = (page - 1) * pageSize;
@@ -142,14 +142,14 @@ public abstract class AbstractIndexManager<T> {
         }
     }
 
-    public Sort getSort(final List<SortInfo> sortInfos) {
+    public Sort getSort(final List<OrderInfo> orderInfos) {
         final List<SortField> sortFields = new ArrayList<>();
-        if (sortInfos == null) {
+        if (orderInfos == null) {
             sortFields.add(new SortField(getDefaultSortField(), SortField.Type.STRING, false));
         } else {
-            for (SortInfo sortInfo: sortInfos) {
-                final SortField sortField = new SortField(sortInfo.getOrderBy(),
-                        SortField.Type.STRING, sortInfo.isReverse());
+            for (OrderInfo orderInfo : orderInfos) {
+                final SortField sortField = new SortField(orderInfo.getOrderBy(),
+                        SortField.Type.STRING, orderInfo.isReverse());
                 sortFields.add(sortField);
             }
         }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/index/OrderInfo.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/index/OrderInfo.java
@@ -28,7 +28,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class SortInfo {
+public class OrderInfo {
     private String orderBy;
     private boolean reverse;
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/index/SearchRequest.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/index/SearchRequest.java
@@ -39,6 +39,6 @@ import java.util.List;
 public class SearchRequest {
     private Integer page;
     private Integer pageSize;
-    private List<SortInfo> sortInfos;
+    private List<OrderInfo> orderInfos;
     private List<Filter> filters;
 }


### PR DESCRIPTION
# Description

## Background
[Launching target identification #849](https://github.com/epam/NGB/issues/849)

## Changes
- OpenTargets filtering by gene ids

- SortInfo -> OrderInfo due to fix sort data model in swagger 