### PR TITLE
Issue 1059 Allow to launch target identification "ad hoc" - fix html export empty description

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportHTMLManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportHTMLManager.java
@@ -208,8 +208,6 @@ public class TargetExportHTMLManager {
         final List<ComparativeGenomics> comparativeGenomics = getComparativeGenomics(geneIds,
                 Collections.emptyList(), genesMap);
         final long homologsCount = comparativeGenomics.size();
-
-
         final DrugsCount drugsCount = launchIdentificationManager.getDrugsCount(geneIds);
         final long structuresCount = structures.stream().mapToInt(d -> d.getData().size()).sum();
 
@@ -234,8 +232,15 @@ public class TargetExportHTMLManager {
                 .publications(publicationsCount)
                 .build();
         final List<String> geneNames = launchIdentificationManager.getGeneNames(geneIds);
+        final Map<String, String> descriptions = launchIdentificationManager.getDescriptions(ncbiGeneIds);
+        GeneDetails details = GeneDetails.builder()
+                .id(geneId)
+                .name(geneNames.get(0))
+                .description(descriptions.get(geneId.toLowerCase()))
+                .build();
         final TargetExportHTML result = TargetExportHTML.builder()
                 .name(geneNames.get(0))
+                .interest(Collections.singletonList(details))
                 .totalCounts(totalCounts)
                 .knownDrugs(knownDrugs)
                 .associatedDiseases(diseases)


### PR DESCRIPTION
# Description

## Background
[[Target Identification] Allow to launch target identification "ad hoc" #1059](https://github.com/epam/NGB/issues/1059)
