### PR TITLE
GUI targetId for requests

### DIFF
--- a/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbBibliographyPanel/ngbBibliographyPanel.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbBibliographyPanel/ngbBibliographyPanel.service.js
@@ -107,6 +107,10 @@ export default class NgbBibliographyPanelService {
         this.updateGenes(ngbTargetPanelService.identificationTarget);
     }
 
+    get targetId() {
+        return this.ngbTargetPanelService.targetId;
+    }
+
     get genes() {
         return this._genes;
     }
@@ -131,7 +135,7 @@ export default class NgbBibliographyPanelService {
     }
 
     getPublicationsResults() {
-        if (!this.genes.length) {
+        if (!this.targetId || !this.genes.length) {
             return new Promise(resolve => {
                 this._loadingPublications = false;
                 this.dispatcher.emit('target:identification:publications:loaded');
@@ -144,6 +148,7 @@ export default class NgbBibliographyPanelService {
         const commit = this._getPublicationsCommitPhase();
         return new Promise(resolve => {
             this.targetDataService.getPublications({
+                targetId: this.targetId,
                 geneIds: this.genes,
                 page: this.currentPage,
                 pageSize: this.pageSize

--- a/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbDiseasesPanel/ngbDiseasesPanel.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbDiseasesPanel/ngbDiseasesPanel.service.js
@@ -85,14 +85,23 @@ class NgbDiseasesPanelService {
         return this.ngbTargetPanelService.translationalGeneIds;
     }
 
+    get targetId() {
+        return this.ngbTargetPanelService.targetId;
+    }
+
     exportResults() {
         const source = this.exportSource[this.sourceModel];
-        if (!this.geneIdsOfInterest || !this.translationalGeneIds) {
+        if (!this.targetId || !this.geneIdsOfInterest || !this.translationalGeneIds) {
             return new Promise(resolve => {
                 resolve(true);
             });
         }
-        return this.targetDataService.getTargetExport(this.geneIdsOfInterest, this.translationalGeneIds, source);
+        return this.targetDataService.getTargetExport(
+            this.targetId,
+            this.geneIdsOfInterest,
+            this.translationalGeneIds,
+            source
+        );
     }
 }
 

--- a/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbGenomicsPanel/ngbGenomicsPanel.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbGenomicsPanel/ngbGenomicsPanel.service.js
@@ -88,6 +88,10 @@ export default class ngbGenomicsPanelService {
         dispatcher.on('target:identification:changed', this.resetData.bind(this));
     }
 
+    get targetId() {
+        return this.ngbTargetPanelService.targetId;
+    }
+
     get translationalSpecies() {
         const { translational = [] } = this.ngbTargetPanelService.identificationTarget || {};
         return translational.map(s => ({
@@ -391,11 +395,16 @@ export default class ngbGenomicsPanelService {
 
     exportResults() {
         const source = this.exportSource;
-        if (!this.geneIdsOfInterest || !this.translationalGeneIds) {
+        if (!this.targetId || !this.geneIdsOfInterest || !this.translationalGeneIds) {
             return new Promise(resolve => {
                 resolve(true);
             });
         }
-        return this.targetDataService.getTargetExport(this.geneIdsOfInterest, this.translationalGeneIds, source);
+        return this.targetDataService.getTargetExport(
+            this.targetId,
+            this.geneIdsOfInterest,
+            this.translationalGeneIds,
+            source
+        );
     }
 }

--- a/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbKnownDrugsPanel/ngbKnownDrugsPanel.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbKnownDrugsPanel/ngbKnownDrugsPanel.service.js
@@ -62,13 +62,22 @@ export default class ngbKnownDrugsPanelService {
         return this.ngbTargetPanelService.translationalGeneIds;
     }
 
+    get targetId() {
+        return this.ngbTargetPanelService.targetId;
+    }
+
     exportResults() {
         const source = this.exportSource[this.sourceModel.name];
-        if (!this.geneIdsOfInterest || !this.translationalGeneIds) {
+        if (!this.targetId || !this.geneIdsOfInterest || !this.translationalGeneIds) {
             return new Promise(resolve => {
                 resolve(true);
             });
         }
-        return this.targetDataService.getTargetExport(this.geneIdsOfInterest, this.translationalGeneIds, source);
+        return this.targetDataService.getTargetExport(
+            this.targetId,
+            this.geneIdsOfInterest,
+            this.translationalGeneIds,
+            source
+        );
     }
 }

--- a/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbSequencesPanel/ngbSequencesPanel.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbSequencesPanel/ngbSequencesPanel.service.js
@@ -74,6 +74,10 @@ export default class ngbSequencesPanelService {
         dispatcher.on('target:identification:changed', this.targetChanged.bind(this));
     }
 
+    get targetId() {
+        return this.ngbTargetPanelService.targetId;
+    }
+
     get genesIds() {
         return this.ngbTargetPanelService.genesIds;
     }
@@ -169,14 +173,14 @@ export default class ngbSequencesPanelService {
     }
 
     getSequencesData() {
-        if (!this.genesIds || !this.genesIds.length) {
+        if (!this.targetId || !this.genesIds || !this.genesIds.length) {
             return new Promise(resolve => {
                 this.loadingData = false;
                 resolve(true);
             });
         }
         return new Promise(resolve => {
-            this.targetDataService.getSequencesTableResults(this.genesIds)
+            this.targetDataService.getSequencesTableResults(this.targetId, this.genesIds)
                 .then((data) => {
                     this._failedResult = false;
                     this._errorMessageList = null;
@@ -216,11 +220,16 @@ export default class ngbSequencesPanelService {
 
     exportResults() {
         const source = this.exportSource;
-        if (!this.geneIdsOfInterest || !this.translationalGeneIds) {
+        if (!this.targetId || !this.geneIdsOfInterest || !this.translationalGeneIds) {
             return new Promise(resolve => {
                 resolve(true);
             });
         }
-        return this.targetDataService.getTargetExport(this.geneIdsOfInterest, this.translationalGeneIds, source);
+        return this.targetDataService.getTargetExport(
+            this.targetId,
+            this.geneIdsOfInterest,
+            this.translationalGeneIds,
+            source
+        );
     }
 }

--- a/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbStructurePanel/ngbStructurePanel.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbIdentificationsTab/ngbStructurePanel/ngbStructurePanel.service.js
@@ -214,6 +214,10 @@ export default class ngbStructurePanelService {
         dispatcher.on('target:identification:changed', this.targetChanged.bind(this));
     }
 
+    get targetId() {
+        return this.ngbTargetPanelService.targetId;
+    }
+
     get geneIds() {
         return this.ngbTargetPanelService.genesIds;
     }
@@ -394,11 +398,16 @@ export default class ngbStructurePanelService {
 
     exportResults() {
         const source = this.exportSource[this.sourceModel];
-        if (!this.geneIdsOfInterest || !this.translationalGeneIds) {
+        if (!this.targetId || !this.geneIdsOfInterest || !this.translationalGeneIds) {
             return new Promise(resolve => {
                 resolve(true);
             });
         }
-        return this.targetDataService.getTargetExport(this.geneIdsOfInterest, this.translationalGeneIds, source);
+        return this.targetDataService.getTargetExport(
+            this.targetId,
+            this.geneIdsOfInterest,
+            this.translationalGeneIds,
+            source
+        );
     }
 }

--- a/client/client/app/components/ngbTargetPanel/ngbTargetPanel.service.js
+++ b/client/client/app/components/ngbTargetPanel/ngbTargetPanel.service.js
@@ -13,6 +13,11 @@ export default class NgbTargetPanelService {
         return this._identificationTarget;
     }
 
+    get targetId() {
+        const {target} = this.identificationTarget || {};
+        return target && target.id;
+    }
+
     get genesIds() {
         const {
             interest = [],
@@ -104,11 +109,11 @@ export default class NgbTargetPanelService {
     }
 
     exportResults() {
-        if (!this.geneIdsOfInterest || !this.translationalGeneIds) {
+        if (!this.targetId || !this.geneIdsOfInterest || !this.translationalGeneIds) {
             return new Promise(resolve => {
                 resolve(true);
             });
         }
-        return this.targetDataService.getTargetReport(this.geneIdsOfInterest, this.translationalGeneIds);
+        return this.targetDataService.getTargetReport(this.targetId, this.geneIdsOfInterest, this.translationalGeneIds);
     }
 }

--- a/client/client/dataServices/target/target-data-service.js
+++ b/client/client/dataServices/target/target-data-service.js
@@ -302,10 +302,10 @@ export class TargetDataService extends DataService {
         });
     }
 
-    getSequencesTableResults(geneIds) {
+    getSequencesTableResults(targetId, geneIds) {
         const getComments = false;
         return new Promise((resolve, reject) => {
-            this.get(`target/sequences/table${getQueryString({geneIds, getComments})}`)
+            this.get(`target/sequences/table${getQueryString({targetId, geneIds, getComments})}`)
                 .then(data => {
                     if (data) {
                         resolve(data);
@@ -360,13 +360,14 @@ export class TargetDataService extends DataService {
         });
     }
 
-    getTargetExport(genesOfInterest, translationalGenes, source) {
+    getTargetExport(targetId, genesOfInterest, translationalGenes, source) {
         const format = 'CSV';
         const includeHeader = true;
         return new Promise((resolve, reject) => {
             this.downloadFile(
                 'get',
                 `target/export${getQueryString({
+                    targetId,
                     genesOfInterest,
                     translationalGenes,
                     format,
@@ -535,11 +536,11 @@ export class TargetDataService extends DataService {
         });
     }
 
-    getTargetReport(genesOfInterest, translationalGenes) {
+    getTargetReport(targetId, genesOfInterest, translationalGenes) {
         return new Promise((resolve, reject) => {
             this.downloadFile(
                 'get',
-                `target/report${getQueryString({genesOfInterest, translationalGenes})}`,
+                `target/report${getQueryString({targetId, genesOfInterest, translationalGenes})}`,
                 undefined,
                 {customResponseType: 'arraybuffer'}
             )


### PR DESCRIPTION
This PR adds targetId for requests:
- sequences table;
- publications;
- export;
- report.