### PR TITLE
Issue 1097 [Target Identification] Sequences table is empty in the export

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportHTMLManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportHTMLManager.java
@@ -234,7 +234,7 @@ public class TargetExportHTMLManager {
         final List<String> geneNames = launchIdentificationManager.getGeneNames(geneIds);
         final Map<String, String> descriptions = launchIdentificationManager.getDescriptions(ncbiGeneIds);
         GeneDetails details = GeneDetails.builder()
-                .id(geneId)
+                .id(geneId.toLowerCase())
                 .name(geneNames.get(0))
                 .description(descriptions.get(geneId.toLowerCase()))
                 .build();
@@ -276,7 +276,7 @@ public class TargetExportHTMLManager {
         final List<Sequence> sequences = new ArrayList<>();
         for (GeneRefSection geneRefSection : sequencesTable) {
             SequenceGene sequenceGene = SequenceGene.builder()
-                    .id(geneRefSection.getGeneId())
+                    .id(geneRefSection.getGeneId().toLowerCase())
                     .name(geneNamesMap.get(geneRefSection.getGeneId().toLowerCase()))
                     .build();
             if (genesMap.containsKey(geneRefSection.getGeneId().toLowerCase())) {


### PR DESCRIPTION
… launch target identification "ad hoc" to HTML

# Description

## Background

[[Target Identification] Sequences table is empty in the export launch target identification "ad hoc" to HTML](https://github.com/epam/NGB/issues/1097)