### PR TITLE
Issue 849 Launching target identification - fixes

### DIFF
--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/TargetGeneManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/TargetGeneManager.java
@@ -698,7 +698,7 @@ public class TargetGeneManager extends AbstractIndexManager<TargetGene> {
             String priority = cells[header.getPriorityIndex()].trim();
             if (!TextUtils.isBlank(priority)) {
                 try {
-                    targetGenePriority = TargetGenePriority.getByValue(Integer.parseInt(priority));
+                    targetGenePriority = TargetGenePriority.valueOf(priority);
                 } catch (NumberFormatException e) {
                     throw new TargetGenesException("Priority should be numeric");
                 }
@@ -769,8 +769,7 @@ public class TargetGeneManager extends AbstractIndexManager<TargetGene> {
             if (header.getPriorityIndex() != null) {
                 Cell priorityCell = row.getCell(header.getPriorityIndex());
                 if (priorityCell != null) {
-                    Assert.isTrue(priorityCell.getCellTypeEnum() == NUMERIC, "Priority should be numeric");
-                    priority = TargetGenePriority.getByValue((int) priorityCell.getNumericCellValue());
+                    priority = TargetGenePriority.valueOf(getCellValue(priorityCell));
                 }
             }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportCSVManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportCSVManager.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.epam.catgenome.manager.target.LaunchIdentificationManager.getGeneIds;
 import static com.epam.catgenome.manager.target.export.TargetExportManager.*;
 
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportHTMLManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportHTMLManager.java
@@ -61,7 +61,7 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.epam.catgenome.manager.target.export.TargetExportManager.getGeneIds;
+import static com.epam.catgenome.manager.target.LaunchIdentificationManager.getGeneIds;
 import static org.apache.commons.lang3.StringUtils.join;
 
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportXLSManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/target/export/TargetExportXLSManager.java
@@ -76,8 +76,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.epam.catgenome.manager.export.ExcelExportUtils.writeSheet;
+import static com.epam.catgenome.manager.target.LaunchIdentificationManager.getGeneIds;
 import static com.epam.catgenome.manager.target.export.TargetExportManager.getAssociationFields;
-import static com.epam.catgenome.manager.target.export.TargetExportManager.getGeneIds;
 
 
 @Service
@@ -162,7 +162,7 @@ public class TargetExportXLSManager {
         final Map<String, Long> diseases = diseaseAssociationManager.totalCountMap(geneIds);
 
         final Map<String, SequencesSummary> sequencesSummaryMap =
-                geneSequencesManager.getSequencesCountMap(ncbiGeneIds);
+                targetExportManager.getGeneSequencesCount(targetId, geneIds, ncbiGeneIds);
 
         final Map<String, Long> structuresCount = getStructuresCount(genesMap);
 


### PR DESCRIPTION
# Description

## Background

[Launching target identification #849](https://github.com/epam/NGB/issues/849)
Fixes:
- import gene files for parasite targets - priorities column
- launch ad hoc identifications for genes without registered targets
- export ad hoc identifications