### PR TITLE
Issue 1059 Allow to launch target identification "ad hoc" - fix csv export empty target name

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportCSVManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportCSVManager.java
@@ -89,6 +89,23 @@ public class TargetExportCSVManager {
         final List<String> geneIds = Stream.concat(genesOfInterest.stream(), translationalGenes.stream())
                 .distinct().collect(Collectors.toList());
         final Map<String, String> genesMap = targetExportManager.getTargetGeneNames(geneIds);
+        return export(genesOfInterest, translationalGenes, format, source, includeHeader, genesMap);
+    }
+
+    public byte[] exportGene(final String geneId, final TargetExportTable source,
+                             final FileFormat format, final boolean includeHeader)
+            throws IOException, ParseException, ExternalDbUnavailableException {
+        final Map<String, String> genesMap = targetExportManager.getTargetGeneNames(geneId);
+        return export(Collections.singletonList(geneId), Collections.emptyList(),
+                format, source, includeHeader, genesMap);
+    }
+
+    private byte[] export(final List<String> genesOfInterest, final List<String> translationalGenes,
+                          final FileFormat format, final TargetExportTable source, final boolean includeHeader,
+                          final Map<String, String> genesMap)
+            throws IOException, ParseException, ExternalDbUnavailableException {
+        final List<String> geneIds = Stream.concat(genesOfInterest.stream(), translationalGenes.stream())
+                .distinct().collect(Collectors.toList());
         byte[] result = null;
         switch (source) {
             case OPEN_TARGETS_DISEASES:
@@ -132,11 +149,5 @@ public class TargetExportCSVManager {
                 break;
         }
         return result;
-    }
-
-    public byte[] exportGene(final String geneId, final TargetExportTable source,
-                             final FileFormat format, final boolean includeHeader)
-            throws IOException, ParseException, ExternalDbUnavailableException {
-        return export(Collections.singletonList(geneId), Collections.emptyList(), format, source, includeHeader);
     }
 }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportHTMLManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportHTMLManager.java
@@ -119,7 +119,7 @@ public class TargetExportHTMLManager {
         final List<SourceData<DiseaseData>> diseases = getDiseases(pharmGKBDiseases, diseaseAssociations);
         final List<Sequence> sequences = getSequences(geneIds, geneNamesMap);
         final List<SourceData<StructureData>> structures = getStructures(geneIds);
-        long publicationsCount = pubMedService.getPublicationsCount(entrezIds);
+        final long publicationsCount = pubMedService.getPublicationsCount(entrezIds);
         final List<Publication> publications = getPublications(entrezIds, publicationsCount);
         final List<ComparativeGenomics> comparativeGenomics = getComparativeGenomics(genesOfInterest,
                 translationalGenes, geneNamesMap);
@@ -170,7 +170,7 @@ public class TargetExportHTMLManager {
             }
         }
 
-        TargetExportHTML result = TargetExportHTML.builder()
+        final TargetExportHTML result = TargetExportHTML.builder()
                 .name(target.getTargetName())
                 .interest(interest)
                 .translational(translational)
@@ -203,7 +203,7 @@ public class TargetExportHTMLManager {
         final List<SourceData<DiseaseData>> diseases = getDiseases(pharmGKBDiseases, diseaseAssociations);
         final List<Sequence> sequences = getSequences(geneIds, genesMap);
         final List<SourceData<StructureData>> structures = getStructures(geneIds);
-        long publicationsCount = pubMedService.getPublicationsCount(entrezIds);
+        final long publicationsCount = pubMedService.getPublicationsCount(entrezIds);
         final List<Publication> publications = getPublications(entrezIds, publicationsCount);
         final List<ComparativeGenomics> comparativeGenomics = getComparativeGenomics(geneIds,
                 Collections.emptyList(), genesMap);
@@ -234,7 +234,7 @@ public class TargetExportHTMLManager {
                 .publications(publicationsCount)
                 .build();
         final List<String> geneNames = launchIdentificationManager.getGeneNames(geneIds);
-        TargetExportHTML result = TargetExportHTML.builder()
+        final TargetExportHTML result = TargetExportHTML.builder()
                 .name(geneNames.get(0))
                 .totalCounts(totalCounts)
                 .knownDrugs(knownDrugs)

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportManager.java
@@ -179,7 +179,6 @@ public class TargetExportManager {
         return homology;
     }
 
-
     public Map<String, String> getTargetGeneNames(final List<String> geneIds) {
         final Map<String, String> genesMap = new HashMap<>();
         final List<TargetGene> genes = targetManager.getTargetGenes(geneIds);
@@ -217,7 +216,7 @@ public class TargetExportManager {
     }
 
     public List<DiseaseAssociation> getDiseaseAssociations(final List<String> geneIds,
-                                                            final Map<String, String> genesMap)
+                                                           final Map<String, String> genesMap)
             throws ParseException, IOException {
         final List<DiseaseAssociation> diseaseAssociations = diseaseAssociationManager.search(geneIds);
         if (MapUtils.isNotEmpty(genesMap)) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportXLSManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportXLSManager.java
@@ -232,14 +232,14 @@ public class TargetExportXLSManager {
         final Map<String, String> descriptions = launchIdentificationManager.getDescriptions(ncbiGeneIds);
 
         final DrugsCount drugsCount = launchIdentificationManager.getDrugsCount(geneIds);
-        long diseasesCount = launchIdentificationManager.getDiseasesCount(geneIds);
+        final long diseasesCount = launchIdentificationManager.getDiseasesCount(geneIds);
         final long structures = launchIdentificationManager.getStructuresCount(geneIds);
-        long publicationsCount = genes.containsKey(geneId) ? pubMedService.getPublicationsCount(
-                Collections.singletonList(genes.get(geneId).getEntrezId().toString())) : 0;
+        final long publicationsCount = genes.containsKey(geneId.toLowerCase()) ? pubMedService.getPublicationsCount(
+                Collections.singletonList(genes.get(geneId.toLowerCase()).getEntrezId().toString())) : 0;
         final SequencesSummary sequencesCount = geneSequencesManager.getSequencesCount(ncbiGeneIds);
 
-        TargetExportSummary summary = TargetExportSummary.builder()
-                .description(descriptions.get(geneId))
+        final TargetExportSummary summary = TargetExportSummary.builder()
+                .description(descriptions.get(geneId.toLowerCase()))
                 .knownDrugs(drugsCount.getDistinctCount())
                 .knownDrugRecords(drugsCount.getTotalCount())
                 .diseases(diseasesCount)


### PR DESCRIPTION
# Description

## Background

[[Target Identification] Allow to launch target identification "ad hoc" #1059](https://github.com/epam/NGB/issues/1059)