### PR TITLE
Gui target identification filter empty values

### DIFF
--- a/client/client/app/components/ngbTargetPanel/ngbDiseasesTab/ngbDiseasesDrugsPanel/ngbDiseasesDrugsPanel.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbDiseasesTab/ngbDiseasesDrugsPanel/ngbDiseasesDrugsPanel.service.js
@@ -189,6 +189,9 @@ export default class ngbDiseasesDrugsPanelService {
                                 const number = unRomanize(v);
                                 return number ? number : '';
                             }
+                            if (v === 'Empty value') {
+                                return '';
+                            }
                             return v;
                         })
                     };
@@ -249,8 +252,8 @@ export default class ngbDiseasesDrugsPanelService {
         const list = this.filterFields;
         for (let i = 0; i < entries.length; i++) {
             const key = entries[i][0];
-            const values = entries[i][1].filter(v => v);
-            const field = list[key]
+            const values = entries[i][1].map(v => !v ? 'Empty value' : v);
+            const field = list[key];
             if (field === 'phase') {
                 this.fieldList[field] = values.map(v => romanize(v));
             } else {

--- a/client/client/app/components/ngbTargetPanel/ngbDiseasesTab/ngbDiseasesTargetsPanel/ngbDiseasesTargetsPanel.controller.js
+++ b/client/client/app/components/ngbTargetPanel/ngbDiseasesTab/ngbDiseasesTargetsPanel/ngbDiseasesTargetsPanel.controller.js
@@ -198,6 +198,8 @@ export default class ngbDiseasesTargetsPanelController {
                         ...columnSettings,
                         cellTemplate: homologueCell,
                         enableFiltering: true,
+                        enableSorting: false,
+                        enableColumnMenu: false,
                     };
                     break;
                 default:

--- a/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbKnownDrugsPanel/ngbDrugsTable/ngbDrugsTable.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbKnownDrugsPanel/ngbDrugsTable/ngbDrugsTable.service.js
@@ -300,6 +300,9 @@ export default class ngbDrugsTableService {
                                 const chip = this.ngbTargetPanelService.getGeneIdByChip(v);
                                 return chip ? chip : '';
                             }
+                            if (v === 'Empty value') {
+                                return '';
+                            }
                             return v;
                         })
                     };
@@ -353,8 +356,8 @@ export default class ngbDrugsTableService {
         const list = this.filterFieldsList;
         for (let i = 0; i < entries.length; i++) {
             const key = entries[i][0];
-            const values = entries[i][1].filter(v => v);
-            const field = list[source][key]
+            const values = entries[i][1].map(v => v ? v : 'Empty value');
+            const field = list[source][key];
             if (field === 'phase') {
                 this.fieldList[field] = values.map(v => romanize(v));
             } else {


### PR DESCRIPTION
This PR:
- removes sorting for homologues column in diseases targets table;
- added empty value item for filter dropdown list.