### PR TITLE
Issue 1059 Allow to launch target identification "ad hoc" - fix export

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/entity/target/export/xls/TargetExportSummaryField.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/entity/target/export/xls/TargetExportSummaryField.java
@@ -43,7 +43,7 @@ public enum TargetExportSummaryField implements ExportField<TargetExportSummary>
     PUBLICATIONS("Publications", o -> String.valueOf(o.getPublications()), true),
     SEQUENCES("Sequences", TargetExportSummary::getSequences, true),
     STRUCTURES("Structures", o -> String.valueOf(o.getStructures()), true),
-    HOMOLOGS("Homologs", o -> String.valueOf(o.getHomologs()), false);
+    HOMOLOGS("Homologs", o -> String.valueOf(o.getHomologs()), true);
     private String label;
     private Function<TargetExportSummary, String> getter;
     private boolean gene;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportCSVManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportCSVManager.java
@@ -135,49 +135,8 @@ public class TargetExportCSVManager {
     }
 
     public byte[] exportGene(final String geneId, final TargetExportTable source,
-                         final FileFormat format, final boolean includeHeader)
+                             final FileFormat format, final boolean includeHeader)
             throws IOException, ParseException, ExternalDbUnavailableException {
-        final List<String> geneIds = Collections.singletonList(geneId);
-        final Map<String, String> genesMap = targetExportManager.getTargetGeneNames(geneId);
-        byte[] result = null;
-        switch (source) {
-            case OPEN_TARGETS_DISEASES:
-                result = ExportUtils.export(targetExportManager.getDiseaseAssociations(geneIds, genesMap),
-                        getAssociationFields(DiseaseField.values()), format, includeHeader);
-                break;
-            case OPEN_TARGETS_DRUGS:
-                result = ExportUtils.export(targetExportManager.getDrugAssociations(geneIds, genesMap),
-                        getAssociationFields(DrugField.values()), format, includeHeader);
-                break;
-            case PHARM_GKB_DISEASES:
-                result = ExportUtils.export(targetExportManager.getPharmGKBDiseases(geneIds, genesMap),
-                        getAssociationFields(PharmGKBDiseaseField.values()), format, includeHeader);
-                break;
-            case PHARM_GKB_DRUGS:
-                result = ExportUtils.export(targetExportManager.getPharmGKBDrugs(geneIds, genesMap),
-                        getAssociationFields(PharmGKBDrugField.values()), format, includeHeader);
-                break;
-            case DGIDB_DRUGS:
-                result = ExportUtils.export(targetExportManager.getDGIDBDrugs(geneIds, genesMap),
-                        getAssociationFields(DGIDBField.values()), format, includeHeader);
-                break;
-            case STRUCTURES:
-                result = ExportUtils.export(targetExportManager.getStructures(geneIds),
-                        Arrays.asList(PdbStructureField.values()), format, includeHeader);
-                break;
-            case LOCAL_PDBS:
-                result = ExportUtils.export(targetExportManager.getPdbFiles(geneIds),
-                        Arrays.asList(PdbFileField.values()), format, includeHeader);
-                break;
-            case SEQUENCES:
-                result = ExportUtils.export(targetExportManager.getSequenceTable(geneIds, genesMap),
-                        Arrays.asList(GeneSequenceField.values()), format, includeHeader);
-                break;
-            case HOMOLOGY:
-                throw new IllegalArgumentException("Homology report not available");
-            default:
-                break;
-        }
-        return result;
+        return export(Collections.singletonList(geneId), Collections.emptyList(), format, source, includeHeader);
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportManager.java
@@ -53,6 +53,7 @@ import com.epam.catgenome.manager.pdb.PdbFileManager;
 import com.epam.catgenome.manager.target.LaunchIdentificationManager;
 import com.epam.catgenome.manager.target.TargetManager;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.http.util.TextUtils;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -96,15 +97,20 @@ public class TargetExportManager {
                                                  final List<String> translationalGenes,
                                                  final Map<String, String> geneNames)
             throws IOException, ParseException {
-        final List<Long> species = targetManager.getTargetGeneSpecies(translationalGenes);
+        final List<Long> species = CollectionUtils.isEmpty(translationalGenes) ?
+                Collections.emptyList() :
+                targetManager.getTargetGeneSpecies(translationalGenes);
         final Map<String, List<HomologGroup>> homologueGroups = homologManager.searchHomolog(genesOfInterest);
         final Map<String, List<HomologeneEntry>> homologenes = homologeneManager.searchHomologenes(genesOfInterest);
         final List<TargetHomologue> homology = new ArrayList<>();
         for (Map.Entry<String, List<HomologGroup>> homologueEntry : homologueGroups.entrySet()) {
             for (HomologGroup group : homologueEntry.getValue()) {
-                List<Gene> genes = group.getHomologs().stream()
-                        .filter(g -> species.stream().anyMatch(s -> s.equals(g.getTaxId())))
-                        .collect(Collectors.toList());
+                List<Gene> genes = group.getHomologs();
+                if (CollectionUtils.isNotEmpty(species)) {
+                    genes = genes.stream()
+                            .filter(g -> species.stream().anyMatch(s -> s.equals(g.getTaxId())))
+                            .collect(Collectors.toList());
+                }
                 for (Gene gene: genes) {
                     TargetHomologue export = new TargetHomologue();
                     export.setGeneId(homologueEntry.getKey());
@@ -123,9 +129,12 @@ public class TargetExportManager {
         }
         for (Map.Entry<String, List<HomologeneEntry>> homologenesMapEntry : homologenes.entrySet()) {
             for (HomologeneEntry entry : homologenesMapEntry.getValue()) {
-                List<Gene> genes = entry.getGenes().stream()
-                        .filter(g -> species.stream().anyMatch(s -> s.equals(g.getTaxId())))
-                        .collect(Collectors.toList());
+                List<Gene> genes = entry.getGenes();
+                if (CollectionUtils.isNotEmpty(species)) {
+                    genes = genes.stream()
+                            .filter(g -> species.stream().anyMatch(s -> s.equals(g.getTaxId())))
+                            .collect(Collectors.toList());
+                }
                 for (Gene gene: genes) {
                     TargetHomologue export = new TargetHomologue();
                     export.setGeneId(homologenesMapEntry.getKey());
@@ -185,7 +194,7 @@ public class TargetExportManager {
         final Map<String, String> genesMap = new HashMap<>();
         final List<String> geneNames = identificationManager.getGeneNames(Collections.singletonList(geneId));
         for (String geneName: geneNames) {
-            genesMap.put(geneId, geneName);
+            genesMap.put(geneId.toLowerCase(), geneName);
         }
         return genesMap;
     }


### PR DESCRIPTION
 (empty target name and homologs)

# Description

## Background

[[Target Identification] Allow to launch target identification "ad hoc" #105](https://github.com/epam/NGB/issues/1059#issuecomment-1838238219)