### PR TITLE
Support allowed urls whitelist

### DIFF
--- a/server/catgenome/profiles/desktop/catgenome.properties
+++ b/server/catgenome/profiles/desktop/catgenome.properties
@@ -9,6 +9,8 @@ files.download.max.m.byte.size=50
 files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
+# comma separated list with allowed to path registration hosts. supports wildcards.
+item.path.register.allowed.hosts=${ALLOWED_ITEM_HOSTS:}
 
 
 # sets buffer size in MB for feature file indexing, the larger buffer increases the performance of

--- a/server/catgenome/profiles/desktop/catgenome.properties
+++ b/server/catgenome/profiles/desktop/catgenome.properties
@@ -10,7 +10,7 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=${ALLOWED_ITEM_HOSTS:}
+url.browsing.allowed.hosts=${ALLOWED_ITEM_HOSTS:*}
 
 
 # sets buffer size in MB for feature file indexing, the larger buffer increases the performance of

--- a/server/catgenome/profiles/dev/catgenome.properties
+++ b/server/catgenome/profiles/dev/catgenome.properties
@@ -19,7 +19,7 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=${ALLOWED_ITEM_HOSTS:ftp-trace.ncbi.nlm.nih.gov}
+url.browsing.allowed.hosts=${ALLOWED_ITEM_HOSTS:*}
 
 # max size of lucene index in bytes to perform group variations and total page count operations
 # default value is 2Gb

--- a/server/catgenome/profiles/dev/catgenome.properties
+++ b/server/catgenome/profiles/dev/catgenome.properties
@@ -18,6 +18,8 @@ files.download.max.m.byte.size=50
 files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
+# comma separated list with allowed to path registration hosts. supports wildcards.
+item.path.register.allowed.hosts=${ALLOWED_ITEM_HOSTS:ftp-trace.ncbi.nlm.nih.gov}
 
 # max size of lucene index in bytes to perform group variations and total page count operations
 # default value is 2Gb

--- a/server/catgenome/profiles/h2/test-catgenome.properties
+++ b/server/catgenome/profiles/h2/test-catgenome.properties
@@ -12,7 +12,7 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=localhost
+url.browsing.allowed.hosts=*
 
 # sets buffer size for feature file indexing, the larger buffer increases the performance of
 # indexing and further search

--- a/server/catgenome/profiles/h2/test-catgenome.properties
+++ b/server/catgenome/profiles/h2/test-catgenome.properties
@@ -11,6 +11,8 @@ files.download.max.m.byte.size=50
 files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=
+# comma separated list with allowed to path registration hosts. supports wildcards.
+item.path.register.allowed.hosts=
 
 # sets buffer size for feature file indexing, the larger buffer increases the performance of
 # indexing and further search

--- a/server/catgenome/profiles/h2/test-catgenome.properties
+++ b/server/catgenome/profiles/h2/test-catgenome.properties
@@ -12,7 +12,7 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=
+item.path.register.allowed.hosts=localhost
 
 # sets buffer size for feature file indexing, the larger buffer increases the performance of
 # indexing and further search

--- a/server/catgenome/profiles/jar/catgenome.properties
+++ b/server/catgenome/profiles/jar/catgenome.properties
@@ -26,6 +26,9 @@ files.download.max.m.byte.size=50
 files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
+# comma separated list with allowed to path registration hosts. supports wildcards.
+item.path.register.allowed.hosts=${ALLOWED_ITEM_HOSTS:}
+
 # configuration properties to establish connection with database engine
 database.max.pool.size=10
 database.username=catgenome

--- a/server/catgenome/profiles/jar/catgenome.properties
+++ b/server/catgenome/profiles/jar/catgenome.properties
@@ -27,7 +27,7 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=ftp-trace.ncbi.nlm.nih.gov
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=${ALLOWED_ITEM_HOSTS:}
+url.browsing.allowed.hosts=${ALLOWED_ITEM_HOSTS:*}
 
 # configuration properties to establish connection with database engine
 database.max.pool.size=10

--- a/server/catgenome/profiles/postgres/test-catgenome.properties
+++ b/server/catgenome/profiles/postgres/test-catgenome.properties
@@ -9,7 +9,7 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=
+item.path.register.allowed.hosts=localhost
 
 # max size of lucene index in bytes to perform group variations and total page count operations
 # default value is 4Gb

--- a/server/catgenome/profiles/postgres/test-catgenome.properties
+++ b/server/catgenome/profiles/postgres/test-catgenome.properties
@@ -8,6 +8,8 @@ files.download.max.m.byte.size=50
 files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=
+# comma separated list with allowed to path registration hosts. supports wildcards.
+item.path.register.allowed.hosts=
 
 # max size of lucene index in bytes to perform group variations and total page count operations
 # default value is 4Gb

--- a/server/catgenome/profiles/postgres/test-catgenome.properties
+++ b/server/catgenome/profiles/postgres/test-catgenome.properties
@@ -9,7 +9,7 @@ files.download.max.minutes=1
 # white list for download file from url
 file.download.whitelist.host=
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=localhost
+url.browsing.allowed.hosts=*
 
 # max size of lucene index in bytes to perform group variations and total page count operations
 # default value is 4Gb

--- a/server/catgenome/profiles/release/catgenome.properties
+++ b/server/catgenome/profiles/release/catgenome.properties
@@ -10,7 +10,7 @@ files.download.max.minutes=
 # white list for download file from url
 file.download.whitelist.host=
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=
+url.browsing.allowed.hosts=
 
 # sets buffer size in MB for feature file indexing, the larger buffer increases the performance of
 # indexing and further search

--- a/server/catgenome/profiles/release/catgenome.properties
+++ b/server/catgenome/profiles/release/catgenome.properties
@@ -9,6 +9,8 @@ files.download.max.m.byte.size=
 files.download.max.minutes=
 # white list for download file from url
 file.download.whitelist.host=
+# comma separated list with allowed to path registration hosts. supports wildcards.
+item.path.register.allowed.hosts=
 
 # sets buffer size in MB for feature file indexing, the larger buffer increases the performance of
 # indexing and further search

--- a/server/catgenome/profiles/staging/catgenome.properties
+++ b/server/catgenome/profiles/staging/catgenome.properties
@@ -10,7 +10,7 @@ files.download.max.minutes=
 # white list for download file from url
 file.download.whitelist.host=
 # comma separated list with allowed to path registration hosts. supports wildcards.
-item.path.register.allowed.hosts=
+url.browsing.allowed.hosts=
 
 # configuration properties to establish connection with database engine
 database.max.pool.size=25

--- a/server/catgenome/profiles/staging/catgenome.properties
+++ b/server/catgenome/profiles/staging/catgenome.properties
@@ -9,7 +9,8 @@ files.download.max.m.byte.size=
 files.download.max.minutes=
 # white list for download file from url
 file.download.whitelist.host=
-
+# comma separated list with allowed to path registration hosts. supports wildcards.
+item.path.register.allowed.hosts=
 
 # configuration properties to establish connection with database engine
 database.max.pool.size=25

--- a/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/constant/MessagesConstants.java
@@ -230,7 +230,7 @@ public final class MessagesConstants {
     public static final String ERROR_LARGE_FILE_FOR_DOWNLOAD = "error.large.file.for.download";
     public static final String ERROR_DOWNLOAD_TIMEOUT = "error.download.timeout";
     public static final String ERROR_UNKNOWN_HOST = "error.unknown.host";
-
+    public static final String ERROR_HOST_NOT_ALLOWED = "error.host.not.allowed";
 
     //EXTERNAL_DB
     public static final String ERROR_PARSING = "error.parsing.exception";

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/FileManager.java
@@ -315,6 +315,9 @@ public class FileManager {
     @Value("${config.path:}")
     private String defaultTrackSettingsDirPath;
 
+    @Autowired
+    private UrlValidatorService urlValidatorService;
+
     /**
      * Returns the real path of a directory used as the content root to store uploaded content
      * files and any immediate post-processing file resources related to them.
@@ -357,6 +360,15 @@ public class FileManager {
         if (!isUrlsBrowsingAllowed()) {
             throw new AccessDeniedException(getMessage(URL_FILE_BROWSING_NOT_ALLOWED));
         }
+    }
+
+    public void checkIfUrlBrowsingAllowed(final String fileUrl,
+                                          final String indexUrl) throws AccessDeniedException {
+        if (!isUrlsBrowsingAllowed()) {
+            throw new AccessDeniedException(getMessage(URL_FILE_BROWSING_NOT_ALLOWED));
+        }
+        urlValidatorService.validateURL(fileUrl);
+        urlValidatorService.validateURL(indexUrl);
     }
 
     /**

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/UrlValidatorService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/UrlValidatorService.java
@@ -46,7 +46,7 @@ import org.springframework.beans.factory.annotation.Value;
 @Slf4j
 public class UrlValidatorService {
 
-    private List<String> allowedHosts;
+    private final List<String> allowedHosts;
 
     public UrlValidatorService(@Value("#{'${item.path.register.allowed.hosts}'.split(',')}")
                                final List<String> allowedHosts) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/UrlValidatorService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/UrlValidatorService.java
@@ -48,7 +48,7 @@ public class UrlValidatorService {
 
     private final List<String> allowedHosts;
 
-    public UrlValidatorService(@Value("#{'${item.path.register.allowed.hosts}'.split(',')}")
+    public UrlValidatorService(@Value("#{'${url.browsing.allowed.hosts}'.split(',')}")
                                final List<String> allowedHosts) {
         this.allowedHosts = allowedHosts;
     }
@@ -62,6 +62,10 @@ public class UrlValidatorService {
 
     public void validateReference(final ReferenceRegistrationRequest request) {
         validatePath(request.getPath(), request.getType());
+    }
+
+    public void validateURL(final String url) {
+        validatePath(url, BiologicalDataItemResourceType.FILE);
     }
 
     private void validatePath(final String inputPath, final BiologicalDataItemResourceType type) {
@@ -88,7 +92,7 @@ public class UrlValidatorService {
                     .orElseThrow(() -> new IllegalStateException(
                             MessageHelper.getMessage(MessagesConstants.ERROR_HOST_NOT_ALLOWED)));
         } catch (URISyntaxException e) {
-            throw new RuntimeException("Failed to parse URL.", e);
+            throw new IllegalArgumentException("Failed to parse URL.", e);
         }
     }
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/UrlValidatorService.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/UrlValidatorService.java
@@ -1,0 +1,107 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 EPAM Systems
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.epam.catgenome.manager;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+
+import com.epam.catgenome.component.MessageHelper;
+import com.epam.catgenome.constant.MessagesConstants;
+import com.epam.catgenome.controller.vo.registration.IndexedFileRegistrationRequest;
+import com.epam.catgenome.controller.vo.registration.ReferenceRegistrationRequest;
+import com.epam.catgenome.entity.BiologicalDataItemResourceType;
+import com.epam.catgenome.util.NgbFileUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+
+@Service
+@Slf4j
+public class UrlValidatorService {
+
+    private List<String> allowedHosts;
+
+    public UrlValidatorService(@Value("#{'${item.path.register.allowed.hosts}'.split(',')}")
+                               final List<String> allowedHosts) {
+        this.allowedHosts = allowedHosts;
+    }
+
+    public void validate(final IndexedFileRegistrationRequest request) {
+        validatePath(request.getPath(), request.getType());
+        final BiologicalDataItemResourceType indexType = Optional.ofNullable(request.getIndexType())
+                .orElse(request.getType());
+        validatePath(request.getIndexPath(), indexType);
+    }
+
+    public void validateReference(final ReferenceRegistrationRequest request) {
+        validatePath(request.getPath(), request.getType());
+    }
+
+    private void validatePath(final String inputPath, final BiologicalDataItemResourceType type) {
+        if (StringUtils.isBlank(inputPath)) {
+            log.debug("Input path is empty. Skipping validation.");
+            return;
+        }
+        if (!validationRequired(inputPath, type)) {
+            log.debug("Validation not required.");
+            return;
+        }
+        validateUrl(inputPath);
+    }
+
+    private void validateUrl(final String inputUrl) {
+        try {
+            final String host = new URI(inputUrl).getHost();
+            log.debug("Validating host '{}'", host);
+            ListUtils.emptyIfNull(allowedHosts).stream()
+                    .map(String::trim)
+                    .filter(StringUtils::isNotBlank)
+                    .filter(domain -> matchesAllowedDomain(domain, host))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            MessageHelper.getMessage(MessagesConstants.ERROR_HOST_NOT_ALLOWED)));
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Failed to parse URL.", e);
+        }
+    }
+
+    private boolean matchesAllowedDomain(final String allowedDomain, final String targetHost) {
+        return FilenameUtils.wildcardMatch(targetHost, allowedDomain);
+    }
+
+    private boolean validationRequired(final String inputPath, final BiologicalDataItemResourceType type) {
+        return BiologicalDataItemResourceType.URL.equals(type)
+                || BiologicalDataItemResourceType.S3.equals(type)
+                || BiologicalDataItemResourceType.AZ.equals(type)
+                || NgbFileUtils.isRemotePath(inputPath)
+                || inputPath.startsWith("s3://") || inputPath.startsWith("sws://")
+                || inputPath.startsWith("az://");
+    }
+}

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamHelper.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamHelper.java
@@ -261,7 +261,7 @@ public class BamHelper {
      */
     public BamFile makeUrlBamFile(String bamUrl, String bamIndexUrl, Chromosome chromosome)
             throws FeatureFileReadingException, AccessDeniedException {
-        fileManager.checkIfUrlBrowsingAllowed();
+        fileManager.checkIfUrlBrowsingAllowed(bamUrl, bamIndexUrl);
         try {
             return Utils.createNonRegisteredFile(BamFile.class, bamUrl, bamIndexUrl, chromosome);
         } catch (InvocationTargetException e) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamManager.java
@@ -40,6 +40,7 @@ import com.epam.catgenome.entity.track.Track;
 import com.epam.catgenome.manager.BiologicalDataItemManager;
 import com.epam.catgenome.manager.FileManager;
 import com.epam.catgenome.manager.TrackHelper;
+import com.epam.catgenome.manager.UrlValidatorService;
 import com.epam.catgenome.manager.bam.handlers.SAMRecordHandler;
 import com.epam.catgenome.manager.parallel.TaskExecutorService;
 import com.epam.catgenome.manager.reference.ReferenceGenomeManager;
@@ -106,6 +107,9 @@ public class BamManager {
     @Autowired
     private TaskExecutorService taskExecutorService;
 
+    @Autowired
+    private UrlValidatorService urlValidatorService;
+
     @Value("#{catgenome['bam.max.coverage.range'] ?: 1000000}")
     private int maxCoverageRange;
 
@@ -120,6 +124,7 @@ public class BamManager {
         Assert.notNull(request.getPath(), getMessage(MessagesConstants.ERROR_NULL_PARAM));
         Assert.notNull(request.getReferenceId(), getMessage(NO_SUCH_REFERENCE));
         Assert.notNull(request.getIndexPath(), getMessage(MessagesConstants.WRONG_BAM_INDEX_FILE));
+        urlValidatorService.validate(request);
         double time1 = Utils.getSystemTimeMilliseconds();
         if (request.getType() == null) {
             request.setType(BiologicalDataItemResourceType.FILE);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bam/BamManager.java
@@ -194,7 +194,7 @@ public class BamManager {
     public void sendBamTrackToEmitterFromUrl(final Track<Read> track, BamQueryOption option, String bamUrl,
                                                        String indexUrl, ResponseBodyEmitter emitter)
             throws IOException {
-        fileManager.checkIfUrlBrowsingAllowed();
+        fileManager.checkIfUrlBrowsingAllowed(bamUrl, indexUrl);
         double time1 = Utils.getSystemTimeMilliseconds();
         final Chromosome chromosome = trackHelper.validateUrlTrack(track, bamUrl, indexUrl);
         BamQueryOption currentOptions = option == null ? new BamQueryOption() : option;

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
@@ -204,7 +204,7 @@ public class BedManager {
 
     public Track<BedRecord> loadFeatures(final Track<BedRecord> track, String fileUrl, String indexUrl)
             throws FeatureFileReadingException, AccessDeniedException {
-        fileManager.checkIfUrlBrowsingAllowed();
+        fileManager.checkIfUrlBrowsingAllowed(fileUrl, indexUrl);
         double time1 = Utils.getSystemTimeMilliseconds();
         final Chromosome chromosome = trackHelper.validateUrlTrack(track, fileUrl, indexUrl);
 

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/bed/BedManager.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.epam.catgenome.entity.bed.FileExtensionMapping;
+import com.epam.catgenome.manager.UrlValidatorService;
 import com.epam.catgenome.manager.bed.parser.NggbBedCodec;
 import com.epam.catgenome.manager.bed.parser.NggbMultiFormatBedCodec;
 import com.epam.catgenome.util.feature.reader.AbstractEnhancedFeatureReader;
@@ -129,6 +130,9 @@ public class BedManager {
     @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
+    @Autowired
+    private UrlValidatorService urlValidatorService;
+
     @Value("${bed.multi.format.file.path}")
     private String bedMultiFormatFilePath;
 
@@ -165,6 +169,7 @@ public class BedManager {
         Assert.isTrue(StringUtils.isNotBlank(requestPath), getMessage(
                 MessagesConstants.ERROR_NULL_PARAM, "path"));
         Assert.notNull(request.getReferenceId(), getMessage(MessagesConstants.ERROR_NULL_PARAM, "referenceId"));
+        urlValidatorService.validate(request);
         double time1 = Utils.getSystemTimeMilliseconds();
         if (request.getType() == null) {
             request.setType(BiologicalDataItemResourceType.FILE);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneTrackManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GeneTrackManager.java
@@ -144,7 +144,7 @@ public class GeneTrackManager {
      */
     public Track<Gene> loadGenes(final Track<Gene> track, boolean collapse, String fileUrl, String indexUrl)
             throws GeneReadingException, AccessDeniedException {
-        fileManager.checkIfUrlBrowsingAllowed();
+        fileManager.checkIfUrlBrowsingAllowed(fileUrl, indexUrl);
         final Chromosome chromosome = trackHelper.validateUrlTrack(track, fileUrl, indexUrl);
         GeneFile geneFile;
         try {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/gene/GffManager.java
@@ -58,6 +58,7 @@ import com.epam.catgenome.manager.DownloadFileManager;
 import com.epam.catgenome.manager.FeatureIndexManager;
 import com.epam.catgenome.manager.FileManager;
 import com.epam.catgenome.manager.TrackHelper;
+import com.epam.catgenome.manager.UrlValidatorService;
 import com.epam.catgenome.manager.activity.ActivityService;
 import com.epam.catgenome.manager.externaldb.pdb.PdbDataManager;
 import com.epam.catgenome.manager.externaldb.bindings.ecsbpdbmap.Alignment;
@@ -172,6 +173,9 @@ public class GffManager {
     @Autowired
     private ActivityService activityService;
 
+    @Autowired
+    private UrlValidatorService urlValidatorService;
+
     @Value("#{'${feature.counts.extensions}'.split(',')}")
     private List<String> featureCountsExtensions;
 
@@ -198,6 +202,7 @@ public class GffManager {
         Assert.isTrue(StringUtils.isNotBlank(requestPath), getMessage(
                 MessagesConstants.ERROR_NULL_PARAM, "path"));
         Assert.notNull(request.getReferenceId(), getMessage(MessagesConstants.ERROR_NULL_PARAM, "referenceId"));
+        urlValidatorService.validate(request);
         if (request.getType() == null) {
             request.setType(BiologicalDataItemResourceType.FILE);
         }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/reference/ReferenceManager.java
@@ -51,6 +51,7 @@ import com.epam.catgenome.exception.ReferenceReadingException;
 import com.epam.catgenome.exception.RegistrationException;
 import com.epam.catgenome.manager.AuthManager;
 import com.epam.catgenome.manager.BiologicalDataItemManager;
+import com.epam.catgenome.manager.UrlValidatorService;
 import com.epam.catgenome.manager.genbank.GenbankManager;
 import com.epam.catgenome.manager.reference.io.FastaSequenceFile;
 import com.epam.catgenome.manager.reference.io.FastaUtils;
@@ -130,6 +131,9 @@ public class ReferenceManager {
     @Autowired
     private AuthManager authManager;
 
+    @Autowired
+    private UrlValidatorService urlValidatorService;
+
     /**
      * @param track {@code Track} Track with information about query
      *              (the most important: chromosome name, Id, start index, end index and scaleFactor)
@@ -155,7 +159,7 @@ public class ReferenceManager {
      * @throws IOException
      */
     public Reference registerGenome(final ReferenceRegistrationRequest request) throws IOException {
-
+        urlValidatorService.validateReference(request);
         final String name;
         String path = request.getPath();
         if (request.getType() == null) {

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/seg/SegManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/seg/SegManager.java
@@ -60,6 +60,7 @@ import com.epam.catgenome.manager.BiologicalDataItemManager;
 import com.epam.catgenome.manager.DownloadFileManager;
 import com.epam.catgenome.manager.FileManager;
 import com.epam.catgenome.manager.TrackHelper;
+import com.epam.catgenome.manager.UrlValidatorService;
 import com.epam.catgenome.manager.seg.parser.SegFeature;
 import com.epam.catgenome.util.IOHelper;
 import com.epam.catgenome.util.Utils;
@@ -97,6 +98,9 @@ public class SegManager {
     @Autowired
     private DownloadFileManager downloadFileManager;
 
+    @Autowired
+    private UrlValidatorService urlValidatorService;
+
     /**
      * Saves a {@code SegFile} in the system, writes it's metadata to the database and
      * creates feature index.
@@ -108,6 +112,7 @@ public class SegManager {
         Assert.isTrue(StringUtils.isNotBlank(requestPath), getMessage(
                 MessagesConstants.ERROR_NULL_PARAM, "path"));
         Assert.notNull(request.getReferenceId(), getMessage(MessagesConstants.ERROR_NULL_PARAM, "referenceId"));
+        urlValidatorService.validate(request);
         if (request.getType() == null) {
             request.setType(BiologicalDataItemResourceType.FILE);
         }

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -301,7 +301,7 @@ public class VcfManager {
     public Track<Variation> loadVariations(final Track<Variation> track, final String fileUrl, final String indexUrl,
                                            final Integer sampleIndex, final boolean loadInfo, final boolean collapse)
             throws VcfReadingException, AccessDeniedException {
-        fileManager.checkIfUrlBrowsingAllowed();
+        fileManager.checkIfUrlBrowsingAllowed(fileUrl, indexUrl);
 
         final double time1 = Utils.getSystemTimeMilliseconds();
         final Chromosome chromosome = trackHelper.validateUrlTrack(track, fileUrl, indexUrl);
@@ -571,7 +571,7 @@ public class VcfManager {
     private VcfFile makeTemporaryVcfFileFromUrl(final String fileUrl, final String indexUrl,
                                                 final Chromosome chromosome)
             throws VcfReadingException, AccessDeniedException {
-        fileManager.checkIfUrlBrowsingAllowed();
+        fileManager.checkIfUrlBrowsingAllowed(fileUrl, indexUrl);
 
         try {
             return Utils.createNonRegisteredFile(VcfFile.class, fileUrl, indexUrl, chromosome);

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/vcf/VcfManager.java
@@ -65,6 +65,7 @@ import com.epam.catgenome.exception.FeatureIndexException;
 import com.epam.catgenome.exception.RegistrationException;
 import com.epam.catgenome.exception.VcfReadingException;
 import com.epam.catgenome.manager.FeatureIndexManager;
+import com.epam.catgenome.manager.UrlValidatorService;
 import com.epam.catgenome.manager.gene.GeneTrackManager;
 import com.epam.catgenome.manager.vcf.reader.VcfGa4ghReader;
 import com.epam.catgenome.util.IOHelper;
@@ -167,6 +168,9 @@ public class VcfManager {
     @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
 
+    @Autowired
+    private UrlValidatorService urlValidatorService;
+
     public static final double HTSJDK_WRONG_QUALITY = -10.0;
 
     @Value("#{catgenome['vcf.filter.whitelist']}")
@@ -197,6 +201,7 @@ public class VcfManager {
         Assert.isTrue(StringUtils.isNotBlank(requestPath), getMessage(
                 MessagesConstants.ERROR_NULL_PARAM, "path"));
         Assert.notNull(request.getReferenceId(), getMessage(MessagesConstants.ERROR_NULL_PARAM, "referenceId"));
+        urlValidatorService.validate(request);
         final double time1 = Utils.getSystemTimeMilliseconds();
         VcfFile vcfFile;
         final Reference reference = referenceGenomeManager.load(request.getReferenceId());

--- a/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/FacadeWigManager.java
+++ b/server/catgenome/src/main/java/com/epam/catgenome/manager/wig/FacadeWigManager.java
@@ -42,6 +42,7 @@ import com.epam.catgenome.manager.BiologicalDataItemManager;
 import com.epam.catgenome.manager.DownloadFileManager;
 import com.epam.catgenome.manager.FileManager;
 import com.epam.catgenome.manager.TrackHelper;
+import com.epam.catgenome.manager.UrlValidatorService;
 import com.epam.catgenome.manager.reference.ReferenceGenomeManager;
 import com.epam.catgenome.util.NgbFileUtils;
 import com.epam.catgenome.util.feature.reader.EhCacheBasedIndexCache;
@@ -98,6 +99,9 @@ public class FacadeWigManager {
     @Autowired
     protected DownloadFileManager downloadFileManager;
 
+    @Autowired
+    private UrlValidatorService urlValidatorService;
+
     @Autowired(required = false)
     protected EhCacheBasedIndexCache indexCache;
 
@@ -131,6 +135,7 @@ public class FacadeWigManager {
         final String requestPath = request.getPath();
         Assert.notNull(requestPath, getMessage(MessagesConstants.WRONG_WIG_FILE));
         Assert.notNull(request.getReferenceId(), getMessage(MessageCode.NO_SUCH_REFERENCE));
+        urlValidatorService.validate(request);
         WigFile wigFile = null;
         try {
             fetchWigManager(requestPath).assertFile(requestPath);

--- a/server/catgenome/src/main/resources/catgenome-messages.properties
+++ b/server/catgenome/src/main/resources/catgenome-messages.properties
@@ -236,6 +236,7 @@ info.start.download.file=File start download from URL: ''{0}''
 error.large.file.for.download=File from URL: ''{0}'' , is large
 error.download.timeout=Downloading file from URL: ''{0}'' has reached timeout
 error.unknown.host=host is absent in white list
+error.host.not.allowed=Provided host is not allowed.
 
 #Short urls
 error.url.was.expired=Page doesn't exist or short url has been expired.

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/bed/BedManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/bed/BedManagerTest.java
@@ -122,9 +122,6 @@ public class BedManagerTest extends AbstractManagerTest {
     @Value("#{catgenome['files.base.directory.path']}")
     private String baseDirPath;
 
-    @Value("#{catgenome['item.path.register.allowed.hosts']}")
-    private List<String> allowedHosts;
-
     private static final int TEST_END_INDEX = 239107476;
     private static final Double FULL_QUERY_SCALE_FACTOR = 1D;
     private static final int TEST_CHROMOSOME_SIZE = 239107476;

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/bed/BedManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/bed/BedManagerTest.java
@@ -122,6 +122,9 @@ public class BedManagerTest extends AbstractManagerTest {
     @Value("#{catgenome['files.base.directory.path']}")
     private String baseDirPath;
 
+    @Value("#{catgenome['item.path.register.allowed.hosts']}")
+    private List<String> allowedHosts;
+
     private static final int TEST_END_INDEX = 239107476;
     private static final Double FULL_QUERY_SCALE_FACTOR = 1D;
     private static final int TEST_CHROMOSOME_SIZE = 239107476;

--- a/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
+++ b/server/catgenome/src/test/java/com/epam/catgenome/manager/vcf/VcfManagerTest.java
@@ -101,6 +101,7 @@ import com.epam.catgenome.manager.gene.GffManager;
 import com.epam.catgenome.manager.reference.ReferenceGenomeManager;
 import com.epam.catgenome.manager.reference.ReferenceManager;
 import com.epam.catgenome.util.Utils;
+import com.epam.catgenome.manager.UrlValidatorService;
 
 /**
  * Source:      VcfManagerTest.java
@@ -194,6 +195,10 @@ public class VcfManagerTest extends AbstractManagerTest {
     @Spy
     @Autowired(required = false)
     private EhCacheBasedIndexCache indexCache;
+
+    @Spy
+    @Autowired
+    private UrlValidatorService urlValidatorService;
 
     @Value("${ga4gh.google.variantSetId}")
     private String varSet;


### PR DESCRIPTION
relates to #1233 

This PR provides ability to specify list with allowed hosts for urls. 
A new application property `item.path.register.allowed.hosts` added - comma-separated list, wildcards supported.